### PR TITLE
133 index reports and meeting minutes metadata on loop

### DIFF
--- a/base/tests.py
+++ b/base/tests.py
@@ -10,10 +10,10 @@ from django.test import Client, TestCase
 from file_parsing import is_json
 from wagtail.core.models import Page, Site
 
-from base.models import BasePage, IntranetPlainPage, get_available_path_under
+from base.models import BasePage, get_available_path_under
 from base.utils import get_hours_by_id, get_json_for_library
 from news.models import NewsPage
-from public.models import LocationPage, StandardPage
+from public.models import StandardPage
 from staff.models import StaffIndexPage, StaffPage
 from units.models import UnitPage
 
@@ -317,8 +317,7 @@ class TestPageModels(TestCase):
                 'FindingAidsPage', 'GroupMeetingMinutesIndexPage',
                 'GroupReportsIndexPage', 'HomePage', 'IntranetFormPage',
                 'IntranetHomePage', 'IntranetUnitsReportsIndexPage',
-                'ProjectIndexPage', 'GroupMeetingMinutesPage',
-                'GroupReportsPage', 'IntranetUnitsReportsPage', 'RedirectPage'
+                'ProjectIndexPage', 'RedirectPage'
             ]
         )
         no_search_fields = set([])

--- a/group/models.py
+++ b/group/models.py
@@ -1,24 +1,25 @@
-from django.db import models
-from django.db.models.fields import CharField, TextField
-from django.utils import timezone
+import re
+from collections import OrderedDict
 from datetime import datetime, timedelta
 
-from base.models import BasePage, LinkFields, DefaultBodyFields, Email, AbstractReport, Report
-from staff.models import StaffPage
-from wagtail.core.fields import RichTextField, StreamField
-from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel, StreamFieldPanel
-from wagtail.core.models import Orderable, Page
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models.fields import CharField
+from django.utils import timezone
 from modelcluster.fields import ParentalKey
+from wagtail.admin.edit_handlers import (
+    FieldPanel, InlinePanel, MultiFieldPanel, StreamFieldPanel
+)
+from wagtail.core.fields import RichTextField, StreamField
+from wagtail.core.models import Orderable, Page
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
-from wagtail.documents.models import Document
-from wagtail.documents.edit_handlers import DocumentChooserPanel
+from base.models import (
+    AbstractReport, BasePage, DefaultBodyFields, Email, Report
+)
+from base.utils import get_doc_titles_for_indexing, get_field_for_indexing
 
-from collections import OrderedDict
-from django.core.exceptions import ValidationError
-import re
-import sys
 
 def default_end_time():
     """
@@ -49,13 +50,19 @@ class GroupMemberRole(models.Model, index.Indexed):
 
 def enforce_name_as_year(title):
     """
-    Helper function for making sure 
-    page titles adhere to a strict 
+    Helper function for making sure
+    page titles adhere to a strict
     formatting policy.
     """
     if not re.match('^[0-9]{4}$', title):
-        raise ValidationError({'title': ('Please enter the year as \
-            a four digit number, e.g. 2016')})
+        raise ValidationError(
+            {
+                'title': (
+                    'Please enter the year as \
+            a four digit number, e.g. 2016'
+                )
+            }
+        )
 
 
 def enforce_name_as_reports(title):
@@ -70,16 +77,16 @@ def enforce_name_as_reports(title):
 
 def get_page_objects_grouped_by_date(obj):
     """
-    Helper function for getting page objects and 
+    Helper function for getting page objects and
     child objects grouped by date.
     Used for meeting minutes and reports.
 
     Args:
         obj: Page.child_object that belongs to a Page type.
-        Must have "date" and "summary" fields associated 
+        Must have "date" and "summary" fields associated
         with it. Other optional fields on the object
-        can be "link" and "document" (wagtail doc obj). 
-    
+        can be "link" and "document" (wagtail doc obj).
+
     Returns:
         OrderedDict
     """
@@ -105,26 +112,23 @@ def get_page_objects_grouped_by_date(obj):
 
 def get_page_objects_as_list(obj):
     """
-    Helper function for getting page objects and 
+    Helper function for getting page objects and
     child objects as a list.
     Used for meeting minutes and reports.
 
     Args:
         obj: Page.child_object that belongs to a Page type.
-        Must have "date" and "summary" fields associated 
+        Must have "date" and "summary" fields associated
         with it. Other optional fields on the object
