### PR TITLE
Made all six libraries available for selection at all times

### DIFF
--- a/base/utils.py
+++ b/base/utils.py
@@ -363,22 +363,24 @@ def sort_buildings(spaces):
 	If not used, buildings list will be randomly organized.
     """
     from public.models import LocationPage, StandardPage
+	# LocationPage Object ids
     REG, SSA, MANSUETO, CRERAR, ECKHART, DANGELO, SCRC = 1797, 1798, 1816, 2713, 2714, 3393, 2971
     new_list = []
     pages = StandardPage.objects
     id_list = spaces.values_list('parent_building',flat=True)
+	#If locationpage id in list of ids of parent buildings, grab StandardPage object
     if REG in id_list:
-        new_list.append(pages.get(id=REGENSTEIN_HOMEPAGE))
+        new_list.append(pages.get(id=REGENSTEIN_HOMEPAGE).unit.location)
     if SSA in id_list:
-        new_list.append(LocationPage.objects.get(id=SSA))
+        new_list.append(pages.get(id=SSA_HOMEPAGE).unit.location)
     if MANSUETO in id_list:
-        new_list.append(pages.get(id=MANSUETO_HOMEPAGE))
+        new_list.append(pages.get(id=MANSUETO_HOMEPAGE).unit.location)
     if CRERAR in id_list:
-        new_list.append(pages.get(id=CRERAR_HOMEPAGE))
+        new_list.append(pages.get(id=CRERAR_HOMEPAGE).unit.location)
     if ECKHART in id_list:
-        new_list.append(pages.get(id=ECKHART_HOMEPAGE))
+        new_list.append(pages.get(id=ECKHART_HOMEPAGE).unit.location)
     if DANGELO in id_list:
-        new_list.append(pages.get(id=DANGELO_HOMEPAGE))
+        new_list.append(pages.get(id=DANGELO_HOMEPAGE).unit.location)
     if SCRC in id_list:
-        new_list.append(pages.get(id=SCRC_HOMEPAGE))
+        new_list.append(pages.get(id=SCRC_HOMEPAGE).unit.location)
     return new_list

--- a/base/utils.py
+++ b/base/utils.py
@@ -360,27 +360,30 @@ def sort_buildings(buildings):
     in spaces page.
     """
     new_list = []
-    reg, law, ssa, mansueto, crerar, eckhart = False, False, False, False, False, False
-    temp1, temp2, temp3, temp4, temp5, temp6 = 0, 0, 0, 0, 0, 0
+    reg, law, ssa, mansueto, crerar, eckhart, scrc = False, False, False, False, False, False, False
+    temp1, temp2, temp3, temp4, temp5, temp6, temp7 = 0, 0, 0, 0, 0, 0, 0
     for b in buildings:
-        if b.libcal_library_id == 1797:
+        if (b.libcal_library_id) == 1357:
             reg = True
             temp1 = b
-        elif b.libcal_library_id == 1798:
+        elif b.libcal_library_id == 1380:
             ssa = True
             temp2 = b
-        elif b.libcal_library_id == 1816:
+        elif b.libcal_library_id == 1379:
             mansueto = True
             temp3 = b
-        elif b.libcal_library_id == 2713:
+        elif b.libcal_library_id == 1373:
             crerar = True
             temp4 = b
-        elif b.libcal_library_id == 2714:
+        elif b.libcal_library_id == 1377:
             eckhart = True
             temp5 = b
-        elif b.libcal_library_id == 3393:
+        elif b.libcal_library_id == 1378:
             law = True
             temp6 = b
+        else:
+            scrc = True
+            temp7 = b
     
     #Now constructing new sorted list
     if reg:
@@ -395,5 +398,7 @@ def sort_buildings(buildings):
         new_list.append(temp5)
     if law:
         new_list.append(temp6)
+    if scrc:
+        new_list.append(temp7)
         
     return new_list

--- a/base/utils.py
+++ b/base/utils.py
@@ -9,6 +9,7 @@ from django.utils.text import slugify
 from bs4 import BeautifulSoup
 import json
 from wagtail.wagtailcore.models import Page
