### PR TITLE
Nav change: Center for Digital Scholarship

### DIFF
--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -228,7 +228,7 @@
                                         <li class="twocol-head">Scholarly Communication &amp; Publishing</li>
                                         <li role="separator" class="divider visible-xs"></li>
                                         <li><a href="/research/scholar/phd" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Dissertation Office">Dissertation Office</a></li>
-                                        <li><a href="/research/scholar/digitalscholarship" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Digital Scholarship</a></li>
+                                        <li><a href="/research/scholar/digitalscholarship" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Center for Digital Scholarship</a></li>
                                         <li><a href="https://www.lib.uchicago.edu/copyrightinfo/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Copyright Info">Copyright Info</a></li>
                                     </ul>
                                 </li>


### PR DESCRIPTION
“For” is not capitalized in accordance to CMOS 8.157: Principles of
headline-style capitalization