### PR TITLE
Alert banners should display on browse views

### DIFF
--- a/alerts/utils.py
+++ b/alerts/utils.py
@@ -30,3 +30,23 @@ def get_alert(current_site):
             msg, alert.alert_level, alert.more_info,
             alert.relative_url(current_site)
         )
+
+
+def get_browse_alerts(current_site):
+    """
+    Get all the banner alert related varibles needed to populate context
+    for regular Django views.
+
+    Args:
+        current_site: Wagtail site object.
+
+    Returns:
+        A tuple where the first value is a boolean and the second value
+        is a tuple of (False, False, False, False) or banner related
+        context variables.
+    """
+    has_alert = False if not get_alert(current_site) else True
+    alert_context_vars = (False, False, False, False)
+    if has_alert:
+        alert_context_vars = get_alert(current_site)
+    return (has_alert, alert_context_vars)

--- a/events/views.py
+++ b/events/views.py
@@ -2,7 +2,9 @@ import calendar
 import datetime
 
 from django.shortcuts import render
+from wagtail.core.models import Site
 
+from alerts.utils import get_browse_alerts
 from ask_a_librarian.utils import (
     get_chat_status, get_chat_status_css, get_unit_chat_link
 )
@@ -72,6 +74,8 @@ def events(request):
     location_and_hours = get_hours_and_location(home_page)
     location = str(location_and_hours['page_location'])
     unit = location_and_hours['page_unit']
+    current_site = Site.find_for_request(request)
+    alert_data = get_browse_alerts(current_site)
 
     next_link = next_start.strftime('%Y-%m-%d')
     previous_link = previous_start.strftime('%Y-%m-%d')
@@ -103,5 +107,10 @@ def events(request):
             'self': {
                 'title': 'Library Events'
             },
+            'has_alert': alert_data[0],
+            'alert_message': alert_data[1][0],
+            'alert_level': alert_data[1][1],
+            'alert_more_info': alert_data[1][2],
+            'alert_link': alert_data[1][3],
         }
     )

--- a/lib_collections/views.py
+++ b/lib_collections/views.py
@@ -1,25 +1,28 @@
-from django.core.management import call_command
-from django.shortcuts import render
-from lib_collections.models import CollectionPage, CollectionPageFormatPlacement, CollectionPageSubjectPlacement, CollectingAreaPage, ExhibitPage, ExhibitPageSubjectPlacement, Format
-from public.models import LocationPage
-from staff.models import StaffPage, StaffPageSubjectPlacement
-from subjects.models import Subject, SubjectParentRelations
-from wagtail.images.models import Image
-from wagtail.search.backends import get_search_backend
-from ask_a_librarian.utils import get_chat_status, get_chat_status_css, get_unit_chat_link
-from public.models import StandardPage
-from library_website.settings import PUBLIC_HOMEPAGE
-from base.utils import get_hours_and_location
-from units.models import UnitPage
-
 import datetime
 import re
-import pickle
 
-from django.core.cache import caches, cache
-from django.views.decorators.cache import cache_page
-from django.db import connection
-from django.conf import settings
+from django.core.cache import caches
+from django.core.management import call_command
+from django.shortcuts import render
+from wagtail.core.models import Site
+from wagtail.images.models import Image
+from wagtail.search.backends import get_search_backend
+
+from alerts.utils import get_browse_alerts
+from ask_a_librarian.utils import (
+    get_chat_status, get_chat_status_css, get_unit_chat_link
+)
+from base.utils import get_hours_and_location
+from lib_collections.models import (
+    CollectionPage, CollectionPageSubjectPlacement, ExhibitPage,
+    ExhibitPageSubjectPlacement, Format
+)
+from library_website.settings import PUBLIC_HOMEPAGE
+from public.models import LocationPage, StandardPage
+from staff.models import StaffPageSubjectPlacement
+from subjects.models import Subject, SubjectParentRelations
+from units.models import UnitPage
+
 
 def collections(request):
     # PARAMETERS
@@ -43,7 +46,7 @@ def collections(request):
     unit = request.GET.get('unit', None)
 
     view = request.GET.get('view', 'collections')
-    if not view in ['collections', 'exhibits', 'subjects', 'subjecttree']:
+    if view not in ['collections', 'exhibits', 'subjects', 'subjecttree']:
         view = 'collections'
 
     # filter collections.