+from library_website.settings import REGENSTEIN_HOMEPAGE, SSA_HOMEPAGE, MANSUETO_HOMEPAGE, CRERAR_HOMEPAGE, ECKHART_HOMEPAGE, DANGELO_HOMEPAGE, SCRC_HOMEPAGE
 
 HOURS_UNAVIALABLE = 'Hours Unavailable'
 
@@ -353,7 +354,7 @@ def get_hours_and_location(obj):
             'libcalid': libcalid,
             'address': ADDRESS_TEMPLATE % (address, location.city, location.state, str(location.postal_code)) }
 
-def sort_buildings(buildings):
+def sort_buildings(spaces):
     """ 
     Sort the given list of buildings so that buildings
     always appear in standard order in dropdown select 
@@ -361,46 +362,23 @@ def sort_buildings(buildings):
 
 	If not used, buildings list will be randomly organized.
     """
+    from public.models import LocationPage
+    from base.models import PublicBasePage
     new_list = []
-    reg, law, ssa, mansueto, crerar, eckhart, scrc = False, False, False, False, False, False, False
-    temp1, temp2, temp3, temp4, temp5, temp6, temp7 = 0, 0, 0, 0, 0, 0, 0
-    for b in buildings:
-        if (b.libcal_library_id) == 1357:
-            reg = True
-            temp1 = b
-        elif b.libcal_library_id == 1380:
-            ssa = True
-            temp2 = b
-        elif b.libcal_library_id == 1379:
-            mansueto = True
-            temp3 = b
-        elif b.libcal_library_id == 1373:
-            crerar = True
-            temp4 = b
-        elif b.libcal_library_id == 1377:
-            eckhart = True
-            temp5 = b
-        elif b.libcal_library_id == 1378:
-            law = True
-            temp6 = b
-        else:
-            scrc = True
-            temp7 = b
-    
-    #Now constructing new sorted list
-    if reg:
-        new_list.append(temp1)
-    if ssa:
-        new_list.append(temp2)
-    if mansueto:
-        new_list.append(temp3)
-    if crerar:
-        new_list.append(temp4)
-    if eckhart:
-        new_list.append(temp5)
-    if law:
-        new_list.append(temp6)
-    if scrc:
-        new_list.append(temp7)
-        
+    pages = PublicBasePage.objects
+    id_list = spaces.values_list('parent_building',flat=True)
+    if 1797 in id_list:
+        new_list.append(pages.get(id=REGENSTEIN_HOMEPAGE))
+    if 1798 in id_list:
+        new_list.append(pages.get(id=1798))
+    if 1816 in id_list:
+        new_list.append(pages.get(id=MANSUETO_HOMEPAGE))
+    if 2713 in id_list:
+        new_list.append(pages.get(id=CRERAR_HOMEPAGE))
+    if 2714 in id_list:
+        new_list.append(pages.get(id=ECKHART_HOMEPAGE))
+    if 3393 in id_list:
+        new_list.append(pages.get(id=DANGELO_HOMEPAGE))
+    if 2971 in id_list:
+        new_list.append(pages.get(id=SCRC_HOMEPAGE))
     return new_list

