### PR TITLE
Removed button from Law

### DIFF
--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -65,8 +65,8 @@ body.libnewspage .breadcrumbs, body.libnewsindexpage .breadcrumbs, .h1-banner .b
   @include visually-hidden;
 }
 
-#p-1754 button[id^='mysched'] { // Hides schedule button from Law Homepage (visually + for screen readers)
-  display: none;
+#p-1754 button[id^='mysched'] { // Hides schedule button from Law Homepage
+  display: none; // hides from screen readers too
 }
 
 


### PR DESCRIPTION
Closes #338 

**Changes in this request**
- Moved button so it is in the same grid column as the profile photo
- Hide button on Law homepage