@@ -59,23 +62,35 @@ def collections(request):
         if digital:
             filter_arguments['collection_placements__format__text'] = 'Digital'
 
-        # subject 
+        # subject
         if subject:
-            filter_arguments['collection_subject_placements__subject__in'] = Subject.objects.get(name=subject).get_descendants()
+            filter_arguments['collection_subject_placements__subject__in'
+                             ] = Subject.objects.get(name=subject
+                                                     ).get_descendants()
 
         # search
         if search:
-            filter_arguments['id__in'] = list(map(lambda s: s.id, CollectionPage.objects.live().search(search)))
+            filter_arguments['id__in'] = list(
+                map(
+                    lambda s: s.id,
+                    CollectionPage.objects.live().search(search)
+                )
+            )
 
         # unit
         if unit:
             filter_arguments['unit'] = UnitPage.objects.get(title=unit)
 
-        collections = CollectionPage.objects.live().filter(**filter_arguments).distinct().select_related('thumbnail').prefetch_related('collection_subject_placements')
+        collections = CollectionPage.objects.live(
+        ).filter(**filter_arguments).distinct().select_related(
+            'thumbnail'
+        ).prefetch_related('collection_subject_placements')
 
-        # sort browses by title, omitting leading articles. 
+        # sort browses by title, omitting leading articles.
         if not search:
-            collections = sorted(collections, key=lambda c: re.sub(r'^(A|An|The) ', '', c.title))
+            collections = sorted(
+                collections, key=lambda c: re.sub(r'^(A|An|The) ', '', c.title)
+            )
 
     # fiter exhibits.
     exhibits = []
@@ -87,7 +102,9 @@ def collections(request):
             filter_arguments['exhibit_location__title'] = location
 
         if subject:
-            filter_arguments['exhibit_subject_placements__subject__in'] = Subject.objects.get(name=subject).get_descendants()
+            filter_arguments['exhibit_subject_placements__subject__in'
+                             ] = Subject.objects.get(name=subject
+                                                     ).get_descendants()
 
         if unit:
             filter_arguments['unit'] = UnitPage.objects.get(title=unit)
@@ -95,34 +112,55 @@ def collections(request):
         if digital:
             filter_arguments['web_exhibit'] = True
 
-        exhibits = ExhibitPage.objects.live().filter(**filter_arguments).distinct().select_related('thumbnail', 'exhibit_location').prefetch_related('exhibit_subject_placements')
-        exhibits_current = exhibits.filter(exhibit_open_date__lt=datetime.datetime.now().date(), exhibit_close_date__gt=datetime.datetime.now().date()).distinct()
+        exhibits = ExhibitPage.objects.live(
+        ).filter(**filter_arguments).distinct().select_related(
+            'thumbnail', 'exhibit_location'
+        ).prefetch_related('exhibit_subject_placements')
+        exhibits_current = exhibits.filter(
+            exhibit_open_date__lt=datetime.datetime.now().date(),
+            exhibit_close_date__gt=datetime.datetime.now().date()
+        ).distinct()
 
         if search:
             exhibits = exhibits.search(search).results()
             exhibits_current = exhibits_current.search(search).results()
 
         if not search:
-            exhibits = sorted(exhibits, key=lambda e: re.sub(r'^(A|An|The) ', '', e.title))
-            exhibits_current = sorted(exhibits_current, key=lambda e: re.sub('r^(A|An|The) ', '', e.title))
+            exhibits = sorted(
+                exhibits, key=lambda e: re.sub(r'^(A|An|The) ', '', e.title)
+            )
+            exhibits_current = sorted(
+                exhibits_current,
+                key=lambda e: re.sub('r^(A|An|The) ', '', e.title)
+            )
 
     # locations
-    locations = sorted(list(set(ExhibitPage.objects.exclude(exhibit_location=None).values_list('exhibit_location__title', flat=True))))
+    locations = sorted(
+        list(
+            set(
+                ExhibitPage.objects.exclude(
+                    exhibit_location=None
+                ).values_list('exhibit_location__title', flat=True)
+            )
+        )
+    )
 
     # formats.
     formats = Format.objects.all().values_list('text', flat=True)
 