--- a/base/utils.py
+++ b/base/utils.py
@@ -362,23 +362,23 @@ def sort_buildings(spaces):
 
 	If not used, buildings list will be randomly organized.
     """
-    from public.models import LocationPage
-    from base.models import PublicBasePage
+    from public.models import LocationPage, StandardPage
+    REG, SSA, MANSUETO, CRERAR, ECKHART, DANGELO, SCRC = 1797, 1798, 1816, 2713, 2714, 3393, 2971
     new_list = []
-    pages = PublicBasePage.objects
+    pages = StandardPage.objects
     id_list = spaces.values_list('parent_building',flat=True)
-    if 1797 in id_list:
+    if REG in id_list:
         new_list.append(pages.get(id=REGENSTEIN_HOMEPAGE))
-    if 1798 in id_list:
-        new_list.append(pages.get(id=1798))
-    if 1816 in id_list:
+    if SSA in id_list:
+        new_list.append(LocationPage.objects.get(id=SSA))
+    if MANSUETO in id_list:
         new_list.append(pages.get(id=MANSUETO_HOMEPAGE))
-    if 2713 in id_list:
+    if CRERAR in id_list:
         new_list.append(pages.get(id=CRERAR_HOMEPAGE))
-    if 2714 in id_list:
+    if ECKHART in id_list:
         new_list.append(pages.get(id=ECKHART_HOMEPAGE))
-    if 3393 in id_list:
+    if DANGELO in id_list:
         new_list.append(pages.get(id=DANGELO_HOMEPAGE))
-    if 2971 in id_list:
+    if SCRC in id_list:
         new_list.append(pages.get(id=SCRC_HOMEPAGE))
     return new_list

--- a/base/utils.py
+++ b/base/utils.py
@@ -353,4 +353,47 @@ def get_hours_and_location(obj):
             'libcalid': libcalid,
             'address': ADDRESS_TEMPLATE % (address, location.city, location.state, str(location.postal_code)) }
 
-
+def sort_buildings(buildings):
+    """ 
+    Sort the given list of buildings so that buildings
+    always appear in standard order in dropdown select 
+    in spaces page.
+    """
+    new_list = []
+    reg, law, ssa, mansueto, crerar, eckhart = False, False, False, False, False, False
+    temp1, temp2, temp3, temp4, temp5, temp6 = 0, 0, 0, 0, 0, 0
+    for b in buildings:
+        if b.libcal_library_id == 1797:
+            reg = True
+            temp1 = b
+        elif b.libcal_library_id == 1798:
+            ssa = True
+            temp2 = b
+        elif b.libcal_library_id == 1816:
+            mansueto = True
+            temp3 = b
+        elif b.libcal_library_id == 2713:
+            crerar = True
+            temp4 = b
+        elif b.libcal_library_id == 2714:
+            eckhart = True
+            temp5 = b
+        elif b.libcal_library_id == 3393:
+            law = True
+            temp6 = b
+    
+    #Now constructing new sorted list
+    if reg:
+        new_list.append(temp1)
+    if ssa:
+        new_list.append(temp2)
+    if mansueto:
+        new_list.append(temp3)
+    if crerar:
+        new_list.append(temp4)
+    if eckhart:
+        new_list.append(temp5)
+    if law:
+        new_list.append(temp6)
+        
+    return new_list

--- a/base/utils.py
+++ b/base/utils.py
@@ -357,7 +357,9 @@ def sort_buildings(buildings):
     """ 
     Sort the given list of buildings so that buildings
     always appear in standard order in dropdown select 
