### PR TITLE
Fixed font sizing in lists and Loop Homepage Sidebar

### DIFF
--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -132,7 +132,6 @@ p {
 }
 
 .rich-text ul, .rich-text ol {
-  font-size: 1.1em;
   line-height: 1.7em;
   max-width: 50em;
     li {

--- a/intranethome/templates/intranethome/intranet_home_page.html
+++ b/intranethome/templates/intranethome/intranet_home_page.html
@@ -55,14 +55,13 @@
     <div class="row-fluid"> <!-- Quicklinks Row -->
       <h1>Quicklinks</h1>
       <ul>
-        <li><a href="https://workday.uchicago.edu/">WorkDay</a></li>
-        <li><a href="http://uchicagotime.uchicago.edu/">UChicago Time</a></li>
         <li><a href="https://humanresources.uchicago.edu/benefits/">Benefits</a></li>
-        <li><a href="http://www.lib.uchicago.edu/cgi-bin/mail-aliases/">Email Aliases</a></li>
-        <li><a href="/staff/">Staff Directory</a></li>
         <li><a href="https://uchicago.app.box.com">Box</a></li>
-        <li><a href="https://outlook.office.com/owa/?realm=ad.uchicago.edu">Outlook</a></li>
+        <li><a href="http://www.lib.uchicago.edu/cgi-bin/mail-aliases/">Email Aliases</a></li>
         <li><a href="https://www.lib.uchicago.edu/h/ole">OLE</a></li>
+        <li><a href="https://outlook.office.com/owa/?realm=ad.uchicago.edu">Outlook</a></li>
+        <li><a href="/staff/">Staff Directory</a></li>
+        <li><a href="https://workday.uchicago.edu/">WorkDay</a></li>
       </ul>
     </div> <!-- / Quicklinks Row -->
 


### PR DESCRIPTION
Fixes #99 and #115

**Changes in this request**
- Removed font sizing from ul / ol so it inherits font size from the parent.
- Reordered sidebar on Loop homepage