-    # the formats pulldown should skip 'Digital'. That shows up as a checkbox. 
-    formats_pulldown = ['Archives & Manuscripts', 'Audio', 'Books & Journals', \
-'Images', 'Maps', 'Microform', 'Music Scores', 'Photographs', 'Reference Works', \
-'Statistics & Datasets', 'Video']
+    # the formats pulldown should skip 'Digital'. That shows up as a checkbox.
+    formats_pulldown = [
+        'Archives & Manuscripts', 'Audio', 'Books & Journals', 'Images', 'Maps',
+        'Microform', 'Music Scores', 'Photographs', 'Reference Works',
+        'Statistics & Datasets', 'Video'
+    ]
 
     subjects = []
     if view == 'subjects':
         # for the code below, list all subjects that are children of the subjects in the list
         # above, plus anything with a libguide id. right now that is equal to
-        # business, medicine and law. See DB's "collections subjects" lucid chart for more 
-        # info. 
+        # business, medicine and law. See DB's "collections subjects" lucid chart for more
+        # info.
         subjects_queryset = Subject.objects.all().prefetch_related('see_also')
 
         if search:
@@ -133,9 +171,19 @@ def collections(request):
             subject_ids = Subject.objects.get(name=subject).get_descendants()
             subjects_queryset = subjects_queryset.filter(id__in=subject_ids)
 
-        subjects_with_collections = set(CollectionPageSubjectPlacement.objects.values_list('subject', flat=True))
-        subjects_with_exhibits = set(ExhibitPageSubjectPlacement.objects.all().values_list('subject', flat=True))
-        subjects_with_specialists = set(StaffPageSubjectPlacement.objects.values_list('subject', flat=True))
+        subjects_with_collections = set(
+            CollectionPageSubjectPlacement.objects.values_list(
+                'subject', flat=True
+            )
+        )
+        subjects_with_exhibits = set(
+            ExhibitPageSubjectPlacement.objects.all().values_list(
+                'subject', flat=True
+            )
+        )
+        subjects_with_specialists = set(
+            StaffPageSubjectPlacement.objects.values_list('subject', flat=True)
+        )
 
         qs = SubjectParentRelations.objects.all().prefetch_related('panels')
 
@@ -146,12 +194,23 @@ def collections(request):
                 subject_descendants = default_cache.get('descendants_%s' % s.id)
 
                 if not subject_descendants:
-                    subject_descendants = set(s.get_descendants().values_list('id', flat=True))
-                    default_cache.set('descendants_%s' % s.id, subject_descendants, 60*5)
+                    subject_descendants = set(
+                        s.get_descendants().values_list('id', flat=True)
+                    )
+                    default_cache.set(
+                        'descendants_%s' % s.id, subject_descendants, 60 * 5
+                    )
 
-                parents = qs.filter(child=s).order_by('parent__name').values_list('parent__name', flat=True).prefetch_related('subject')
-                has_collections = bool(subjects_with_collections.intersection(subject_descendants))
-                has_exhibits = bool(subjects_with_exhibits.intersection(subject_descendants))
+                parents = qs.filter(child=s
+                                    ).order_by('parent__name').values_list(
+                                        'parent__name', flat=True
+                                    ).prefetch_related('subject')
+                has_collections = bool(
+                    subjects_with_collections.intersection(subject_descendants)
+                )
+                has_exhibits = bool(
+                    subjects_with_exhibits.intersection(subject_descendants)
+                )
                 collecting_area_url = s.get_collecting_area_page_url(request)
                 has_collecting_area = bool(collecting_area_url)
                 has_subject_specialists = s.id in subjects_with_specialists
@@ -174,15 +233,17 @@ def collections(request):
             see_also_qs = s.see_also.all()
             if see_also_qs:
                 for see_also in see_also_qs:
-                    subjects.append({
-                        'has_collections': False,
-                        'has_exhibits': False,
-                        'has_subject_specialists': False,
-                        'libguide_url': None,
-                        'name': see_also.alias,
-                        'parents': [],
-                        'see_also': see_also.snippet.name
-                    })
+                    subjects.append(
+                        {
+                            'has_collections': False,
+                            'has_exhibits': False,
+                            'has_subject_specialists': False,
+                            'libguide_url': None,
+                            'name': see_also.alias,
+                            'parents': [],
+                            'see_also': see_also.snippet.name
+                        }
+                    )
         subjects = sorted(subjects, key=lambda s: s['name'])
 
     subjecttree = ''