-        can be "link" and "document" (wagtail doc obj). 
-    
+        can be "link" and "document" (wagtail doc obj).
+
     Returns: list
     """
     retval = []
     for i in obj.order_by('-date'):
         if not i.link and not i.document.url:
             continue
-        item = {
-            'summary': i.summary,
-            'date': i.date.strftime("%b. %-d, %Y")
-        }
+        item = {'summary': i.summary, 'date': i.date.strftime("%b. %-d, %Y")}
         if i.link:
             item['url'] = i.link
         elif m.document.url:
@@ -148,7 +152,9 @@ class GroupMeetingMinutesPageTable(Orderable, MeetingMinutes):
     """
     Meeting minutes for group pages.
     """
-    page = ParentalKey('group.GroupMeetingMinutesPage', related_name='meeting_minutes')
+    page = ParentalKey(
+        'group.GroupMeetingMinutesPage', related_name='meeting_minutes'
+    )
 
 
 class GroupReportsPageTable(Orderable, Report):
@@ -160,7 +166,7 @@ class GroupReportsPageTable(Orderable, Report):
 
 class GroupMembers(Orderable, models.Model):
     """
-    Through table for linking staff pages to 
+    Through table for linking staff pages to
     groups and committees.
     """
     parent = ParentalKey(
@@ -180,50 +186,48 @@ class GroupMembers(Orderable, models.Model):
     )
     role = models.ForeignKey(
         'group.GroupMemberRole',
-        on_delete=models.SET_NULL, 
+        on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name='+'
-    )    
+    )
 
     class Meta:
         verbose_name = 'Member'
         verbose_name_plural = 'Members'
 
+
 class GroupPage(BasePage, Email):
     """
     Content type for group and committee pages.
     """
-    meeting_location = CharField(
-        blank=True,
-        max_length=255)
+    meeting_location = CharField(blank=True, max_length=255)
     meeting_start_time = models.TimeField(
-        auto_now=False, 
+        auto_now=False,
         auto_now_add=False,
         default=timezone.now,
         blank=True,
-        null=True)
+        null=True
+    )
     meeting_end_time = models.TimeField(
-        auto_now=False, 
+        auto_now=False,
         auto_now_add=False,
         default=default_end_time,
         blank=True,
-        null=True) 
-    meeting_frequency = CharField(
-        blank=True,
-        max_length=255)
+        null=True
+    )
+    meeting_frequency = CharField(blank=True, max_length=255)
     intro = StreamField(DefaultBodyFields(), blank=True)
     is_active = models.BooleanField(default=True)
     body = StreamField(DefaultBodyFields())
 
-
     content_panels = Page.content_panels + Email.content_panels + [
         MultiFieldPanel(
             [
-               FieldPanel('meeting_start_time'),
-               FieldPanel('meeting_end_time'),              
-               FieldPanel('meeting_location'), 
-               FieldPanel('meeting_frequency'),
+                FieldPanel('meeting_start_time'),
+                FieldPanel('meeting_end_time'),
+                FieldPanel('meeting_location'),
+                FieldPanel('meeting_frequency'),
             ],
             heading='Meeting Information'
         ),
@@ -231,12 +235,14 @@ class GroupPage(BasePage, Email):
         InlinePanel('group_members', label='Group Members'),
         FieldPanel('is_active'),
         StreamFieldPanel('body'),
-    ] + BasePage.content_panels 
+    ] + BasePage.content_panels
 
-    subpage_types = ['base.IntranetIndexPage', 'base.IntranetPlainPage', 'group.GroupPage', \
-                     'group.GroupMeetingMinutesIndexPage', 'group.GroupReportsIndexPage', \
-                     'group.GroupReportsPage', 'intranetforms.IntranetFormPage', \
-                     'intranettocs.TOCPage', 'projects.ProjectPage']
+    subpage_types = [
+        'base.IntranetIndexPage', 'base.IntranetPlainPage', 'group.GroupPage',
+        'group.GroupMeetingMinutesIndexPage', 'group.GroupReportsIndexPage',
+        'group.GroupReportsPage', 'intranetforms.IntranetFormPage',
+        'intranettocs.TOCPage', 'projects.ProjectPage'
+    ]
 
     search_fields = BasePage.search_fields + [
         index.SearchField('meeting_location'),
@@ -250,7 +256,7 @@ class GroupPage(BasePage, Email):
         context = super(GroupPage, self).get_context(request)
         group_members = self.group_members.all()
 
-        # sorting: chairs or co-chairs first, alphabetically; then others, alphabetically. 
+        # sorting: chairs or co-chairs first, alphabetically; then others, alphabetically.
         group_member_chairs = []
         non_group_member_chairs = []
         for g in group_members:
@@ -263,13 +269,19 @@ class GroupPage(BasePage, Email):
             else:
                 non_group_member_chairs.append(g)
 
-        group_member_chairs = sorted(group_member_chairs, key=lambda g: g.group_member.title)
-        non_group_member_chairs = sorted(non_group_member_chairs, key=lambda g: g.group_member.title)
+        group_member_chairs = sorted(
+            group_member_chairs, key=lambda g: g.group_member.title
+        )
+        non_group_member_chairs = sorted(
+            non_group_member_chairs, key=lambda g: g.group_member.title
+        )
         group_members = group_member_chairs + non_group_member_chairs
 
         # minutes
         tmp = []
-        group_meeting_min_pages = GroupMeetingMinutesPage.objects.descendant_of(self)
+        group_meeting_min_pages = GroupMeetingMinutesPage.objects.descendant_of(
+            self
+        )
         for group_meeting_min_page in group_meeting_min_pages:
             for m in group_meeting_min_page.meeting_minutes.all():
                 try:
@@ -289,7 +301,7 @@ class GroupPage(BasePage, Email):
                 tmp.append(minute)
         minutes = sorted(tmp, key=lambda m: m['sortdate'], reverse=True)[:3]
 
-        #reports
+        # reports
         tmp = []
         group_reports_pages = GroupReportsPage.objects.descendant_of(self)
         for group_reports_page in group_reports_pages:
@@ -310,7 +322,27 @@ class GroupPage(BasePage, Email):
 
         context['minutes'] = minutes
         context['reports'] = reports
-        context['group_members'] = list(map(lambda m: { 'title': m.group_member.title, 'unit': '<br/>'.join(sorted(map(lambda u: u.library_unit.get_full_name(), m.group_member.staff_page_units.all()))), 'url': m.group_member.url, 'role': m.role }, group_members))
+        context['group_members'] = list(
+            map(
+                lambda m: {
+                    'title':
+                    m.group_member.title,
+                    'unit':
+                    '<br/>'.join(
+                        sorted(
+                            map(
+                                lambda u: u.library_unit.get_full_name(),
+                                m.group_member.staff_page_units.all()
+                            )
+                        )
+                    ),
+                    'url':
+                    m.group_member.url,
+                    'role':
+                    m.role
+                }, group_members
+            )
+        )
         return context
 
 
@@ -327,7 +359,9 @@ class GroupMeetingMinutesIndexPage(BasePage):
         formatting policy.
         """
         if not self.title.strip() == "Meeting Minutes":
