### PR TITLE
Delayed display of news category changes to published pages

### DIFF
--- a/lib_news/models.py
+++ b/lib_news/models.py
@@ -2,7 +2,7 @@ import json
 from urllib.request import URLError, urlopen
 
 import bleach
-from django.core.cache import caches
+from django.core.cache import cache, caches
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.template.response import TemplateResponse
@@ -550,6 +550,7 @@ def build_news_feed(sender, instance, **kwargs):
         None but writes a file to the static directory
     """
     clear_cache()
+    cache.delete('news_cats')
     drf_url = instance.get_site().root_url + DRF_NEWS_FEED
     try:
         serialized_data = urlopen(drf_url).read()


### PR DESCRIPTION
Fixes #209 

**Changes in this request**
Adds the clearing of Redis cache for news site categories in the build_news_feed function. When a news site is published, the Redis cache for news categories is cleared, similar to what we do with the wagtail_cache.