@@ -193,17 +254,18 @@ def collections(request):
         subjecttree = subjecttree.replace('<body>', '')
         subjecttree = subjecttree.replace('</body>', '')
 
-    # for the subject pulldown, find subjects that are first generation children- their parents should have no parent. 
+    # for the subject pulldown, find subjects that are first generation children- their parents should have no parent.
     # still need these:
     # Area and Cultural Studies
     # Social Sciences
     # Biological Sciences
     # Physical Sciences
 
-    subjects_pulldown = ['Area & Cultural Studies', 'Arts', \
-'Biological Sciences', 'Business', 'Humanities', 'Law', 'Literature', \
-'Medicine', 'Physical Sciences', 'Social Sciences', 'Social Services', \
-'Special Collections']
+    subjects_pulldown = [
+        'Area & Cultural Studies', 'Arts', 'Biological Sciences', 'Business',
+        'Humanities', 'Law', 'Literature', 'Medicine', 'Physical Sciences',
+        'Social Sciences', 'Social Services', 'Special Collections'
+    ]
 
     default_image = None
     try:
@@ -216,38 +278,44 @@ def collections(request):
     location_and_hours = get_hours_and_location(home_page)
     page_location = str(location_and_hours['page_location'])
     page_unit = location_and_hours['page_unit']
+    current_site = Site.find_for_request(request)
+    alert_data = get_browse_alerts(current_site)
 
-#    if not default_cache.has_key('exhibits_current_list'):
-#        exhibits_current_list = set(exhibits)
-#        default_cache.set('exhibits_current_list', exhibits_current_list)
-
-    return render(request, 'lib_collections/collections_index_page.html', {
-        'collections': collections,
-        'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
-        'content_div_css': 'container body-container col-xs-12 col-lg-11 col-lg-offset-1',
-        'default_image': default_image,
-        'digital': digital,
-        'exhibits': exhibits,
-        'exhibits_current': exhibits_current,
-        'format': format,
-        'formats': formats,
-        'formats_pulldown': formats_pulldown,
-        'location': location,
-        'locations': locations,
-        'search': search,
-        'self': {
-            'title': 'Collections & Exhibits'
-        },
-        'subject': subject,
-        'subjects': subjects,
-        'subjects_pulldown': subjects_pulldown,
-        'subjecttree': subjecttree,
-        'view': view,
-        'page_unit': str(page_unit),
-        'page_location': page_location,
-        'address': location_and_hours['address'],
-        'chat_url': get_unit_chat_link(page_unit, request),
-        'chat_status': get_chat_status('uofc-ask'),
-        'chat_status_css': get_chat_status_css('uofc-ask'),
-        'hours_page_url': home_page.get_hours_page(request),
-    })
+    return render(
+        request, 'lib_collections/collections_index_page.html', {
+            'collections': collections,
+            'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
+            'content_div_css':
+            'container body-container col-xs-12 col-lg-11 col-lg-offset-1',
+            'default_image': default_image,
+            'digital': digital,
+            'exhibits': exhibits,
+            'exhibits_current': exhibits_current,
+            'format': format,
+            'formats': formats,
+            'formats_pulldown': formats_pulldown,
+            'location': location,
+            'locations': locations,
+            'search': search,
+            'self': {
+                'title': 'Collections & Exhibits'
+            },
+            'subject': subject,
+            'subjects': subjects,
+            'subjects_pulldown': subjects_pulldown,
+            'subjecttree': subjecttree,
+            'view': view,
+            'page_unit': str(page_unit),
+            'page_location': page_location,
+            'address': location_and_hours['address'],
+            'chat_url': get_unit_chat_link(page_unit, request),
+            'chat_status': get_chat_status('uofc-ask'),
+            'chat_status_css': get_chat_status_css('uofc-ask'),
+            'hours_page_url': home_page.get_hours_page(request),
+            'has_alert': alert_data[0],
+            'alert_message': alert_data[1][0],
+            'alert_level': alert_data[1][1],
+            'alert_more_info': alert_data[1][2],
+            'alert_link': alert_data[1][3],
+        }
+    )

