### PR TITLE
Changed default link colors and text-decoration

### DIFF
--- a/base/static/base/css/_variables.scss
+++ b/base/static/base/css/_variables.scss
@@ -46,6 +46,8 @@ $accent-font: 'Cormorant Garamond', serif;
  * --------------------------------------------------
  */
 
+$default-link: #2A5DB0;
+
 // Unv Color Palette
 
 $darkgray: #767676;
@@ -112,6 +114,7 @@ $divider: 1px solid $darkgray;
   border-radius: 0;
   padding: 6px 12px;
   margin-bottom: 10px;
+  text-decoration: none;
   &:after {
     content: "\0020\f101";
     font-family: FontAwesome;

--- a/base/static/base/css/global.scss
+++ b/base/static/base/css/global.scss
@@ -31,6 +31,7 @@ html, body {  /* The html and body elements cannot have any padding or margin. *
 }
 
 body {
+  color: #000000;
   margin-bottom: 0;
   font-family: 'ProximaNova-Regular', "Arial", sans-serif;
 }
@@ -52,10 +53,13 @@ html, body {
 
 /* Links */
 a {
-  text-decoration: none;
+  color: $default-link;
   outline: 0;
+  text-decoration: underline;
     &:hover, &:focus {
-      color: #5B8FA8;
+      color: #487286;
+      outline-offset: 1px;
+      text-decoration: none;
     }
   &.social {
     color: #767676;

--- a/base/static/base/css/navigation.scss
+++ b/base/static/base/css/navigation.scss
@@ -37,12 +37,16 @@ Navigation Drop Downs
   padding-right: 1.5em;
   &>li>a {
       color: #f9f9f9;
+      text-decoration: none;
       &:hover {
       	color:#E4E4E4;
         background-color: $transparent;
+        text-decoration: underline;
       }
       &:focus {
         background-color: $transparent;
+        outline-offset: 1px;
+        text-decoration: underline;
       }
     }
   &>li>.dropdown-menu {
@@ -113,12 +117,17 @@ i.ask-icon {
   .navbar-nav {
     &>li>a {
       color: #eee;
+      text-decoration: none;
       &:hover {
         color: #fff;
         background-color: $transparent;
+        text-decoration: underline;
       }
       &:focus {
         color: #fff;
+        background-color: $transparent;
+        outline-offset: 1px;
+        text-decoration: underline;
       }
     }
     & .open .dropdown-menu {
@@ -129,7 +138,7 @@ i.ask-icon {
       color: #fff;
     }
     &>.open>a, &>.open>a:hover {
-      color: #E4E4E4;
+      color: #EDD4C1;
       background-color: $transparent;
     }
   }
@@ -144,6 +153,8 @@ i.ask-icon {
   padding-left:0.5em;
   &.navbar-nav>li>a:focus {
     color: #fff;
+    outline-offset: 1px;
+    text-decoration: underline;
   }
   &.navbar-nav>.open>a:focus {
     background-color: $maroon;
@@ -170,14 +181,33 @@ i.ask-icon {
       color: #fff;
       font-size: 1.05em;
       margin-bottom: 5px;
+      text-decoration: none;
     &:hover { //For top right nav
-        color: $hoveraccent;
-        text-decoration: none;
+        color: #EDD4C1;
+        text-decoration: underline;
         background-color: transparent;
+    }
+    &:focus { //For top right nav
+      color: #fff;
+      background-color: transparent;
+      outline-offset: 1px;
+      text-decoration: underline;
     }
   }
 }
 
+.dropdown-menu>li>a { // ADA
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+  &:focus {
+    color: #fff;
+    background-color: transparent;
+    outline-offset: 1px;
+    text-decoration: underline;
+  }
+}
 
 /* Not currently using, but saved for when nav changes */
 // .dropdown-menu-right {
@@ -207,7 +237,8 @@ i.ask-icon {
       font-size: $font-small;
       text-decoration: none;
       &:hover {
-        color: $hoveraccent;
+        color: #EDD4C1;
+        text-decoration: underline;
       }
     }
   }
@@ -229,7 +260,7 @@ i.ask-icon {
       font-size: $font-small;
       margin-bottom: 12px;
       &:hover {
-        color: $hoveraccent!important;
+        color: #EDD4C1!important;
         background-color: transparent!important;
       }
     }

--- a/base/static/base/css/sidebars.scss
+++ b/base/static/base/css/sidebars.scss
@@ -74,6 +74,12 @@ Right Sidebar: Widget Items
     padding-left: 1em;
     padding-top: 35px;
   }
+  a { // ADA
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 
   // Library specific colors
   &.crerar>ul>li>a {
@@ -165,6 +171,10 @@ Right Sidebar: Widget Items
   }
   a {
     color:  $active-hover;
+    &:hover {
+      color: $default-link;
+      text-decoration: none;
+    }
   }
   h2, h3 {
     font-weight: 400;
@@ -246,6 +256,7 @@ Right Sidebar: Widget Items
   a {
     color: $darkgray;
     display: inline;
+    text-decoration: none;
     &.viewall {
         &:before {
         content: "\0020|\0020";

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -98,18 +98,19 @@ body.libnewspage .breadcrumbs, body.libnewsindexpage .breadcrumbs, .h1-banner .b
   color: #E7E5E2;
   left: 0;
   top: 0;
+  a {
+    color: #fff;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
   .h2 {
     color: #fff;
     font-weight: 400;
     font-size: 1.2em;
     margin-top: 0;
     padding: 10px 15px;
-    &:hover {
-      text-decoration: none;
-    }
-    a & {
-      color: #fff;
-    }
   }
   &.crerar {
     background-color: $trans-blue;
@@ -722,6 +723,12 @@ figure.embed {
   @extend .btn-morelink;
 }
 
+.spaces-toggle {
+  a {
+    text-decoration: none;
+  }
+}
+
 .btn-list-toggle {  //Behavior togglers with maroon lines
   color: $darkgray;
   background-color: #fff;
@@ -808,6 +815,10 @@ figure.embed {
  .distinct-list { //table base
   a {
     color: #8a4a20;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
   }
   .material-icons, .fa {
     padding-right: 10px;


### PR DESCRIPTION
Closes #321

**Changes in this request**
All color contrast min requirements are 4:5.1
- Changed nav link hover color contrast from 3.4:1 to 7.88:1
- Changed default link color contrast from 3:0 to 6.38:1
- Changed default hover color contrast from 3:1 to 5:21.1
- Added a change in text-decoration when in hover state (toggle between underline or none depending on where the link is)
- Added focus outline so we are not relying on browser styling for focus.
