### PR TITLE
Middle Search tab re-titled, allow users to see all buildings in spaces

### DIFF
--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -2,7 +2,7 @@
   <nav class="transformer-tabs">
     <ul>
       <li><a class="active" href="#tab-1">Catalogs</a></li>
-      <li><a href="#tab-2"><span class="hidden-xs">Databases, Journals &amp; </span>Articles</a></li>
+      <li><a href="#tab-2"><span class="hidden-xs">Articles, Journals &amp; </span>Databases</a></li>
       <li><a href="#tab-3">Library Website</a></li>
     </ul>
   </nav>
@@ -17,8 +17,8 @@
           <select class="selectpicker btn-searchtype" name="type">
             <option value="">All Fields</option>
             <option value="Title">Title</option>
-            <option value="Author">Author</option>
             <option value="Subject">Subject</option>
+            <option value="Author">Author</option>
             <option value="JournalTitle">Journal Title</option>
             <option value="StandardNumbers">ISBN, ISSN, etc.</option>
           </select>
@@ -31,7 +31,7 @@
 
       <!-- Filter Search -->
       <div class="col-xs-12 col-sm-9 eoptions">
-        <input name="filter[]" type="checkbox" value="format:&quot;E-Resource&quot;" id="checkboxebooks"/> 
+        <input name="filter[]" type="checkbox" value="format:&quot;E-Resource&quot;" id="checkboxebooks"/ aria-label="Limit to Ebooks"> 
         Limit to Ebooks &amp; Ejournals<p></p>
       </div> <!-- // eoptions -->
     </form>
@@ -109,9 +109,9 @@
     <!-- Filter Search -->
     <div class="col-xs-12 col-sm-9 eoptions">
       <p><strong class="hidden-xs">Searching for &nbsp;</strong>
-        <input checked="checked" name="searching_for" type="radio" value="articles" data-radio-button-controller="articles-plus">Articles &nbsp;
-        <input name="searching_for" type="radio" value="journals" data-radio-button-controller="ejournals">Journals &nbsp;
-        <input name="searching_for" type="radio" value="databases" data-radio-button-controller="database-finder">Databases
+        <input checked="checked" name="searching_for" type="radio" value="articles" data-radio-button-controller="articles-plus" aria-label="Articles">Articles &nbsp;
+        <input name="searching_for" type="radio" value="journals" data-radio-button-controller="ejournals" aria-label="Journals">Journals &nbsp;
+        <input name="searching_for" type="radio" value="databases" data-radio-button-controller="database-finder" aria-label="Databases">Databases
       </p>
     </div>
 

--- a/public/templates/public/spaces_index_page.html
+++ b/public/templates/public/spaces_index_page.html
@@ -79,7 +79,7 @@
                     {% endif %}
                     {% for f in features %}
                       <li>
-                        <a href="?{% if building %}building={{ building|urlencode }}&amp;{% endif %}{% if floor %}floor={{ floor|urlencode }}&amp;{% endif %}feature={{ f.field|urlencode }}&amp;space_type={{ space_type|urlencode }}" class="dropdown-item">{{ f.label }}</a>
+                        <a href="?{% if building %}building={{ building|urlencode }}&amp;{% endif %}{% if floor %}floor={{ floor|urlencode }}&amp;{% endif %}feature={{ f.0|urlencode }}&amp;space_type={{ space_type|urlencode }}" class="dropdown-item">{{ f.1 }}</a>
                       </li>
                     {% endfor %}
                   </ul>

--- a/public/views.py
+++ b/public/views.py
@@ -33,6 +33,8 @@ def spaces(request):
 
     # get spaces.
     spaces = LocationPage.objects.live()
+    if building:
+	    spaces = spaces.filter(parent_building = LocationPage.objects.get(title=building))
     if feature:
         spaces = spaces.filter(**{feature: True})
     if floor:

--- a/public/views.py
+++ b/public/views.py
@@ -34,7 +34,7 @@ def spaces(request):
     # get spaces.
     spaces = LocationPage.objects.live()
     if building:
-	    spaces = spaces.filter(parent_building = LocationPage.objects.get(title=building))
+        spaces = spaces.filter(parent_building = LocationPage.objects.get(title=building))
     if feature:
         spaces = spaces.filter(**{feature: True})
     if floor:

--- a/public/views.py
+++ b/public/views.py
@@ -33,8 +33,6 @@ def spaces(request):
 
     # get spaces.
     spaces = LocationPage.objects.live()
-    if building:
-        spaces = spaces.filter(parent_building = LocationPage.objects.get(title=building))
     if feature:
         spaces = spaces.filter(**{feature: True})
     if floor:

--- a/units/templates/units/browse_by_pulldowns.html
+++ b/units/templates/units/browse_by_pulldowns.html
@@ -20,9 +20,7 @@
     </button>
     <ul class="dropdown-menu listings-dropdown">
       <li><a href=".?view=staff{% if library %}&library={{ library|urlencode }}{% endif %}{% if query %}&query={{ query|urlencode }}{% endif %}&subject=All+Subject+Specialists">View All Subject Specialists</a></li>
-      {% if subject %}
-        <li><a href=".?view=staff{% if library %}&library={{ library|urlencode }}{% endif %}{% if query %}&query={{ query|urlencode }}{% endif %}">Browse All Subjects</a></li>
-      {% endif %}
+      <li><a href="/collex/?view=subjects">Browse All Subjects</a></li>
       <li class="divider" role="separator"></li>
       {% for s in subjects %}
         <li><a href=".?view=staff{% if library %}&library={{ library|urlencode }}{% endif %}{% if query %}&query={{ query|urlencode }}{% endif %}&subject={{ s|urlencode }}">{{ s }}</a></li>


### PR DESCRIPTION
changed middle tab of search box to match sequence of search types below
Also removed building filtering to allow user to see all the main buildings from dropdown list in spaces pages.

Added some aria-labels to enhance search accessibility.