### PR TITLE
Command for updating the site hostname

### DIFF
--- a/base/management/commands/update_site_data.py
+++ b/base/management/commands/update_site_data.py
@@ -1,0 +1,70 @@
+from django.core.management.base import BaseCommand
+from wagtail.core.models import Site
+
+
+class Command(BaseCommand):
+    """
+    Updates data for a site with a given hostname.
+
+    Required args:
+        hostname: string, current hostname of the Wagtail
+        site object to be updated
+
+    Optional args:
+        new_host: string, a new and different hostname for
+        the site
+
+    Returns:
+        None, saves an updated version of the Wagtail site
+        object with the given input parameters
+    """
+    help = 'Updates a Wagtail site object with the given arguments. \
+            Can be used to change the hostname of a site.'
+
+    def add_arguments(self, parser):
+        """
+        Add required positional options and optional
+        named arguments.
+        """
+        # Required positional options
+        parser.add_argument('hostname', nargs='+', type=str)
+
+        # Optional named arguments
+        parser.add_argument(
+            '-nh',
+            '--new_host',
+            action='store',
+            nargs=1,
+            help='Change the site hostname.'
+        )
+
+        parser.add_argument(
+            '-p',
+            '--port',
+            action='store',
+            nargs=1,
+            help='Change the site port.'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Meat of the command.
+        """
+        # Required args
+        current_host = options['hostname'][0]
+
+        # Optional args
+        new_host = options['new_host'][0] if options['new_host'] else None
+        new_port = options['port'][0] if options['port'] else None
+
+        site_obj = Site.objects.get(hostname=current_host)
+
+        if new_host:
+            site_obj.hostname = new_host
+
+        if new_port:
+            if not new_port.isdigit():
+                raise ValueError('The new port must be numeric')
+            site_obj.port = new_port
+
+        site_obj.save()

--- a/base/tests.py
+++ b/base/tests.py
@@ -557,3 +557,48 @@ class TestPageOwnerReports(TestCase):
         }
         csv = run_report_page_maintainers_and_editors(options)
         self.assertEqual(csv.strip(), ','.join(self.c.HEADER))
+
+
+class TestUpdateSiteDataCommand(TestCase):
+    """
+    Test cases for the update_site_data manage command.
+    """
+    fixtures = ['test.json']
+
+    def test_changing_port_alone(self):
+        """
+        Change the site port to a new one
+        """
+        management.call_command('update_site_data', 'loopdev', '--port=555')
+        site_obj = Site.objects.get(hostname='loopdev')
+        self.assertEqual(555, site_obj.port)
+
+    def test_changing_hostname_alone(self):
+        """
+        Change the site hostname to a new one
+        """
+        management.call_command(
+            'update_site_data', 'loopdev', '--new_host=lcars'
+        )
+        site_obj = Site.objects.get(hostname='lcars')
+        self.assertEqual('lcars', site_obj.hostname)
+
+    def test_changing_all_options_at_once(self):
+        """
+        Pass all paramaters at once
+        """
+        management.call_command(
+            'update_site_data', 'loopdev', '--new_host=lcars', '--port=8912'
+        )
+        site_obj = Site.objects.get(hostname='lcars')
+        self.assertEqual('lcars', site_obj.hostname)
+        self.assertEqual(8912, site_obj.port)
+
+    def test_bad_port_given(self):
+        """
+        Test what happens when a non-numeric port is given
+        """
+        self.assertRaises(
+            ValueError, management.call_command, 'update_site_data', 'loopdev',
+            '--port=borg'
+        )


### PR DESCRIPTION
Fixes #256 

**Changes in this request**
Adds a new `update_site_data` management command that can be used to update the site hostname and port number.

***Example uses***
`./manage.py update_site_data wwwdev -nh public-site`
`./manage.py update_site_data wwwdev -p 8888`
`./manage.py update_site_data wwwdev -nh public-site -p 8888`