-    in spaces page.
+    in spaces page. Uses libcal_library_id of main library buildings.
+
+	If not used, buildings list will be randomly organized.
     """
     new_list = []
     reg, law, ssa, mansueto, crerar, eckhart, scrc = False, False, False, False, False, False, False

--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -257,3 +257,12 @@ HOURS_PAGE = 4084
 
 # Library news categories
 NEWS_CATEGORIES = set(['Resources', 'Research', 'Teaching', 'Events', 'Exhibits', 'People', 'Hours & Access', 'Spaces', 'Spotlight', 'From the Director'])
+
+# UChicago Library Pages
+REGENSTEIN_HOMEPAGE = 1757
+SSA_HOMEPAGE = 1758
+MANSUETO_HOMEPAGE = 1753 
+CRERAR_HOMEPAGE = 1752
+ECKHART_HOMEPAGE = 1755
+DANGELO_HOMEPAGE = 1754
+SCRC_HOMEPAGE = 1756

--- a/public/views.py
+++ b/public/views.py
@@ -52,9 +52,6 @@ def spaces(request):
         all_spaces = all_spaces.filter(**{feature: True})
     if space_type:
         all_spaces = all_spaces.filter(**{space_type: True})
-    #buildings = []
-    #for s in all_spaces:
-    #    buildings.append(s.parent_building)
     buildings = sort_buildings(all_spaces)
 
     # make sure all features have at least one LocationPage for the current space_type. 

--- a/public/views.py
+++ b/public/views.py
@@ -44,10 +44,16 @@ def spaces(request):
         spaces = spaces.filter(**{space_type: True})
 
     # the spaces have been filtered down by building, feature, floor and space type. 
-    # get possible buildings from that filtered list. 
+    # get possible buildings from that filtered list if feature is selected.
+    # else show all libraries as options
     buildings = []
-    parent_building_ids = list(map(lambda s: s.parent_building.id, list(filter(lambda s: s.parent_building, spaces))))
-    buildings = LocationPage.objects.filter(id__in = parent_building_ids)
+
+	# 3393 = D'Angelo Law Library, 1797 = Regenstein Library, 1816 = Mansueto
+	# 2713 = Crerar, 2714 = Eckart, 1798 = Social Service Administration
+    buildings = LocationPage.objects.filter(id__in = [3393, 1797, 1816, 2713, 2714])
+    if feature:
+        parent_building_ids = list(map(lambda s: s.parent_building.id, list(filter(lambda s: s.parent_building, spaces))))
+        buildings = LocationPage.objects.filter(id__in = parent_building_ids)
 
     # make sure all features have at least one LocationPage for the current space_type. 
     features = list(filter(lambda f: spaces.filter(**{f[0]: True}), possible_features))

--- a/public/views.py
+++ b/public/views.py
@@ -46,14 +46,10 @@ def spaces(request):
     # the spaces have been filtered down by building, feature, floor and space type. 
     # get possible buildings from that filtered list if feature is selected.
     # else show all libraries as options
-    buildings = []
 
 	# 3393 = D'Angelo Law Library, 1797 = Regenstein Library, 1816 = Mansueto
 	# 2713 = Crerar, 2714 = Eckart, 1798 = Social Service Administration
-    buildings = LocationPage.objects.filter(id__in = [3393, 1797, 1816, 2713, 2714])
-    if feature:
-        parent_building_ids = list(map(lambda s: s.parent_building.id, list(filter(lambda s: s.parent_building, spaces))))
-        buildings = LocationPage.objects.filter(id__in = parent_building_ids)
+    buildings = LocationPage.objects.filter(id__in = [3393, 1797, 1816, 2713, 2714, 1798])
 
     # make sure all features have at least one LocationPage for the current space_type. 
     features = list(filter(lambda f: spaces.filter(**{f[0]: True}), possible_features))

--- a/public/views.py
+++ b/public/views.py
@@ -3,7 +3,7 @@ from public.models import LocationPage, LocationPageFloorPlacement
 from wagtail.wagtailimages.models import Image
 from public.models import StandardPage
 from library_website.settings import PUBLIC_HOMEPAGE
-from base.utils import get_hours_and_location
+from base.utils import get_hours_and_location, sort_buildings
 from ask_a_librarian.utils import get_chat_status, get_chat_status_css, get_unit_chat_link
 from public.utils import get_features, has_feature
 
@@ -50,7 +50,16 @@ def spaces(request):
 	# 3393 = D'Angelo Law Library, 1797 = Regenstein Library, 1816 = Mansueto
 	# 2713 = Crerar, 2714 = Eckart, 1798 = Social Service Administration
     buildings = LocationPage.objects.filter(id__in = [3393, 1797, 1816, 2713, 2714, 1798])
-
+    if feature:
+	    # Sort by feature, obtain all buildings, filter by featurem then obtain
+		# parent buildings and use set() to eliminate doubles now have to organize
+        all_buildings = LocationPage.objects.all()
+        all_buildings = all_buildings.filter(**{feature: True})
+        buildings = []
+        for b in all_buildings:
+            buildings.append(b.parent_building)
+        buildings = list(set(buildings))
+        #buildings = sort_buildings(buildings)			
     # make sure all features have at least one LocationPage for the current space_type. 
     features = list(filter(lambda f: spaces.filter(**{f[0]: True}), possible_features))
 

--- a/public/views.py
+++ b/public/views.py
@@ -45,17 +45,17 @@ def spaces(request):
 
     # Narrow down list of buildings from all buildings by using feature
     # and space_type, create list of libraries for display in dropdown
-    # from parent_building of filtered all_buildings. Use set to remove
+    # from parent_building of filtered all_spaces. Use set to remove
     # duplicates and sort_buildings to organize resulting list of libraries
-    all_buildings = LocationPage.objects.all()
+    all_spaces = LocationPage.objects.live()
     if feature:
-        all_buildings = all_buildings.filter(**{feature: True})
+        all_spaces = all_spaces.filter(**{feature: True})
     if space_type:
-        all_buildings = all_buildings.filter(**{space_type: True})
-    buildings = []
-    for b in all_buildings:
-        buildings.append(b.parent_building)
-    buildings = sort_buildings(list(set(buildings)))
+        all_spaces = all_spaces.filter(**{space_type: True})
+    #buildings = []
+    #for s in all_spaces:
+    #    buildings.append(s.parent_building)
+    buildings = sort_buildings(all_spaces)
 
     # make sure all features have at least one LocationPage for the current space_type. 
     features = list(filter(lambda f: spaces.filter(**{f[0]: True}), possible_features))
@@ -64,9 +64,9 @@ def spaces(request):
     # the parameters that have been set. 
     floors = []
     if building:
-        # Changed spaces to all_buildings in id_list to bypass filtering in spaces.
+        # Changed spaces to all_spaces in id_list to bypass filtering in spaces.
         # get all locations that are descendants of this building. 
-        id_list = all_buildings.filter(parent_building__title=building).values_list('pk', flat=True)
+        id_list = all_spaces.filter(parent_building__title=building).values_list('pk', flat=True)
         # get a unique, sorted list of the available floors here. 
         floors = sorted(list(set(LocationPageFloorPlacement.objects.filter(parent__in=id_list).exclude(floor=None).values_list('floor__title', flat=True))))
 

--- a/public/views.py
+++ b/public/views.py
@@ -43,9 +43,10 @@ def spaces(request):
     if space_type:
         spaces = spaces.filter(**{space_type: True})
 
-    # the spaces have been filtered down by building, feature, floor and space type. 
-    # get possible buildings from that filtered list if feature is selected.
-    # else show all libraries as options
+    # Narrow down list of buildings from all buildings by using feature
+    # and space_type, create list of libraries for display in dropdown
+    # from parent_building of filtered all_buildings. Use set to remove
+    # duplicates and sort_buildings to organize resulting list of libraries
     all_buildings = LocationPage.objects.all()
     if feature:
         all_buildings = all_buildings.filter(**{feature: True})
@@ -63,8 +64,9 @@ def spaces(request):
     # the parameters that have been set. 
     floors = []
     if building:
+        # Changed spaces to all_buildings in id_list to bypass filtering in spaces.
         # get all locations that are descendants of this building. 
-        id_list = spaces.filter(parent_building__title=building).values_list('pk', flat=True)
+        id_list = all_buildings.filter(parent_building__title=building).values_list('pk', flat=True)
         # get a unique, sorted list of the available floors here. 
         floors = sorted(list(set(LocationPageFloorPlacement.objects.filter(parent__in=id_list).exclude(floor=None).values_list('floor__title', flat=True))))
 

--- a/public/views.py
+++ b/public/views.py
@@ -46,20 +46,16 @@ def spaces(request):
     # the spaces have been filtered down by building, feature, floor and space type. 
     # get possible buildings from that filtered list if feature is selected.
     # else show all libraries as options
-
-	# 3393 = D'Angelo Law Library, 1797 = Regenstein Library, 1816 = Mansueto
-	# 2713 = Crerar, 2714 = Eckart, 1798 = Social Service Administration
-    buildings = LocationPage.objects.filter(id__in = [3393, 1797, 1816, 2713, 2714, 1798])
+    all_buildings = LocationPage.objects.all()
     if feature:
-	    # Sort by feature, obtain all buildings, filter by featurem then obtain
-		# parent buildings and use set() to eliminate doubles now have to organize
-        all_buildings = LocationPage.objects.all()
         all_buildings = all_buildings.filter(**{feature: True})
-        buildings = []
-        for b in all_buildings:
-            buildings.append(b.parent_building)
-        buildings = list(set(buildings))
-        #buildings = sort_buildings(buildings)			
+    if space_type:
+        all_buildings = all_buildings.filter(**{space_type: True})
+    buildings = []
+    for b in all_buildings:
+        buildings.append(b.parent_building)
+    buildings = sort_buildings(list(set(buildings)))
+
     # make sure all features have at least one LocationPage for the current space_type. 
     features = list(filter(lambda f: spaces.filter(**{f[0]: True}), possible_features))
 


### PR DESCRIPTION
Addresses user complaint that you could not select another library while filtering by library in the spaces page, previously could only select 'All Libraries' and the currently selected library. However, this fix does not address filtering the buildings by feature, in other words a user can select a library and a feature that that library does not have producing a blank table. 