### PR TITLE
Reverted changes that prevented needed page types under StandardPages

### DIFF
--- a/public/models.py
+++ b/public/models.py
@@ -112,10 +112,12 @@ class StandardPage(PublicBasePage, SocialMediaFields):
 
     subpage_types = [
         'alerts.AlertIndexPage', 'public.StandardPage', 'public.LocationPage',
-        'public.DonorPage', 'lib_news.LibNewsIndexPage',
-        'redirects.RedirectPage', 'ask_a_librarian.AskPage',
-        'conferences.ConferenceIndexPage', 'dirbrowse.DirBrowsePage',
-        'findingaids.FindingAidsPage', 'public.PublicRawHTMLPage'
+        'public.DonorPage', 'lib_collections.CollectingAreaPage',
+        'lib_collections.CollectionPage', 'lib_collections.ExhibitPage',
+        'lib_news.LibNewsIndexPage', 'redirects.RedirectPage', 'units.UnitPage',
+        'ask_a_librarian.AskPage', 'units.UnitIndexPage',
+        'conferences.ConferenceIndexPage', 'base.IntranetPlainPage',
+        'dirbrowse.DirBrowsePage', 'public.StaffPublicPage',
     ]
 
     content_panels = Page.content_panels + [


### PR DESCRIPTION
Fixes issue #273.

**Changes in this request**
Reverted the [changes introduced in a previous commit](https://github.com/uchicago-library/library_website/commit/c9dc6f6c4ed5331d40990f2f52007c60f914e483?diff=unified) that disabled select page types from being created under StandardPages. Only reverted changes in `public/models.py`.