### PR TITLE
Modified the database search box to use the LibGuides A-Z list.

### DIFF
--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -93,11 +93,9 @@
     <!-- TAB 3 - Database Finder -->
     <div data-radio-button-content-panel="database-finder">
       <h1 class="searchbox-header">Database Finder</h1>
-      <form method="get" action="https://www.lib.uchicago.edu/cgi-bin/nand/search/databasefinder" data-ga-category="search-widget" data-ga-action="submit" data-ga-label="Articles, Journals &amp; Databases &gt; Search">
-        <input type="hidden" value="::CONFIG::titlesearch" name="search">
-        <input type="hidden" value="::CONFIG::keyword" name="search-field-0">
+      <form method="get" action="https://www.lib.uchicago.edu/dbfinder" data-ga-category="search-widget" data-ga-action="submit" data-ga-label="Articles, Journals &amp; Databases &gt; Search">
         <div class="col-xs-9 col-sm-10 nopadding">
-          <input name="search-parm-0" type="text" placeholder="evolutionary biology database" aria-label="..." class="form-control">
+          <input name="q" type="text" placeholder="evolutionary biology database" aria-label="..." class="form-control">
         </div>
                    
         <div class="col-xs-3 col-sm-2 search-btn-wrapper">


### PR DESCRIPTION
Fixes #103 

Switches the databasefinder form action to the `/dbfinder` handle and modifies the input to work with the LibGuides A-Z list.