### PR TITLE
Broken Preview on News Stories

### DIFF
--- a/lib_news/models.py
+++ b/lib_news/models.py
@@ -330,7 +330,7 @@ class LibNewsPage(PublicBasePage):
         # To handle this, we won't show any categories.
         except (AttributeError):
             return [
-                'Can\'t load categories in PEVIEW',
+                'Can\'t load categories in PREVIEW',
                 'Check categories on the LIVE page'
             ]
 

--- a/lib_news/models.py
+++ b/lib_news/models.py
@@ -321,10 +321,18 @@ class LibNewsPage(PublicBasePage):
         Returns:
             list of strings
         """
-        return [
-            str(PublicNewsCategories.objects.get(id=cat['category_id']))
-            for cat in self.lib_news_categories.values()
-        ]
+        try:
+            return [
+                str(PublicNewsCategories.objects.get(id=cat['category_id']))
+                for cat in self.lib_news_categories.values()
+            ]
+        # This is a FakeQuerySet and we are probably in preview mode.
+        # To handle this, we won't show any categories.
+        except (AttributeError):
+            return [
+                'Can\'t load categories in PEVIEW',
+                'Check categories on the LIVE page'
+            ]
 
     def get_first_feature_story_id(self):
         """


### PR DESCRIPTION
Handled an attribute error while getting categories on a FakeQuerySet for LibNewsPages in PREVIEW mode. 

Fixes #171 

**Changes in this request**
Instead of trying to display categories that are inaccessible in PREVIEW mode, we display simple text that should inform the editor as to what's going on and what they should do. This text is displayed in place of categories at the bottom of the news story.

![image](https://user-images.githubusercontent.com/7826429/65456249-85f75c80-de0e-11e9-93a9-4f1045bae365.png)