-            raise ValidationError({'title': ('The title should be "Meeting Minutes"')})
+            raise ValidationError(
+                {'title': ('The title should be "Meeting Minutes"')}
+            )
 
     def get_context(self, request):
         """
@@ -336,11 +370,12 @@ class GroupMeetingMinutesIndexPage(BasePage):
         context = super(GroupMeetingMinutesIndexPage, self).get_context(request)
 
         year_pages = self.get_children().order_by('-title')
-        
+
         data = []
         for page in year_pages:
             year_title = page.title
-            year_minutes = page.groupmeetingminutespage.get_meeting_minutes_grouped_by_date()
+            year_minutes = page.groupmeetingminutespage.get_meeting_minutes_grouped_by_date(
+            )
             data.append((year_title, year_minutes))
 
         context['data'] = data
@@ -351,12 +386,17 @@ class GroupMeetingMinutesPage(BasePage):
     """
     Page class that acts as a receptacle for meeting minutes.
     Objects created with this class should represent a year
-    and they should hold all of the meeting minutes for the 
+    and they should hold all of the meeting minutes for the
     given year.
     """
     content_panels = Page.content_panels + [
         InlinePanel('meeting_minutes', label='Meeting Minutes'),
-    ] + BasePage.content_panels 
+    ] + BasePage.content_panels
+
+    search_fields = BasePage.search_fields + [
+        index.SearchField('get_mm_summaries_for_indexing', partial_match=True),
+        index.SearchField('get_mm_doc_links_for_indexing', partial_match=True),
+    ]
 
     subpage_types = ['base.IntranetPlainPage']
 
@@ -370,7 +410,7 @@ class GroupMeetingMinutesPage(BasePage):
     def get_meeting_minutes(self):
         """
         Get meeting minutes as a list.
-        
+
         Returns: list
         """
         return get_page_objects_as_list(self.meeting_minutes)
@@ -378,7 +418,7 @@ class GroupMeetingMinutesPage(BasePage):
     def get_meeting_minutes_grouped_by_date(self):
         """
         Get meeting minutes grouped by date.
