### PR TITLE
Subject dropdown display problem

### DIFF
--- a/units/tests.py
+++ b/units/tests.py
@@ -1,19 +1,43 @@
-from diablo_tests import assert_assertion_error
-from django.conf import settings
-from django.core import management
-from django.test import TestCase, Client, override_settings
-from io import StringIO
-from unittest.mock import patch
-from wagtail.core.models import Page, Site
-
-from .models import UnitPage
-from .utils import get_quick_num_or_link, get_quick_num_html, get_all_quick_nums_html, get_quick_nums_for_library_or_dept
-from library_website.settings import PUBLIC_HOMEPAGE, QUICK_NUMS
-from openpyxl import load_workbook
-from staff.models import StaffPage
+import os
 from tempfile import NamedTemporaryFile
 
-import os
+from diablo_tests import assert_assertion_error
+from django.core import management
+from django.db.models.query import QuerySet
+from django.test import Client, TestCase
+from openpyxl import load_workbook
+from wagtail.core.models import Page, Site
+
+from library_website.settings import PUBLIC_HOMEPAGE, QUICK_NUMS
+from staff.models import StaffPage
+
+from .models import UnitPage
+from .utils import (
+    get_all_quick_nums_html, get_quick_num_html, get_quick_num_or_link,
+    get_quick_nums_for_library_or_dept
+)
+
+
+class TestLibraryDirectory(TestCase):
+    """
+    Tests for the staff browse.
+    """
+
+    fixtures = ['test.json']
+
+    def test_subject_browse_dropdown(self):
+        """
+        Assert that the subjects context variable is always a
+        QuerySet. A session must be saved in order to access
+        context from the response.
+        """
+        client = Client()
+        session = client.session
+        session.save()
+        response = client.get('/about/directory/?view=staff')
+        qs = response.context['subjects']
+        is_qs = isinstance(qs, QuerySet)
+        self.assertEqual(is_qs, True)
 
 
 class TestQuickNumberUtils(TestCase):
@@ -28,13 +52,32 @@ class TestQuickNumberUtils(TestCase):
         """
         Reusable stuff.
         """
-        self.quick_num = {'label': 'Foobar', 'number': '773-702-8740', 'link': None}
-        self.quick_link = {'label': 'Foobar', 'number': '', 'link': PUBLIC_HOMEPAGE}
-        self.dlist = [{'label': 'Captain Janeway',   'number': '00100', 'link': None},
-                     {'label': 'B\'Elanna Torres',  'number': '11000', 'link': None},
-                     {'label': 'Seven of Nine',     'number': '01001', 'link': None}]
+        self.quick_num = {
+            'label': 'Foobar',
+            'number': '773-702-8740',
+            'link': None
+        }
+        self.quick_link = {
+            'label': 'Foobar',
+            'number': '',
+            'link': PUBLIC_HOMEPAGE
+        }
+        self.dlist = [
+            {
+                'label': 'Captain Janeway',
+                'number': '00100',
+                'link': None
+            }, {
+                'label': 'B\'Elanna Torres',
+                'number': '11000',
+                'link': None
+            }, {
+                'label': 'Seven of Nine',
+                'number': '01001',
+                'link': None
+            }
+        ]
         self.dlist_expected = '<td><strong>Captain Janeway</strong> 00100</td><td><strong>B\'Elanna Torres</strong> 11000</td><td><strong>Seven of Nine</strong> 01001</td>'
-
 
     def test_get_quick_num_or_link(self):
         """
@@ -64,10 +107,11 @@ class TestQuickNumberUtils(TestCase):
         self.assertTrue(assert_assertion_error(get_quick_num_or_link, d))
 
         # Test return values
-        self.assertEqual(get_quick_num_or_link(e), (0, 'Foobar', '773-702-8740'))
+        self.assertEqual(
+            get_quick_num_or_link(e), (0, 'Foobar', '773-702-8740')
+        )
         self.assertEqual(get_quick_num_or_link(f), (1, 'Foobar', '/'))
         self.assertRaises(ValueError, get_quick_num_or_link, g)
-
 
     def test_get_quick_num_html(self):
         """
@@ -78,17 +122,20 @@ class TestQuickNumberUtils(TestCase):
         expected_link = '<td><strong><a href="/">Foobar</a></strong></td>'
 
         # Returned HTML
-        quick_num_html = get_quick_num_html(get_quick_num_or_link(self.quick_num))
-        quick_link_html = get_quick_num_html(get_quick_num_or_link(self.quick_link))
+        quick_num_html = get_quick_num_html(
+            get_quick_num_or_link(self.quick_num)
+        )
+        quick_link_html = get_quick_num_html(
+            get_quick_num_or_link(self.quick_link)
+        )
 
         # Test HTML
         self.assertHTMLEqual(quick_num_html, expected_num)
         self.assertHTMLEqual(quick_link_html, expected_link)
 
