### PR TITLE
Gets restricted pages out of search results and fixes issue #112.

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -265,6 +265,9 @@ ROOT_UNIT = 2455
 
 PUBLIC_HOMEPAGE = 3378
 
+# Restricted directory locked down to campus by shib
+RESTRICTED = 3831
+
 # String templates for hours and address display in the header and footer
 HOURS_TEMPLATE = '%s &nbsp; %s'
 ADDRESS_TEMPLATE = '%s, %s, %s %s'

--- a/library_website/settings/dev.py
+++ b/library_website/settings/dev.py
@@ -15,6 +15,9 @@ COMPRESS_OFFLINE = True
 COMPRESS_OFFLINE_TIMEOUT = 3
 COMPRESS_REBUILD_TIMEOUT = 3
 
+# Restricted directory locked down to campus by shib
+RESTRICTED = 7164
+
 try:
     from .local import *
 except ImportError:

--- a/results/views.py
+++ b/results/views.py
@@ -4,7 +4,7 @@ from wagtail.core.models import Page, Site
 from wagtail.search.models import Query
 from wagtail.contrib.search_promotions.models import SearchPromotion
 from public.models import StandardPage
-from library_website.settings import PUBLIC_HOMEPAGE
+from library_website.settings import PUBLIC_HOMEPAGE, RESTRICTED
 from base.utils import get_hours_and_location
 from ask_a_librarian.utils import get_chat_status, get_chat_status_css, get_unit_chat_link
 from units.models import UnitIndexPage
@@ -17,7 +17,9 @@ def results(request):
     if search_query:
         homepage = Site.objects.get(site_name="Public").root_page
         unit_index_page = UnitIndexPage.objects.first()
-        search_results = Page.objects.live().descendant_of(homepage).not_descendant_of(unit_index_page, True).search(search_query)
+        restricted = StandardPage.objects.live().get(id=RESTRICTED)
+        search_results = Page.objects.live().descendant_of(homepage).not_descendant_of(
+            unit_index_page, True).not_descendant_of(restricted, True).search(search_query)
         query = Query.get(search_query)
 
         # Record hit


### PR DESCRIPTION
Fixes #112.

**Changes in this request**
- Pages in /restricted/ are now filtered out of search results.
- The test database was updated to include a restricted page and child page. 
- Config files were updated for production and dev to identify the restricted page.