-        
+
         Returns:
             OrderedDict
         """
@@ -392,6 +432,28 @@ class GroupMeetingMinutesPage(BasePage):
         minutes = self.get_meeting_minutes()
         context['minutes'] = minutes
         return context
+
+    def get_mm_summaries_for_indexing(self):
+        """
+        Get meeting minute summaries in order to index them.
+
+        Returns:
+            Concatonated string of all meeting minute sumaries for
+            indexing purposes.
+        """
+        return get_field_for_indexing('summary', self.meeting_minutes.values())
+
+    def get_mm_doc_links_for_indexing(self):
+        """
+        Get meeting minute document links in order to index them.
+
+        Returns:
+            Concatonated string of all meeting minute document titles for
+            document links. Used for indexing purposes.
+        """
+        return get_doc_titles_for_indexing(
+            'link_document_id', self.meeting_minutes.values()
+        )
 
 
 class GroupReportsIndexPage(BasePage):
@@ -415,7 +477,7 @@ class GroupReportsIndexPage(BasePage):
         context = super(GroupReportsIndexPage, self).get_context(request)
 
         year_pages = self.get_children().order_by('-title')
-        
+
         data = []
         for page in year_pages:
             year_title = page.title
@@ -430,12 +492,19 @@ class GroupReportsPage(BasePage):
     """
     Page class that acts as a receptacle for reports.
     Objects created with this class should represent a year
-    and they should hold all of the reports for the 
+    and they should hold all of the reports for the
     given year.
     """
     content_panels = Page.content_panels + [
         InlinePanel('group_reports', label='Reports'),
-    ] + BasePage.content_panels 
+    ] + BasePage.content_panels
+
+    search_fields = BasePage.search_fields + [
+        index.
+        SearchField('get_report_summaries_for_indexing', partial_match=True),
+        index.
+        SearchField('get_report_doc_links_for_indexing', partial_match=True),
+    ]
 
     subpage_types = ['base.IntranetPlainPage']
 
@@ -455,11 +524,10 @@ class GroupReportsPage(BasePage):
         context['reports'] = reports
         return context
 
-
     def get_reports(self):
         """
         Get group reports as a list.
-        
+
         Returns:
             list
         """
@@ -474,6 +542,28 @@ class GroupReportsPage(BasePage):
         """
         return get_page_objects_grouped_by_date(self.group_reports)
 
