### PR TITLE
215 page owners report for departed staff

### DIFF
--- a/base/forms.py
+++ b/base/forms.py
@@ -14,7 +14,7 @@ class PageOwnersForm(forms.Form):
 
     cnetid_choices = [
         (s.cnetid, s.title)
-        for s in StaffPage.objects.live().order_by('last_name', 'first_name')
+        for s in StaffPage.objects.all().order_by('last_name', 'first_name')
     ]
     label = 'Limit by staff member'
     cnetid = forms.ChoiceField(

--- a/base/templates/base/page_owners_form.html
+++ b/base/templates/base/page_owners_form.html
@@ -40,7 +40,8 @@
         <h2>Page Owners Report</h2>
         <p>Download a report of pages and ownership information in CSV format. The report will tell you 
         who is the Page Maintainer, Editor, and Content Specialist for every page. Data can be downloaded
-        for all pages on the site or restricted by site (Loop/Public) or cnetid and role.</p>
+        for all pages on the site or restricted by site (Loop/Public) or cnetid and role. Upon submission,
+        your download will begin promptly, however, it might take awhile to complete.</p>
         <ul>
           <li>If no limits are selected, ownership data will be downloadad for all pages in the system.</li>
           <li>If only a staff member is selected, all pages will be returned if <em>any</em> role matches the given staff member.</li>

--- a/base/tests.py
+++ b/base/tests.py
@@ -494,10 +494,10 @@ class TestPageOwnerReports(TestCase):
         ).get_descendants().live().count() + 1
         get_loop_pages_count = sum(
             1 for p in self.c._get_pages(None, 'Loop', None)
-        )
+        ) - 1
         get_public_pages_count = sum(
             1 for p in self.c._get_pages(None, 'Public', None)
-        )
+        ) - 1
         self.assertEqual(get_loop_pages_count, num_pages_loop)
         self.assertEqual(get_public_pages_count, num_pages_public)
 
@@ -511,7 +511,7 @@ class TestPageOwnerReports(TestCase):
         """
         get_locutus_pages_count = sum(
             1 for p in self.c._get_pages('locutus', None, None)
-        )
+        ) - 1
         self.assertEqual(get_locutus_pages_count, 6)
 
     def test_get_pages_with_cnetid_and_role(self):
@@ -527,13 +527,13 @@ class TestPageOwnerReports(TestCase):
         """
         page_maintainer_in_scope = sum(
             1 for p in self.c._get_pages('locutus', None, 'page_maintainer')
-        )
+        ) - 1
         editor_in_scope = sum(
             1 for p in self.c._get_pages('locutus', None, 'editor')
-        )
+        ) - 1
         content_specialist_in_scope = sum(
             1 for p in self.c._get_pages('locutus', None, 'content_specialist')
-        )
+        ) - 1
         self.assertEqual(page_maintainer_in_scope, 3)
         self.assertEqual(editor_in_scope, 1)
         self.assertEqual(content_specialist_in_scope, 2)
@@ -542,7 +542,7 @@ class TestPageOwnerReports(TestCase):
         self
     ):
         all_pages_count = self.all_live_pages.count()
-        num_pages = sum(1 for p in self.c._get_pages(None, None, None))
+        num_pages = sum(1 for p in self.c._get_pages(None, None, None)) - 1
         self.assertEqual(num_pages, all_pages_count)
 
     def test_main_command_when_no_pages_are_returned(self):

--- a/base/wagtail_hooks.py
+++ b/base/wagtail_hooks.py
@@ -1,22 +1,30 @@
-import sys
-import pandas
-from io import StringIO
+import csv
 
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib.staticfiles.templatetags.staticfiles import static
-from django.core import management
-from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.html import format_html
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks
-from base.management.commands.report_page_maintainers_and_editors import Command
 
+from base.management.commands.report_page_maintainers_and_editors import \
+    Command
 from library_website.settings.base import (
     NO_PERMISSIONS_REDIRECT_URL, PERMISSIONS_MAPPING
 )
+
+
+class Echo:
+    """An object that implements just the write method of the file-like
+    interface.
+    """
+
+    def write(self, value):
+        """Write the value by returning it, instead of storing in a buffer."""
+        return value
 
 
 def get_required_groups(page):
@@ -105,17 +113,17 @@ def admin_view(request):
         }
 
         if form.is_valid():
-            records = c.get_records(**options)
-
-            head = records.pop(0)
-            df = pandas.DataFrame(records, columns=head)
-
-            response = HttpResponse(content_type='text/csv')
+            rows = c._get_pages(**options)
+            pseudo_buffer = Echo()
+            writer = csv.writer(pseudo_buffer)
+            response = StreamingHttpResponse(
+                (writer.writerow(row) for row in rows), content_type="text/csv"
+            )
             response['Content-Disposition'
-                     ] = 'attachment; filename="page-owner-report.csv"'
+                     ] = 'attachment; filename="somefilename.csv"'
 
-            df.to_csv(response, encoding='utf-8', index=False)
             return response
+
     else:
         form = PageOwnersForm()
         return render(request, 'base/page_owners_form.html', {'form': form})


### PR DESCRIPTION
Fixes #215 

**Changes in this request**
-  Adds departed, inactive staff to the page owner's report.
-  Switches the page owner's report to `StreamingHttpResponse` instead of `HttpResponse` to help with the Gateway timeout problem. 