-
     def test_quick_num_base_config(self):
         """
-        Run the current configuration for quicknumbers found 
+        Run the current configuration for quicknumbers found
         in the base config. This tests the QUICK_NUMS constant.
         No exceptions should be raised.
         """
@@ -96,8 +143,6 @@ class TestQuickNumberUtils(TestCase):
             for number in QUICK_NUMS[library]:
                 get_quick_num_or_link(number)
 
-
-    
     def test_get_quick_nums_for_library_or_dept_output(self):
         """
         Test the output of get_quick_nums_for_library_or_dept.
@@ -106,50 +151,92 @@ class TestQuickNumberUtils(TestCase):
         site = Site.objects.filter(is_default_site=True)[0]
 
         # Override for the QUICK_NUMS constant to use in testing
-        with self.settings(QUICK_NUMS = {
+        with self.settings(
+            QUICK_NUMS={
                 'voyager':
-                    self.dlist,
-                'enterprise':
-                    [{'label': 'Captain Picard',    'number': '11100', 'link': None},
-                     {'label': 'Worf Rozhenko',     'number': '00001', 'link': None},
-                     {'label': 'Data',              'number': '10111', 'link': None}],
-                'defiant':
-                    [{'label': 'Benjamin Sisko',    'number': '101001', 'link': None},
-                     {'label': 'Quark',             'number': '',       'link': site.root_page.id}],
-                'the-university-of-chicago-library':
-                    [{'label': 'Captain Long',   'number': '00100', 'link': None},
-                     {'label': 'Lieutenant Commander Blair',  'number': '11000', 'link': None}],
-            }):
+                self.dlist,
+                'enterprise': [
+                    {
+                        'label': 'Captain Picard',
+                        'number': '11100',
+                        'link': None
+                    },
+                    {
+                        'label': 'Worf Rozhenko',
+                        'number': '00001',
+                        'link': None
+                    }, {
+                        'label': 'Data',
+                        'number': '10111',
+                        'link': None
+                    }
+                ],
+                'defiant': [
+                    {
+                        'label': 'Benjamin Sisko',
+                        'number': '101001',
+                        'link': None
+                    },
+                    {
+                        'label': 'Quark',
+                        'number': '',
+                        'link': site.root_page.id
+                    }
+                ],
+                'the-university-of-chicago-library': [
+                    {
+                        'label': 'Captain Long',
+                        'number': '00100',
+                        'link': None
+                    },
+                    {
+                        'label': 'Lieutenant Commander Blair',
+                        'number': '11000',
+                        'link': None
+                    }
+                ],
+            }
+        ):
 
             # Normal quick numbers
             expected = '<td><strong>Captain Picard</strong> 11100</td><td><strong>Worf Rozhenko</strong> 00001</td><td><strong>Data</strong> 10111</td>'
-            response = client.get('/about/directory/?view=staff&department=Enterprise', HTTP_HOST=site.hostname)
+            response = client.get(
+                '/about/directory/?view=staff&department=Enterprise',
+                HTTP_HOST=site.hostname
+            )
             request = response.wsgi_request
             html = get_quick_nums_for_library_or_dept(request)
             self.assertHTMLEqual(html, expected)
 
             # Link instead of number
             expected = '<td><strong>Benjamin Sisko</strong> 101001</td><td><strong><a href="/">Quark</a></strong></td>'
-            response = client.get('/about/directory/?view=staff&department=Defiant', HTTP_HOST=site.hostname)
+            response = client.get(
+                '/about/directory/?view=staff&department=Defiant',
+                HTTP_HOST=site.hostname
+            )
             request = response.wsgi_request
             html = get_quick_nums_for_library_or_dept(request)
             self.assertHTMLEqual(html, expected)
 
             # Test library parameter
             expected = self.dlist_expected
-            response = client.get('/about/directory/?view=staff&library=Voyager', HTTP_HOST=site.hostname)
+            response = client.get(
+                '/about/directory/?view=staff&library=Voyager',
+                HTTP_HOST=site.hostname
+            )
             request = response.wsgi_request
             html = get_quick_nums_for_library_or_dept(request)
             self.assertHTMLEqual(html, expected)
 
             # Bad parameter not in dictionary should return the default values for library
             expected = '<td><strong>Captain Long</strong> 00100</td><td><strong>Lieutenant Commander Blair</strong> 11000</td>'
-            response = client.get('/about/directory/?view=staff&department=Borg Cube', HTTP_HOST=site.hostname)
+            response = client.get(
+                '/about/directory/?view=staff&department=Borg Cube',
+                HTTP_HOST=site.hostname
+            )
             request = response.wsgi_request
             html = get_quick_nums_for_library_or_dept(request)
             self.assertHTMLEqual(html, expected)
-
-
 
     def test_get_quick_nums_for_library_or_dept_with_bad_config(self):
         """