+    def get_report_summaries_for_indexing(self):
+        """
+        Get report summaries in order to index them.
+
+        Returns:
+            Concatonated string of all meeting minute sumaries for
+            indexing purposes.
+        """
+        return get_field_for_indexing('summary', self.group_reports.values())
+
+    def get_report_doc_links_for_indexing(self):
+        """
+        Get meeting minute document links in order to index them.
+
+        Returns:
+            Concatonated string of all meeting minute document titles for
+            document links. Used for indexing purposes.
+        """
+        return get_doc_titles_for_indexing(
+            'link_document_id', self.group_reports.values()
+        )
+
 
 class GroupIndexPage(BasePage):
     """
@@ -485,7 +575,9 @@ class GroupIndexPage(BasePage):
         FieldPanel('intro')
     ] + BasePage.content_panels
 
-    subpage_types = ['base.IntranetIndexPage', 'base.IntranetPlainPage', 'group.GroupPage']
+    subpage_types = [
+        'base.IntranetIndexPage', 'base.IntranetPlainPage', 'group.GroupPage'
+    ]
 
     search_fields = BasePage.search_fields + [
         index.SearchField('intro'),
@@ -494,25 +586,35 @@ class GroupIndexPage(BasePage):
     def get_context(self, request):
         context = super(GroupIndexPage, self).get_context(request)
 
-        groups_active = [{
-            'title': GroupIndexPage.objects.first().title,
-            'url': GroupIndexPage.objects.first().url,
-            'children': [],
-        }]
+        groups_active = [
+            {
+                'title': GroupIndexPage.objects.first().title,
+                'url': GroupIndexPage.objects.first().url,
+                'children': [],
+            }
+        ]
 
         # for each group page get a list of the page's "group page" or "group
         # index page" ancestors. Check to see if this particular ancestor
         # already exists in the groups_active tree. If it doesn't exist,
         # create it. Then continue on, one descendant at a time, either adding
-        # new levels or using the existing ones if they're already there 
-        # from previous group pages. 
+        # new levels or using the existing ones if they're already there
+        # from previous group pages.
         for grouppage in GroupPage.objects.live().filter(is_active=True):
-            ancestors = [GroupIndexPage.objects.first()] + list(GroupPage.objects.ancestor_of(grouppage)) + [grouppage]
+            ancestors = [GroupIndexPage.objects.first()] + list(
+                GroupPage.objects.ancestor_of(grouppage)
+            ) + [grouppage]
             currentlevel = groups_active
             while ancestors:
                 ancestor = ancestors.pop(0)
-                if str(ancestor.content_type) in ['group page', 'group index page']:
-                    nextlevels = list(filter(lambda g: g['url'] == ancestor.url, currentlevel))
+                if str(ancestor.content_type) in [
+                    'group page', 'group index page'
+                ]:
+                    nextlevels = list(
+                        filter(
+                            lambda g: g['url'] == ancestor.url, currentlevel
+                        )
+                    )
                     if nextlevels:
                         currentlevel = nextlevels[0]['children']
                     else:
@@ -528,15 +630,33 @@ class GroupIndexPage(BasePage):
             for node in currentlevel:
                 node['children'] = alphabetize_groups(node['children'])
             return sorted(currentlevel, key=lambda c: c['title'])
+
         groups_active = alphabetize_groups(groups_active)
 
         def get_html(currentlevel):
             if not currentlevel:
                 return ''
             else:
-                return "<ul>" + "".join(list(map(lambda n: "<li><a href='" + n['url'] + "'>" + n['title'] + "</a>" + get_html(n['children']) + "</li>", currentlevel))) + "</ul>"
+                return "<ul>" + "".join(
+                    list(
+                        map(
+                            lambda n: "<li><a href='" + n['url'] + "'>" + n[
+                                'title'] + "</a>" + get_html(n['children']) +
+                            "</li>", currentlevel
+                        )
+                    )
+                ) + "</ul>"
+
         groups_active_html = get_html(groups_active[0]['children'])
-        
+
         context['groups_active_html'] = groups_active_html
-        context['groups_inactive'] = list(map(lambda g: { 'title': g.title, 'url': g.url }, GroupPage.objects.live().filter(is_active=False).order_by('title')))
+        context['groups_inactive'] = list(
+            map(
+                lambda g: {
+                    'title': g.title,
+                    'url': g.url
+                },
+                GroupPage.objects.live().filter(is_active=False).order_by('title')
+            )
+        )
         return context

--- a/intranetunits/models.py
+++ b/intranetunits/models.py
@@ -1,20 +1,29 @@
-from base.models import BasePage, DefaultBodyFields, Email, PhoneNumber, Report
-from group.models import get_page_objects_grouped_by_date, get_page_objects_as_list, enforce_name_as_year, enforce_name_as_reports
 from django.db import models
-from django.db.models.fields import CharField, TextField
 from modelcluster.fields import ParentalKey
-from staff.models import StaffPage
-from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel, StreamFieldPanel
+from wagtail.admin.edit_handlers import (
+    FieldPanel, InlinePanel, MultiFieldPanel, StreamFieldPanel
+)
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable, Page
 from wagtail.search import index
-from django.core.exceptions import ValidationError
+
+from base.models import BasePage, DefaultBodyFields, Email, PhoneNumber, Report
+from base.utils import get_doc_titles_for_indexing, get_field_for_indexing
+from group.models import (
+    enforce_name_as_reports, enforce_name_as_year, get_page_objects_as_list,
+    get_page_objects_grouped_by_date
+)
+from staff.models import StaffPage
+
 
 class IntranetUnitsReportsPageTable(Orderable, Report):
     """
     Reports for intranet unit pages.
     """
-    page = ParentalKey('intranetunits.IntranetUnitsReportsPage', related_name='intranet_units_reports')
+    page = ParentalKey(
+        'intranetunits.IntranetUnitsReportsPage',
+        related_name='intranet_units_reports'
+    )
 
 
 class IntranetUnitsReportsIndexPage(BasePage):
@@ -35,8 +44,11 @@ class IntranetUnitsReportsIndexPage(BasePage):
         """
         Get reports from children.
         """
-        context = super(IntranetUnitsReportsIndexPage, self).get_context(request)
-        year_pages = Page.objects.live().descendant_of(self.get_parent()).type(IntranetUnitsReportsPage).order_by('-title')
+        context = super(IntranetUnitsReportsIndexPage,
+                        self).get_context(request)
+        year_pages = Page.objects.live().descendant_of(
+            self.get_parent()
+        ).type(IntranetUnitsReportsPage).order_by('-title')
 
         data = []
         for page in year_pages:
@@ -51,7 +63,12 @@ class IntranetUnitsReportsIndexPage(BasePage):
 class IntranetUnitsReportsPage(BasePage):
     content_panels = Page.content_panels + [
         InlinePanel('intranet_units_reports', label='Reports'),
-    ] + BasePage.content_panels 
+    ] + BasePage.content_panels
+
+    search_fields = BasePage.search_fields + [
+        index.SearchField('get_report_summaries_for_indexing', partial_match=True),
+        index.SearchField('get_report_doc_links_for_indexing', partial_match=True),
+    ]
 
     subpage_types = ['base.IntranetPlainPage']
 
@@ -89,10 +106,34 @@ class IntranetUnitsReportsPage(BasePage):
         """
         return get_page_objects_grouped_by_date(self.intranet_units_reports)
 
