### PR TITLE
Moved the sticky until field for loop news stories to the promote tab.

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -46,7 +46,6 @@ class NewsPage(BasePage):
         StreamFieldPanel('body'),
         FieldPanel('author'),
         FieldPanel('story_date'),
-        FieldPanel('sticky_until'),
         MultiFieldPanel(
             [
                 ImageChooserPanel('thumbnail'),
@@ -56,6 +55,10 @@ class NewsPage(BasePage):
         ),
         FieldPanel('excerpt'),
     ] + BasePage.content_panels
+
+    promote_panels = BasePage.content_panels + [
+        FieldPanel('sticky_until'),
+    ]
 
     search_fields = PublicBasePage.search_fields + [
         index.SearchField('excerpt'),


### PR DESCRIPTION
Fixes issue #124.

Moved the sticky_until field to the promote tab.