--- a/public/views.py
+++ b/public/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from wagtail.core.models import Site
 from wagtail.images.models import Image
 
+from alerts.utils import get_browse_alerts
 from ask_a_librarian.utils import (
     get_chat_status, get_chat_status_css, get_unit_chat_link
 )
@@ -115,7 +116,10 @@ def spaces(request):
     if building:
         # Changed spaces to all_spaces in id_list to bypass filtering in spaces.
         # get all locations that are descendants of this building.
-        id_list = all_spaces.filter(parent_building__title=building).values_list('pk', flat=True)
+        id_list = all_spaces.filter(parent_building__title=building
+                                    ).values_list(
+                                        'pk', flat=True
+                                    )
         # get a unique, sorted list of the available floors here.
         floors = sorted(
             list(
@@ -153,71 +157,52 @@ def spaces(request):
     location_and_hours = get_hours_and_location(home_page)
     location = str(location_and_hours['page_location'])
     unit = location_and_hours['page_unit']
+    current_site = Site.find_for_request(request)
+    alert_data = get_browse_alerts(current_site)
+    unfriendly_a = True if friendly_name.strip(
+    ) in UNFRIENDLY_ARTICLES else False
 
     # Find banner for given home_page and add to context
-    current_site = Site.find_for_request(request)
     section_info = home_page.get_banner(current_site)
     return render(
         request, 'public/spaces_index_page.html', {
-            'building':
-            building,
-            'buildings':
-            buildings,
-            'breadcrumb_div_css':
-            'col-md-12 breadcrumbs hidden-xs hidden-sm',
+            'building': building,
+            'buildings': buildings,
+            'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
             'content_div_css':
             'container body-container col-xs-12 col-lg-11 col-lg-offset-1',
-            'default_image':
-            default_image,
-            'feature':
-            feature,
-            'feature_label':
-            feature_label,
-            'features':
-            features,
-            'floor':
-            floor,
-            'floors':
-            floors,
+            'default_image': default_image,
+            'feature': feature,
+            'feature_label': feature_label,
+            'features': features,
+            'floor': floor,
+            'floors': floors,
             'self': {
                 'title': 'Library Spaces',
                 'friendly_name': friendly_name
             },
-            'spaces':
-            spaces,
-            'space_type':
-            space_type,
-            'page_unit':
-            str(unit),
-            'page_location':
-            location,
-            'address':
-            location_and_hours['address'],
-            'chat_url':
-            get_unit_chat_link(unit, request),
-            'chat_status':
-            get_chat_status('uofc-ask'),
-            'chat_status_css':
-            get_chat_status_css('uofc-ask'),
-            'hours_page_url':
-            home_page.get_hours_page(request),
-            'unfriendly_a':
-            True if friendly_name.strip() in UNFRIENDLY_ARTICLES else False,
-            'libcalid':
-            llid,
-            'has_banner':
-            section_info[0],
-            'banner':
-            section_info[1],
-            'banner_feature':
-            section_info[2],
-            'banner_title':
-            section_info[3],
-            'banner_subtitle':
-            section_info[4],
-            'banner_url':
-            section_info[5],
-            'branch_lib_css':
-            home_page.get_branch_lib_css_class(),
+            'spaces': spaces,
+            'space_type': space_type,
+            'page_unit': str(unit),
+            'page_location': location,
+            'address': location_and_hours['address'],
+            'chat_url': get_unit_chat_link(unit, request),
+            'chat_status': get_chat_status('uofc-ask'),
+            'chat_status_css': get_chat_status_css('uofc-ask'),
+            'hours_page_url': home_page.get_hours_page(request),
+            'unfriendly_a': unfriendly_a,
+            'libcalid': llid,
+            'has_banner': section_info[0],
+            'banner': section_info[1],
+            'banner_feature': section_info[2],
+            'banner_title': section_info[3],
+            'banner_subtitle': section_info[4],
+            'banner_url': section_info[5],
+            'branch_lib_css': home_page.get_branch_lib_css_class(),
+            'has_alert': alert_data[0],
+            'alert_message': alert_data[1][0],
+            'alert_level': alert_data[1][1],
+            'alert_more_info': alert_data[1][2],
+            'alert_link': alert_data[1][3],
         }
     )

--- a/units/views.py
+++ b/units/views.py
@@ -1,29 +1,29 @@
-from .models import Tree
-from .forms import UnitReportingForm
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.db.models import Q
-from django.db.models.expressions import RawSQL
+import re
+
 from django.http import HttpResponse
 from django.shortcuts import render
 from openpyxl.writer.excel import save_virtual_workbook
+from wagtail.core.models import Site
+from wagtail.images.models import Image
+
+from alerts.utils import get_browse_alerts
+from ask_a_librarian.utils import (
+    get_chat_status, get_chat_status_css, get_unit_chat_link
+)
+from base.utils import get_hours_and_location
+from library_website.settings import PUBLIC_HOMEPAGE
+from public.models import LocationPage, StandardPage
 from staff.models import StaffPage, StaffPageSubjectPlacement
 from subjects.models import Subject
 from units.models import UnitIndexPage, UnitPage
-from units.utils import get_quick_nums_for_library_or_dept
-from units.utils import WagtailUnitsReport
-from wagtail.images.models import Image
-from public.models import StandardPage, LocationPage
-from library_website.settings import PUBLIC_HOMEPAGE, QUICK_NUMS, REGENSTEIN_HOMEPAGE, SSA_HOMEPAGE, MANSUETO_HOMEPAGE, CRERAR_HOMEPAGE, ECKHART_HOMEPAGE, DANGELO_HOMEPAGE, SCRC_HOMEPAGE
-from base.utils import get_hours_and_location
-from ask_a_librarian.utils import get_chat_status, get_chat_status_css, get_unit_chat_link
-from django.utils.text import slugify
+from units.utils import WagtailUnitsReport, get_quick_nums_for_library_or_dept
 
-import os
-import re
-import subprocess
-import urllib.parse
+from .forms import UnitReportingForm
 
-def get_staff_pages_for_unit(unit_page_full_name = None, recursive = False, display_supervisor_first = False):
+
+def get_staff_pages_for_unit(
+    unit_page_full_name=None, recursive=False, display_supervisor_first=False
+):
     unit_page_ids = None
     unit_page = None
     if unit_page_full_name:
@@ -31,22 +31,32 @@ def get_staff_pages_for_unit(unit_page_full_name = None, recursive = False, disp
             if u.get_full_name() == unit_page_full_name:
                 unit_page = u
                 if recursive:
-                    unit_page_ids = list(u.get_descendants(True).values_list('id', flat=True))
+                    unit_page_ids = list(
+                        u.get_descendants(True).values_list('id', flat=True)
+                    )
                 else:
                     unit_page_ids = [u.id]
                 break
 
     if unit_page_ids == None:
         recursive = True
-        unit_page_ids = list(UnitIndexPage.objects.first().get_descendants(True).values_list('id', flat=True))
- 
-    staff_pages = StaffPage.objects.live().filter(staff_page_units__library_unit__id__in=unit_page_ids).distinct().order_by('last_name', 'first_name')
-    
+        unit_page_ids = list(
+            UnitIndexPage.objects.first().get_descendants(True).values_list(
+                'id', flat=True
+            )
+        )
+
+    staff_pages = StaffPage.objects.live().filter(
+        staff_page_units__library_unit__id__in=unit_page_ids
+    ).distinct().order_by('last_name', 'first_name')
+
     if display_supervisor_first:
         if unit_page and unit_page.department_head and unit_page.department_head.live:
-            staff_pages = [unit_page.department_head] + list(staff_pages.exclude(id=unit_page.department_head.id))
-        
+            staff_pages = [unit_page.department_head] + \
+                list(staff_pages.exclude(id=unit_page.department_head.id))
+
     return staff_pages
+
 
 def get_libraries():
     return sorted(
@@ -54,9 +64,10 @@ def get_libraries():
         key=lambda p: re.sub(r'^The ', '', p)
     )
 
+
 def units(request):
     divisions = []
-    
+
     department = request.GET.get('department', None)
     library = request.GET.get('library', None)
     page = request.GET.get('page', 1)
@@ -74,8 +85,10 @@ def units(request):
     departments = []
 
     if query:
-      staff_pages = StaffPage.objects.live().search(query)
-      departments = UnitPage.objects.filter(display_in_library_directory=True, live=True).search(query)
+        staff_pages = StaffPage.objects.live().search(query)
+        departments = UnitPage.objects.filter(
+            display_in_library_directory=True, live=True
+        ).search(query)
 
     elif view == 'staff':
         if library == None:
@@ -90,23 +103,42 @@ def units(request):
         # subjects.
         if subject:
             if subject == 'All Subject Specialists':
-                staff_pages = staff_pages.filter(id__in=StaffPageSubjectPlacement.objects.all().values_list('page', flat=True).distinct())
+                staff_pages = staff_pages.filter(
+                    id__in=StaffPageSubjectPlacement.objects.all().
+                    values_list('page', flat=True).distinct()
+                )
             else:
-                # get a subject and all it's descendants. 
-                subject_and_descendants = Subject.objects.get(name=subject).get_descendants()
-                # from staff page subject placements, get all of the staff that match those subjects. 
-                subject_staff_ids = StaffPageSubjectPlacement.objects.filter(subject__in=subject_and_descendants).values_list('page', flat=True)
-                # filter staff_pages to only include those staff pages. 
-                staff_pages = staff_pages.filter(id__in=subject_staff_ids).order_by('last_name')
+                # get a subject and all it's descendants.
+                subject_and_descendants = Subject.objects.get(
+                    name=subject
+                ).get_descendants()
+                # from staff page subject placements, get all of the staff that match those subjects.
+                subject_staff_ids = StaffPageSubjectPlacement.objects.filter(
+                    subject__in=subject_and_descendants
+                ).values_list(
+                    'page', flat=True
+                )
+                # filter staff_pages to only include those staff pages.
+                staff_pages = staff_pages.filter(id__in=subject_staff_ids
+                                                 ).order_by('last_name')
 
     elif view == 'department':
-      divisions = []
-      for division in UnitIndexPage.objects.first().get_children().specific().type(UnitPage).filter(live=True, unitpage__display_in_library_directory=True).order_by('title'):
-        divisions.append({
-          'unit': division,
-          'descendants': division.get_descendants().specific().type(UnitPage).filter(live=True, unitpage__display_in_library_directory=True).order_by('title')
-        })
-    
+        divisions = []
+        for division in UnitIndexPage.objects.first().get_children().specific(
+        ).type(UnitPage).filter(
+            live=True, unitpage__display_in_library_directory=True
+        ).order_by('title'):
+            divisions.append(
+                {
+                    'unit':
+                    division,
+                    'descendants':
+                    division.get_descendants().specific().type(UnitPage).filter(
+                        live=True, unitpage__display_in_library_directory=True
+                    ).order_by('title')
+                }
+            )
+
     default_image = Image.objects.get(title="Default Placeholder Photo")
 
     try:
@@ -119,46 +151,63 @@ def units(request):
     location_and_hours = get_hours_and_location(home_page)
     location = str(location_and_hours['page_location'])
     unit = location_and_hours['page_unit']
+    current_site = Site.find_for_request(request)
+    alert_data = get_browse_alerts(current_site)
 
     title = ''
     if query:
-      title = 'Search Results'
+        title = 'Search Results'
     elif view == 'staff':
-      title = 'Library Directory: Staff'
-    elif view == 'department': 
-      title = 'Library Directory: Departments'
+        title = 'Library Directory: Staff'
+    elif view == 'department':
+        title = 'Library Directory: Departments'
     elif view == 'org':
-      title = 'Library Directory: Org Chart'
+        title = 'Library Directory: Org Chart'
 
-    quick_nums = get_quick_nums_for_library_or_dept(request).replace('<td>', '<li>').replace('</td>', '</li>')
+    quick_nums = get_quick_nums_for_library_or_dept(request).replace(
+        '<td>', '<li>'
+    ).replace('</td>', '</li>')
 
-    return render(request, 'units/unit_index_page.html', {
-        'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
-        'content_div_css': 'container body-container directory col-xs-12 col-lg-11 col-lg-offset-1',
-        'department': department,
-        'departments': departments,
-        'default_image': default_image,
-        'divisions': divisions,
-        'libraries': get_libraries(),
-        'library': library,
-        'org_chart_image': org_chart_image,
-        'query': query,
-        'staff_pages': staff_pages,
-        'subjects': Subject.objects.filter(display_in_dropdown=True).values_list('name', flat=True),
-        'subject': subject,
-        'view': view,
-        'self': {
-            'title': title
-        },
-        'page_unit': str(unit),
-        'page_location': location,
-        'address': location_and_hours['address'],
-        'chat_url': get_unit_chat_link(unit, request),
-        'chat_status': get_chat_status('uofc-ask'),
-        'chat_status_css': get_chat_status_css('uofc-ask'),
-        'hours_page_url': home_page.get_hours_page(request),
-        'quick_nums': quick_nums
-    })
+    subjects = Subject.objects.filter(display_in_dropdown=True).values_list(
+        'name', flat=True
+    ),
+
+    return render(
+        request, 'units/unit_index_page.html', {
+            'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
+            'content_div_css':
+            'container body-container directory col-xs-12 col-lg-11 col-lg-offset-1',
+            'department': department,
+            'departments': departments,
+            'default_image': default_image,
+            'divisions': divisions,
+            'libraries': get_libraries(),
+            'library': library,
+            'org_chart_image': org_chart_image,
+            'query': query,
+            'staff_pages': staff_pages,
+            'subjects': subjects,
+            'subject': subject,
+            'view': view,
+            'self': {
+                'title': title
+            },
+            'page_unit': str(unit),
+            'page_location': location,
+            'address': location_and_hours['address'],
+            'chat_url': get_unit_chat_link(unit, request),
+            'chat_status': get_chat_status('uofc-ask'),
+            'chat_status_css': get_chat_status_css('uofc-ask'),
+            'hours_page_url': home_page.get_hours_page(request),
+            'quick_nums': quick_nums,
+            'has_alert': alert_data[0],
+            'alert_message': alert_data[1][0],
+            'alert_level': alert_data[1][1],
+            'alert_more_info': alert_data[1][2],
+            'alert_link': alert_data[1][3],
+        }
+    )
+
 
 def unit_reporting_admin_view(request):
     """
@@ -167,28 +216,35 @@ def unit_reporting_admin_view(request):
     if request.method == 'POST':
         form = UnitReportingForm(request.POST)
         options = {
-            'display_in_campus_directory': form.data.get('display_in_campus_directory', False),
-            'email_to': form.data.get('email_to', None),
-            'filename': form.data.get('filename', 'unit_report'),
-            'live': form.data.get('live', None),
-            'latest_revision_created_at': form.data.get('latest_revision_created_at', None),
+            'display_in_campus_directory':
+            form.data.get('display_in_campus_directory', False),
+            'email_to':
+            form.data.get('email_to', None),
+            'filename':
+            form.data.get('filename', 'unit_report'),
+            'live':
+            form.data.get('live', None),
+            'latest_revision_created_at':
+            form.data.get('latest_revision_created_at', None),
         }
-        options['all'] = not(bool(options['live']))
+        options['all'] = not (bool(options['live']))
         if form.is_valid():
             unit_report = WagtailUnitsReport(
-                sync_report = False,
-                unit_report = True,
-                **options
+                sync_report=False, unit_report=True, **options
             )
             virtual_workbook = save_virtual_workbook(unit_report.workbook())
-            response = HttpResponse(virtual_workbook, content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-            response['content-disposition'] = 'attachment; filename="' + options['filename'] + '.xlsx"'
+            response = HttpResponse(
+                virtual_workbook,
+                content_type=
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            )
+            response['content-disposition'] = 'attachment; filename="' + \
+                options['filename'] + '.xlsx"'
             return response
         else:
-            return render(request, 'units/unit_reporting_form.html', {'form': form})
+            return render(
+                request, 'units/unit_reporting_form.html', {'form': form}
+            )
     else:
         form = UnitReportingForm({'live': True, 'filename': 'unit_report'})
-    return render(request, 'units/unit_reporting_form.html', {
-        'form': form
-    })
-
+    return render(request, 'units/unit_reporting_form.html', {'form': form})


### PR DESCRIPTION
Added context variables to browse views for the display of alert banners, ran view code through linter and removed unused import statements.

Fixes issue #271

Adds banner alerts to the following views.
- https://www.lib.uchicago.edu/about/directory/?view=staff
- https://www.lib.uchicago.edu/collex/
- https://www.lib.uchicago.edu/about/news-events/events/
- https://www.lib.uchicago.edu/spaces/