+    def get_report_summaries_for_indexing(self):
+        """
+        Get report summaries in order to index them.
+
+        Returns:
+            Concatonated string of all meeting minute sumaries for
+            indexing purposes.
+        """
+        return get_field_for_indexing(
+            'summary', self.intranet_units_reports.values()
+        )
+
+    def get_report_doc_links_for_indexing(self):
+        """
+        Get meeting minute document links in order to index them.
+
+        Returns:
+            Concatonated string of all meeting minute document titles for
+            document links. Used for indexing purposes.
+        """
+        return get_doc_titles_for_indexing(
+            'link_document_id', self.intranet_units_reports.values()
+        )
+
 
 class IntranetUnitsPage(BasePage, Email, PhoneNumber):
     """
-    Content type for department pages on the intranet. 
+    Content type for department pages on the intranet.
     """
 
     unit_page = models.ForeignKey(
@@ -104,23 +145,20 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
     )
 
     intro = StreamField(DefaultBodyFields(), blank=True)
-
     internal_location = models.CharField(max_length=255, blank=True)
-
     internal_phone_number = models.CharField(max_length=255, blank=True)
-
     internal_email = models.EmailField(max_length=255, blank=True)
-
     staff_only_email = models.EmailField(max_length=254, blank=True)
-    
     body = StreamField(DefaultBodyFields(), null=True, blank=True)
-
     show_staff = models.BooleanField(default=False)
-
     show_departments = models.BooleanField(default=False)
 
