### PR TITLE
Limited minute types to wagtail page and changed table styling

### DIFF
--- a/base/templates/base/minutes_and_reports_inner_table.html
+++ b/base/templates/base/minutes_and_reports_inner_table.html
@@ -1,10 +1,10 @@
-              {% for date, items in table.items %}
-                <tr>
-                  <td>{{date}}</td>
-                  <td>
+              <dl>
+                {% for date, items in table.items %}
+                  <dt>{{date}}</dt>
+                  <dd>
                   {% for item in items %}
-                    <a href="{{item.url}}">{{item.summary}}</a><br/>
+                    <a href="{{item.url}}">{{item.summary}}</a>
                   {% endfor %}
-                  </td>
-                </tr>
-              {% endfor %}
+                  </dd>
+                {% endfor %}
+              </dl>

--- a/base/templates/base/minutes_and_reports_inner_table.html
+++ b/base/templates/base/minutes_and_reports_inner_table.html
@@ -1,10 +1,10 @@
               <dl>
                 {% for date, items in table.items %}
                   <dt>{{date}}</dt>
-                  <dd>
                   {% for item in items %}
-                    <a href="{{item.url}}">{{item.summary}}</a>
+                    <dd>
+                      <a href="{{item.url}}">{{item.summary}}</a>
+                    </dd>
                   {% endfor %}
-                  </dd>
                 {% endfor %}
               </dl>

--- a/group/models.py
+++ b/group/models.py
@@ -8,7 +8,7 @@ from django.db.models.fields import CharField
 from django.utils import timezone
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
-    FieldPanel, InlinePanel, MultiFieldPanel, StreamFieldPanel
+    FieldPanel, InlinePanel, MultiFieldPanel, PageChooserPanel, StreamFieldPanel
 )
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable, Page
@@ -142,10 +142,18 @@ class MeetingMinutes(AbstractReport):
     """
     Meeting minutes content type.
     """
-    panels = AbstractReport.panels
+    date = models.DateField(blank=False)
+    summary = models.TextField(null=False, blank=False)
+
+    panels = [
+        FieldPanel('date'),
+        FieldPanel('summary'),
+        PageChooserPanel('link_page'),
+    ]
 
     class Meta:
         abstract = True
+        ordering = ['-date']
 
 
 class GroupMeetingMinutesPageTable(Orderable, MeetingMinutes):

--- a/group/models.py
+++ b/group/models.py
@@ -142,8 +142,13 @@ class MeetingMinutes(AbstractReport):
     """
     Meeting minutes content type.
     """
-    date = models.DateField(blank=False)
-    summary = models.TextField(null=False, blank=False)
+    link_page = models.ForeignKey(
+        "wagtailcore.Page",
+        null=True,
+        blank=False,
+        on_delete=models.SET_NULL,
+        related_name="+",
+    )
 
     panels = [
         FieldPanel('date'),
@@ -153,7 +158,6 @@ class MeetingMinutes(AbstractReport):
 
     class Meta:
         abstract = True
-        ordering = ['-date']
 
 
 class GroupMeetingMinutesPageTable(Orderable, MeetingMinutes):


### PR DESCRIPTION
Closes #255 

**Changes in this request**
- Limited meeting minutes to only allow Wagtail pages
- Changed the minutes display table to a dictionary list

**Questions**
- Unsure if I should remove the else statements in the [meeting minutes model](https://github.com/uchicago-library/library_website/blob/master/group/models.py#L283) for determining between link and document files.
- Would love to switch the item link to be the date rather than the summary in the ["inner table"](https://github.com/uchicago-library/library_website/blob/master/base/templates/base/minutes_and_reports_inner_table.html#L6) but am not able to figure that one out.
- Also unsure why there is the `for item in items` line in this inner table since there is only one summary allowed per meeting minute item.
