### PR TITLE
Out of Sync Staff Report Fails

### DIFF
--- a/staff/utils.py
+++ b/staff/utils.py
@@ -390,6 +390,7 @@ class WagtailStaffReport:
         Returns: two lists of strings.
         """
         def _format(cnetid, value, field):
+            value = '' if value is None else str(value)
             return '{} -{}- ({})'.format(cnetid, self._clean(value), field)
 
         # Don't sync up some staff accounts. Former library directors may


### PR DESCRIPTION
Fixes #186

**Changes in this request**
Ensure that only strings are being passed to the `_clean` function of `WagtailStaffReport`.