-    subpage_types = ['base.IntranetIndexPage', 'base.IntranetPlainPage', 'intranetforms.IntranetFormPage', \
-    'intranettocs.TOCPage', 'intranetunits.IntranetUnitsPage', 'intranetunits.IntranetUnitsReportsIndexPage']
+    subpage_types = [
+        'base.IntranetIndexPage', 'base.IntranetPlainPage',
+        'intranetforms.IntranetFormPage', 'intranettocs.TOCPage',
+        'intranetunits.IntranetUnitsPage',
+        'intranetunits.IntranetUnitsReportsIndexPage'
+    ]
 
     search_fields = BasePage.search_fields + [
         index.SearchField('intro'),
@@ -135,12 +173,11 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
         """
         Helper function for get_full_name() and
         get_campus_directory_full_name(). This returns a list of page titles
-        that can be processed by those two functions. 
+        that can be processed by those two functions.
         """
         return list(
             self.get_ancestors(True).live().type(IntranetUnitsPage).values_list(
-                'title', 
-                flat=True
+                'title', flat=True
             )
         )
 
@@ -149,7 +186,7 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
         Get an IntranetUnitsPage's full name according to Wagtail.
 
         The full name of an IntranetUnitsPage includes a breadcrumb trail of
-        the titles its ancestor IntranetUnitsPages. 
+        the titles its ancestor IntranetUnitsPages.
 
         Example:
         Wagtail contains an IntranetUnitsPage for "Collections & Access". That
@@ -189,11 +226,10 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
                 continue
 
         # Our system includes more than two levels of heiarchy, but the campus
-        # directory only includes two. 
+        # directory only includes two.
         titles = titles[:2]
 
         return ' - '.join(titles)
-
 
     def get_context(self, request):
         context = super(IntranetUnitsPage, self).get_context(request)
@@ -203,11 +239,11 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
             context['phone'] = self.specific.internal_phone_number
 
         context['location'] = ''
-        if self.specific.internal_location: 
+        if self.specific.internal_location:
             context['location'] = self.specific.internal_location
 
         context['email'] = ''
-        if  self.specific.internal_email:
+        if self.specific.internal_email:
             context['email'] = self.specific.internal_email
 
         context['show_staff'] = self.show_staff
@@ -217,12 +253,16 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
         department_members = []
         if self.specific.unit_page:
             unit_pages = self.specific.unit_page.get_descendants(True)
-            staff_pages = StaffPage.objects.live().filter(staff_page_units__library_unit__in=unit_pages).distinct()
+            staff_pages = StaffPage.objects.live().filter(
+                staff_page_units__library_unit__in=unit_pages
+            ).distinct()
 
-            # sorting: supervisors first, alphabetically; then non-supervisors, alphabetically. 
+            # sorting: supervisors first, alphabetically; then non-supervisors, alphabetically.
             supervisor = self.specific.unit_page.department_head
             if supervisor:
-                staff_pages = [supervisor] + list(staff_pages.exclude(pk=supervisor.pk).order_by('last_name'))
+                staff_pages = [supervisor] + list(
+                    staff_pages.exclude(pk=supervisor.pk).order_by('last_name')
+                )
             else:
                 staff_pages = list(staff_pages.order_by('last_name'))
 
@@ -231,60 +271,78 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
                     email = staff_page.staff_page_email.first().email
                 except AttributeError:
                     email = None
-                phone_numbers = staff_page.staff_page_phone_faculty_exchange.all().values_list('phone_number', flat=True) 
+                phone_numbers = staff_page.staff_page_phone_faculty_exchange.all(
+                ).values_list(
+                    'phone_number', flat=True
+                )
                 titles = [staff_page.position_title]
 
-                department_members.append({
-                    'title': staff_page.title,
-                    'url': staff_page.url,
-                    'jobtitle': "<br/>".join(titles),
-                    'email': email,
-                    'phone': "<br/>".join(phone_numbers),
-                })
+                department_members.append(
+                    {
+                        'title': staff_page.title,
+                        'url': staff_page.url,
+                        'jobtitle': "<br/>".join(titles),
+                        'email': email,
+                        'phone': "<br/>".join(phone_numbers),
+                    }
+                )
 
         context['department_members'] = department_members
 
         department_units = []
         try:
             for unit_page in self.unit_page.get_descendants():
-                intranet_unit_page = unit_page.specific.loop_page.live().filter(show_in_menus=True).first()
+                intranet_unit_page = unit_page.specific.loop_page.live().filter(
+                    show_in_menus=True
+                ).first()
                 if intranet_unit_page:
                     unit = {
                         'title': intranet_unit_page.title,
                         'url': intranet_unit_page.url,
                         'location': intranet_unit_page.internal_location,
-                        'phone_number': intranet_unit_page.internal_phone_number,
+                        'phone_number':
+                        intranet_unit_page.internal_phone_number,
                         'email': intranet_unit_page.internal_email
                     }
-                       
-                    supervisors = [] 
+
+                    supervisors = []
                     if unit_page.specific.department_head:
                         try:
-                            email = unit_page.specific.department_head.staff_page_email.first().email
+                            email = unit_page.specific.department_head.staff_page_email.first(
+                            ).email
                         except AttributeError:
                             email = ''
                         try:
-                           phone_number = unit_page.specific.department_head.staff_page_phone_faculty_exchange.first().phone_number
+                            phone_number = unit_page.specific.department_head.staff_page_phone_faculty_exchange.first(
+                            ).phone_number
                         except AttributeError:
                             phone_number = ''
 
-                        supervisors.append({
-                            'title': unit_page.specific.department_head.title,
-                            'url': unit_page.specific.department_head.url,
-                            'phone_number': phone_number,
-                            'email': email
-                        })
+                        supervisors.append(
+                            {
+                                'title':
+                                unit_page.specific.department_head.title,
+                                'url': unit_page.specific.department_head.url,
+                                'phone_number': phone_number,
+                                'email': email
+                            }
+                        )
                     unit['supervisors'] = supervisors
                     department_units.append(unit)
-        except(AttributeError):
+        except (AttributeError):
             pass
 
         # split the department units into lists of lists, each inner list containing 4 or less items.
-        context['department_unit_rows'] = [department_units[i:i+4] for i in range(0, len(department_units), 4)]
+        context['department_unit_rows'] = [
+            department_units[i:i + 4]
+            for i in range(0, len(department_units), 4)
+        ]
 
-        #reports
+        # reports
         tmp = []
-        unit_reports_pages = IntranetUnitsReportsPage.objects.descendant_of(self)
+        unit_reports_pages = IntranetUnitsReportsPage.objects.descendant_of(
+            self
+        )
         for unit_reports_page in unit_reports_pages:
             for r in unit_reports_page.intranet_units_reports.all():
                 try:
@@ -305,8 +363,9 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
         reports = sorted(tmp, key=lambda r: r['sortdate'], reverse=True)[:3]
 
         context['reports'] = reports
-                
+
         return context
+
 
 IntranetUnitsPage.content_panels = Page.content_panels + [
     StreamFieldPanel('intro'),
@@ -323,12 +382,13 @@ IntranetUnitsPage.content_panels = Page.content_panels + [
 ] + BasePage.content_panels + [
     MultiFieldPanel(
         [
-        FieldPanel('show_staff'),
-        FieldPanel('show_departments'),
+            FieldPanel('show_staff'),
+            FieldPanel('show_departments'),
         ],
         heading="Show staff or subdepartments on this page"
     )
 ]
+
 
 class IntranetUnitsIndexPage(BasePage):
     intro = RichTextField()
@@ -337,7 +397,10 @@ class IntranetUnitsIndexPage(BasePage):
         FieldPanel('intro')
     ] + BasePage.content_panels
 
-    subpage_types = ['base.IntranetIndexPage', 'base.IntranetPlainPage', 'intranetunits.IntranetUnitsPage']
+    subpage_types = [
+        'base.IntranetIndexPage', 'base.IntranetPlainPage',
+        'intranetunits.IntranetUnitsPage'
+    ]
 
     search_fields = BasePage.search_fields + [
         index.SearchField('intro'),
@@ -346,25 +409,35 @@ class IntranetUnitsIndexPage(BasePage):
     def get_context(self, request):
         context = super(IntranetUnitsIndexPage, self).get_context(request)
 
-        units = [{
-            'title': IntranetUnitsIndexPage.objects.first().title,
-            'url': IntranetUnitsIndexPage.objects.first().url,
-            'children': [],
-        }]
+        units = [
+            {
+                'title': IntranetUnitsIndexPage.objects.first().title,
+                'url': IntranetUnitsIndexPage.objects.first().url,
+                'children': [],
+            }
+        ]
 
         # for each unit page get a list of the page's "intranet units page" or
         # "intranet units index page" ancestors. Check to see if this
         # particular ancestor already exists in the units tree. If it doesn't
         # exist, create it. Then continue on, one descendant at a time, either
         # adding new levels or using the existing ones if they're already there
-        # from previous unit pages. 
+        # from previous unit pages.
         for intranetunitspage in IntranetUnitsPage.objects.live():
-            ancestors = [IntranetUnitsIndexPage.objects.first()] + list(IntranetUnitsPage.objects.ancestor_of(intranetunitspage)) + [intranetunitspage]
+            ancestors = [IntranetUnitsIndexPage.objects.first()] + list(
+                IntranetUnitsPage.objects.ancestor_of(intranetunitspage)
+            ) + [intranetunitspage]
             currentlevel = units
             while ancestors:
                 ancestor = ancestors.pop(0)
-                if str(ancestor.content_type) in ['intranet units page', 'intranet units index page']:
-                    nextlevels = list(filter(lambda g: g['url'] == ancestor.url, currentlevel))
+                if str(ancestor.content_type) in [
+                    'intranet units page', 'intranet units index page'
+                ]:
+                    nextlevels = list(
+                        filter(
+                            lambda g: g['url'] == ancestor.url, currentlevel
+                        )
+                    )
                     if nextlevels:
                         currentlevel = nextlevels[0]['children']
                     else:
@@ -380,14 +453,23 @@ class IntranetUnitsIndexPage(BasePage):
             for node in currentlevel:
                 node['children'] = alphabetize_units(node['children'])
             return sorted(currentlevel, key=lambda c: c['title'])
+
         units = alphabetize_units(units)
 
         def get_html(currentlevel):
             if not currentlevel:
                 return ''
             else:
-                return "<ul>" + "".join(list(map(lambda n: "<li><a href='" + n['url'] + "'>" + n['title'] + "</a>" + get_html(n['children']) + "</li>", currentlevel))) + "</ul>"
+                return "<ul>" + "".join(
+                    list(
+                        map(
+                            lambda n: "<li><a href='" + n['url'] + "'>" + n[
+                                'title'] + "</a>" + get_html(n['children']) +
+                            "</li>", currentlevel
+                        )
+                    )
+                ) + "</ul>"
+
         units_html = get_html(units[0]['children'])
         context['units_html'] = units_html
         return context
-

--- a/library_website/settings/dev.py
+++ b/library_website/settings/dev.py
@@ -16,7 +16,7 @@ COMPRESS_OFFLINE_TIMEOUT = 3
 COMPRESS_REBUILD_TIMEOUT = 3
 
 # Restricted directory locked down to campus by shib
-RESTRICTED = 7164
+RESTRICTED = 7163
 
 try:
     from .local import *


### PR DESCRIPTION
Fixes #133.

- Updated the test database to include RESTRICTED pages
- Ran code through linter
- Added summaries and document link titles to the search_fields for GroupMeetingMinutesPage, GroupReportsPage and IntranetUnitsReportsPage models