@@ -157,35 +244,56 @@ class TestQuickNumberUtils(TestCase):
         """
         client = Client()
         site = Site.objects.filter(is_default_site=True)[0]
-        response = client.get('/about/directory/?view=staff&department=Voyager', HTTP_HOST=site.hostname) # Must stay outside of the context manager
+        # Must stay outside of the context manager
+        response = client.get(
+            '/about/directory/?view=staff&department=Voyager',
+            HTTP_HOST=site.hostname
+        )
 
-        with self.settings(QUICK_NUMS = {
+        with self.settings(
+            QUICK_NUMS={
                 'voyager':
-                    self.dlist,
-                'enterprise':
-                    [{'label': 'Captain Picard',    'number': '11100', 'link': None},
-                     {'label': 'Worf Rozhenko',     'number': '00001', 'link': None},
-                     {'label': 'Data',              'number': '10111', 'link': None}],
-            }):
+                self.dlist,
+                'enterprise': [
+                    {
+                        'label': 'Captain Picard',
+                        'number': '11100',
+                        'link': None
+                    },
+                    {
+                        'label': 'Worf Rozhenko',
+                        'number': '00001',
+                        'link': None
+                    }, {
+                        'label': 'Data',
+                        'number': '10111',
+                        'link': None
+                    }
+                ],
+            }
+        ):
 
             request = response.wsgi_request
-            self.assertTrue(assert_assertion_error(get_quick_nums_for_library_or_dept, request))
-
+            self.assertTrue(
+                assert_assertion_error(
+                    get_quick_nums_for_library_or_dept, request
+                )
+            )
 
     def test_get_all_quick_nums_html_output(self):
         """
         Test for expected html.
         """
-        self.assertHTMLEqual(get_all_quick_nums_html(self.dlist), self.dlist_expected)
+        self.assertHTMLEqual(
+            get_all_quick_nums_html(self.dlist), self.dlist_expected
+        )
 
 
 class ListUnitsWagtail(TestCase):
+
     def run_command(self, **options):
         tempfile = NamedTemporaryFile(delete=False, suffix='.xlsx')
-        options.update({
-            'filename': tempfile.name,
-            'output_format': 'excel'
-        })
+        options.update({'filename': tempfile.name, 'output_format': 'excel'})
         management.call_command('list_units_wagtail', **options)
 
         wb = load_workbook(tempfile.name)
@@ -199,21 +307,15 @@ class ListUnitsWagtail(TestCase):
             welcome = Page.objects.get(path='00010001')
         except:
             root = Page.objects.create(
-                depth=1,
-                path='0001',
-                slug='root',
-                title='Root')
+                depth=1, path='0001', slug='root', title='Root'
+            )
 
-            welcome = Page(
-                path='00010001',
-                slug='welcome',
-                title='Welcome')
+            welcome = Page(path='00010001', slug='welcome', title='Welcome')
             root.add_child(instance=welcome)
 
         staff_person = StaffPage(
-            cnetid='staff-person',
-            slug='staff-person',
-            title='Staff Person')
+            cnetid='staff-person', slug='staff-person', title='Staff Person'
+        )
         welcome.add_child(instance=staff_person)
 
         some_unit = UnitPage(
@@ -221,7 +323,8 @@ class ListUnitsWagtail(TestCase):
             department_head=staff_person,
             page_maintainer=staff_person,
             slug='some-unit',
-            title='Some Unit')
+            title='Some Unit'
+        )
         welcome.add_child(instance=some_unit)
 
     def test_report_column_count(self):
@@ -231,5 +334,3 @@ class ListUnitsWagtail(TestCase):
     def test_report_record_count(self):
         records = self.run_command(all='True')
         self.assertEqual(len(records), 1)
-
-       

--- a/units/views.py
+++ b/units/views.py
@@ -186,7 +186,7 @@ def units(request):
             'org_chart_image': org_chart_image,
             'query': query,
             'staff_pages': staff_pages,
-            'subjects': subjects,
+            'subjects': subjects[0],
             'subject': subject,
             'view': view,
             'self': {


### PR DESCRIPTION
Fixes #293

**Changes in this request**
- Fixed the incorrect display of the subject list that was incorrectly passing a `QuerySet` inside a `tuple` to the templates instead of passing the `QuerySet` directly.
-  Wrote a unit test so this doesn't happen again.
- Linted and autofixed the `units/tests.py` file