### PR TITLE
Updated borrow request nav links

### DIFF
--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -133,8 +133,9 @@
                                        <li class="twocol-head">Access &amp; Privileges</li>
                                         <li role="separator" class="divider visible-xs"></li>
                                         <li><a href="/borrow/access-privileges/uchicago-faculty-students-and-staff/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Faculty, Students, and Staff">Faculty, Students, and Staff</a></li>
-                                        <li><a href="/borrow/access-privileges/alumni-other-researchers/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Alumni &amp; Other Researchers">Alumni &amp; Other Researchers</a></li>
-                                        <li><a href="/borrow/access-privileges/privileges-other-libraries/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Privileges at Other Libraries">Privileges at Other Libraries</a></li>
+                                        <li><a href="/borrow/access-privileges/alumni/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Alumni">Alumni</a></li>
+                                        <li><a href="/borrow/access-privileges/other-colleges-universities/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Researchers from Other Colleges &amp; Universities">Researchers from Other Colleges &amp; Universities</a></li>
+                                        <li><a href="/borrow/access-privileges/visitors/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Other Visitors">Other Visitors</a></li>
                                         <li><a href="/borrow/access-privileges/offcampus" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Off-Campus Access">Proxy &amp; Off-Campus Access</a></li>
                                     </ul>
                                 </li>


### PR DESCRIPTION
Verify against changes requested in #344 
Do not close issue; need to move pages in production

**Changes in this request**
- Will be removing the "Alumni & Other Researchers" index page, so have updated links to reflect that
- Removed link for "Privileges at Other Libraries"
- Changed "Alumni & Other Researchers" to "Alumni"
- Added "Researchers from Other Colleges & Universities"
- Added "Other Visitors"