### PR TITLE
322 ada homepage and template easy fixes

### DIFF
--- a/base/static/base/css/footer.scss
+++ b/base/static/base/css/footer.scss
@@ -51,10 +51,13 @@ Pleeb Footer Code
   background-repeat: repeat;
   padding-top: 20px;
   padding-bottom: 20px;
+  ul {
+    list-style:none;
+  }
   &>hr {
     border-top: 1px solid $mid-dark;
   }
-  p, small {
+  p, li, small {
     color: $neutral;
   }
   & a {

--- a/base/static/base/css/navigation.scss
+++ b/base/static/base/css/navigation.scss
@@ -227,19 +227,17 @@ i.ask-icon {
 .twocol-drop {
   background-color: $transparent;
   @include respond-to(small) {
-      min-width: 500px;
-      padding: 10px 0 10px 0;
+    min-width: 500px;
+    padding: 10px 0 10px 0;
   }
-  >li>ul>li {
-    margin-bottom: 10px;
-    a {
-      color: #fff;
-      font-size: $font-small;
-      text-decoration: none;
-      &:hover {
-        color: #EDD4C1;
-        text-decoration: underline;
-      }
+  a {
+    color: #fff;
+    font-size: $font-small;
+    text-decoration: none;
+    line-height: 2em;
+    &:hover {
+      color: #EDD4C1;
+      text-decoration: underline;
     }
   }
 }

--- a/base/templates/base/includes/footer.html
+++ b/base/templates/base/includes/footer.html
@@ -4,67 +4,74 @@
 
         <!-- Contact -->
         <div class="col-xs-12 col-sm-2 col-footer">
-            <p>Contact<br/>
-            <a href="/research/help/ask-librarian/ask-contact/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Contact Us">Contact Us</a><br/>
-            <a href="/about/directory/?view=department" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Library Departments">Library Departments</a><br/>
-            <a href="/about/directory/?view=staff" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Staff Directory">Staff Directory</a><br/><br/>
-
-            Policies<br/>
-            <a href="/about/thelibrary/policies/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Policies &gt; Library Policies">Library Policies</a></p>
+            <ul>
+                <li role="header">Contact</li>
+                <li><a href="/research/help/ask-librarian/ask-contact/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Contact Us">Contact Us</a></li>
+                <li><a href="/about/directory/?view=department" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Library Departments">Library Departments</a></li>
+                <li><a href="/about/directory/?view=staff" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Staff Directory">Staff Directory</a></li>
+                <li role="header"><br/>Policies</li>
+                <li><a href="/about/thelibrary/policies/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Policies &gt; Library Policies">Library Policies</a></li>
+            </ul>
         </div>
         <!-- // Contact -->
 
 
         <!-- Information -->
         <div class="col-xs-12 col-sm-2 col-footer divider-vertical">
-            <p>Information for<br/>
+            <ul>
+                <li role="header">Information for</li>
             {% if is_law %}
-                <a href="http://guides.lib.uchicago.edu/lawfacultyservices" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Faculty">Law Faculty</a><br/>
-                <a href="http://guides.lib.uchicago.edu/lawstudents" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Students">Law Students</a><br/>
+                <li><a href="http://guides.lib.uchicago.edu/lawfacultyservices" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Faculty">Law Faculty</a></li>
+                <li><a href="http://guides.lib.uchicago.edu/lawstudents" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Students">Law Students</a></li>
             {% else %}
-                <a href="/research/help/infofor/faculty/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Faculty">Faculty</a><br/>
-                <a href="/research/help/infofor/students/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Students">Students</a><br/>
+                <li><a href="/research/help/infofor/faculty/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Faculty">Faculty</a></li>
+                <li><a href="/research/help/infofor/students/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Students">Students</a></li>
             {% endif %}
-            <a href="/research/help/infofor/staff/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; University Staff">University Staff</a><br/>
+                <li><a href="/research/help/infofor/staff/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; University Staff">University Staff</a></li>
             {% if is_law %}
-                <a href="/law/about/access/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Visitors">Visiting the Law Library</a><br/>
+                <li><a href="/law/about/access/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Visitors">Visiting the Law Library</a></li>
             {% else %}
-                <a href="/research/help/infofor/information-visitors/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Visitors">Visitors</a><br/>
+                <li><a href="/research/help/infofor/information-visitors/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Visitors">Visitors</a></li>
             {% endif %}
-            <a href="/research/help/infofor/alumni/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Alumni &amp; Library Friends">Alumni &amp; Library Friends</a><br/>
-            <a href="/research/help/infofor/accessibility/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Patrons with Disabilities">Patrons with Disabilities</a></p>
+                <li><a href="/research/help/infofor/alumni/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Alumni &amp; Library Friends">Alumni &amp; Library Friends</a></li>
+                <li><a href="/research/help/infofor/accessibility/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Patrons with Disabilities">Patrons with Disabilities</a></li>
+            </ul>
         </div>
         <!-- // Information -->
 
         <!-- Libraries -->
         <div class="col-xs-12 col-sm-2 col-footer col-sm-push-4 divider-vertical">
-            <p>Libraries<br/>
-            <a href="/crerar/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Crerar">Crerar</a><br/>
-            <a href="/law/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; D'Angelo Law">D’Angelo Law</a><br/>
-            <a href="/eck/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Eckhart">Eckhart</a><br/>
-            <a href="/mansueto/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Mansueto">Mansueto</a><br/>
-            <a href="/spaces/joseph-regenstein-library/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Regenstein">Regenstein</a><br/>
-            <a href="/scrc/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Special Collections">Special Collections</a><br/>
-            <a href="/ssa/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; SSA">SSA</a></p>
+            <ul>
+                <li role="header">Libraries</li>
+                <li><a href="/crerar/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Crerar">Crerar</a></li>
+                <li><a href="/law/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; D'Angelo Law">D’Angelo Law</a></li>
+                <li><a href="/eck/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Eckhart">Eckhart</a></li>
+                <li><a href="/mansueto/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Mansueto">Mansueto</a></li>
+                <li><a href="/spaces/joseph-regenstein-library/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Regenstein">Regenstein</a></li>
+                <li><a href="/scrc/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; Special Collections">Special Collections</a></li>
+                <li><a href="/ssa/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Libraries &gt; SSA">SSA</a></li>
+            </ul>
         </div>
         <!-- // Libraries -->
 
         <!-- Social -->
         <div class="col-xs-12 col-sm-2 col-footer col-sm-push-4">
-            <p>Library Social Media<br/>
+            <ul>
+                <li role="header">Library Social Media</li>
             {% if is_law %}
-                <a href="https://www.facebook.com/dangelolawlib" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Facebook"><i class="fa fa-facebook-official" aria-hidden="true"></i> &nbsp; Law Library Facebook</a><br/>
-                <a href="https://twitter.com/dangelolawlib" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Twitter"><i class="fa fa-twitter" aria-hidden="true"></i> &nbsp; Law Twitter</a><br/>
-                <a href="https://www.instagram.com/dangelolawlib/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Instagram"><i class="fa fa-instagram" aria-hidden="true"></i> &nbsp; Law Instagram</a><br/>
-                <a href="http://news.lib.uchicago.edu/law/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Library News"><i class="fa fa-rss-square" aria-hidden="true"></i> &nbsp; Law Library News</a><br/>
+                <li><a href="https://www.facebook.com/dangelolawlib" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Facebook"><i class="fa fa-facebook-official" aria-hidden="true"></i> &nbsp; Law Library Facebook</a></li>
+                <li><a href="https://twitter.com/dangelolawlib" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Twitter"><i class="fa fa-twitter" aria-hidden="true"></i> &nbsp; Law Twitter</a></li>
+                <li><a href="https://www.instagram.com/dangelolawlib/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Instagram"><i class="fa fa-instagram" aria-hidden="true"></i> &nbsp; Law Instagram</a></li>
+                <li><a href="http://news.lib.uchicago.edu/law/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Library News"><i class="fa fa-rss-square" aria-hidden="true"></i> &nbsp; Law Library News</a></li>
             {% else %}
-                <a href="http://www.facebook.com/uchicagolibrary" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Facebook"><i class="fa fa-facebook-official" aria-hidden="true"></i> &nbsp; Facebook</a><br/>
-                <a href="https://twitter.com/UChicagoLibrary" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Twitter"><i class="fa fa-twitter" aria-hidden="true"></i> &nbsp; Twitter</a><br/>
-                <a href="https://www.instagram.com/uchicagolibrary/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Instagram"><i class="fa fa-instagram" aria-hidden="true"></i> &nbsp; Instagram</a><br/>
-               <a href="http://news.lib.uchicago.edu/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Library News"><i class="fa fa-rss-square" aria-hidden="true"></i> &nbsp; Library News</a><br/>
+                <li><a href="http://www.facebook.com/uchicagolibrary" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Facebook"><i class="fa fa-facebook-official" aria-hidden="true"></i> &nbsp; Facebook</a></li>
+                <li><a href="https://twitter.com/UChicagoLibrary" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Twitter"><i class="fa fa-twitter" aria-hidden="true"></i> &nbsp; Twitter</a></li>
+                <li><a href="https://www.instagram.com/uchicagolibrary/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Instagram"><i class="fa fa-instagram" aria-hidden="true"></i> &nbsp; Instagram</a></li>
+                <li><a href="http://news.lib.uchicago.edu/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; Library News"><i class="fa fa-rss-square" aria-hidden="true"></i> &nbsp; Library News</a></li>
             {% endif %}
-            <a href="https://www.youtube.com/user/uchicagolibrary" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; YouTube"><i class="fa fa-youtube-square" aria-hidden="true"></i> &nbsp; YouTube</a><br/>
-            <a href="/about/news-events/social-media/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; More Library Accounts"><i class="fa fa-clone" aria-hidden="true"></i> &nbsp; More Library Accounts...</a></p>
+                <li><a href="https://www.youtube.com/user/uchicagolibrary" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; YouTube"><i class="fa fa-youtube-square" aria-hidden="true"></i> &nbsp; YouTube</a></li>
+                <li><a href="/about/news-events/social-media/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Library Social Media &gt; More Library Accounts"><i class="fa fa-clone" aria-hidden="true"></i> &nbsp; More Library Accounts...</a></li>
+            </ul>
         </div>
         <!-- // Social -->
 

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -157,7 +157,7 @@
                         <li class="dropdown">
                             <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Research &amp; Teaching" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Research <span class="hidden-sm">&amp; Teaching</span> <span class="caret"></span></a>
                             <ul class="dropdown-menu twocol-drop">
-                            <!-- Research > Help Tools column -->
+                                <!-- Research > Help Tools column -->
                                 <li class="col-sm-5 ul-left"><span class="twocol-head" role="heading" aria-level="2" id="research_tools">Research Help &amp; Tools</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="research_tools">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
@@ -170,31 +170,29 @@
                                 </li>
                                 <!-- // Research > Help Tools column -->
                                 
-                                <div class="col-sm-7">
-                                    <!-- Research > Support sub-column -->
-                                    <li><span class="twocol-head" role="heading" aria-level="2" id="research_support">Teaching Support</span>
-                                        <ul class="list-unstyled" role="region" aria-labelledby="research_support">
-                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                            <li><a href="/research/teaching/course-reserves-setup/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Course Reserves Setup">Course Reserves Setup</a></li>
-                                            <li><a href="/research/teaching/research-instruction-courses/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Instruction for Courses">Instruction for Courses</a></li>
-                                            <li><a href="/research/teaching/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Teaching &amp; Learning Services">Teaching &amp; Learning Services</a></li>
-                                            <li role="separator" class="divider hidden-xs" role="presentation"></li>
-                                        </ul>
-                                    </li>
-                                    <!-- // Research > Support sub-column -->
+                                <!-- Research > Support sub-column -->
+                                <li class="col-sm-7"><span class="twocol-head" role="heading" aria-level="2" id="research_support">Teaching Support</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="research_support">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                        <li><a href="/research/teaching/course-reserves-setup/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Course Reserves Setup">Course Reserves Setup</a></li>
+                                        <li><a href="/research/teaching/research-instruction-courses/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Instruction for Courses">Instruction for Courses</a></li>
+                                        <li><a href="/research/teaching/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Teaching &amp; Learning Services">Teaching &amp; Learning Services</a></li>
+                                        <li role="separator" class="divider hidden-xs" role="presentation"></li>
+                                    </ul>
+                                </li>
+                                <!-- // Research > Support sub-column -->
 
-                                    <!-- Research > Digital Scholarship sub-column -->
-                                    <li><span class="twocol-head" role="heading" aria-level="2" id="research_digital">Digital Scholarship</span>
-                                        <ul class="list-unstyled" role="region" aria-labelledby="research_support">
-                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                            <li><a href="/research/scholar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Center for Digital Scholarship</a></li>
-                                            <li><a href="/research/scholar/phd" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Dissertation Office">Dissertation Office</a></li>
-                                            <li><a href="https://knowledge.uchicago.edu/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="KnowledgeUChicago">Knowledge&#64;UChicago</a></li>
-                                            <li><a href="https://www.lib.uchicago.edu/copyrightinfo/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Copyright Info">Copyright Info</a></li>
-                                        </ul>
-                                    </li>
-                                    <!-- // Research > Digital Scholarship sub-column -->
-                                </div>
+                                <!-- Research > Digital Scholarship sub-column -->
+                                <li class="col-sm-7"><span class="twocol-head" role="heading" aria-level="2" id="research_digital">Digital Scholarship</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="research_support">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                        <li><a href="/research/scholar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Center for Digital Scholarship</a></li>
+                                        <li><a href="/research/scholar/phd" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Dissertation Office">Dissertation Office</a></li>
+                                        <li><a href="https://knowledge.uchicago.edu/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="KnowledgeUChicago">Knowledge&#64;UChicago</a></li>
+                                        <li><a href="https://www.lib.uchicago.edu/copyrightinfo/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Copyright Info">Copyright Info</a></li>
+                                    </ul>
+                                </li>
+                                <!-- // Research > Digital Scholarship sub-column -->
                             </ul>
                         </li>
                         <!-- // Research Dropdown -->
@@ -204,30 +202,26 @@
                             <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Collections &amp; Exhibits" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Collections <span class="hidden-sm">&amp; Exhibits</span> <span class="caret"></span></a>
                             <ul class="dropdown-menu twocol-drop">
 
-                                <div class="col-sm-6 ul-left">
-                                    <!-- Collection/Exhibits > Collections sub-column -->
-                                    <li><span class="twocol-head" role="heading" aria-level="2" id="collex_collections">Collections</span>
-                                        <ul class="list-unstyled" role="region" aria-labelledby="collex_collections">
-                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                            <li><a href="/collex/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Notable Collections">Notable Collections</a></li>
-                                            <li><a href="/collex/?digital=on&view=collections" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Digital Collections">Digital Collections</a></li>
-                                            <li><a href="/collex/?view=subjects" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Collecting Areas by Subject">Collecting Areas by Subject</a></li>
-                                            <li><a href="/collex/collections/other-local-collections/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Other Local Collections">Other Local Collections</a></li>
-                                            <li role="separator" class="divider hidden-xs" role="presentation"></li>
-                                        </ul>
-                                    </li>
-                                    <!-- // Collection/Exhibits > Collections sub-column -->
+                                <!-- Collection/Exhibits > Collections sub-column -->
+                                <li class="col-sm-6 ul-left"><span class="visually-hidden" role="heading" aria-level="2" id="collex_materials">Collection Materials</span> <!-- Formatted like this for ADA purposes since Collection and Exhibit division is for visual reasons only. -->
+                                    <ul class="list-unstyled" role="region" aria-labelledby="collex_materials">
+                                        <li class="twocol-head" role="heading" aria-level="3">Collections</li>
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                        <li><a href="/collex/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Notable Collections">Notable Collections</a></li>
+                                        <li><a href="/collex/?digital=on&view=collections" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Digital Collections">Digital Collections</a></li>
+                                        <li><a href="/collex/?view=subjects" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Collecting Areas by Subject">Collecting Areas by Subject</a></li>
+                                        <li><a href="/collex/collections/other-local-collections/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Other Local Collections">Other Local Collections</a></li>
+                                        <li role="separator" class="divider hidden-xs" role="presentation"></li>
+                                        <!-- // Collection/Exhibits > Collections sub-column -->
 
-                                    <!-- // Collection/Exhibits > Exhibits sub-column -->
-                                    <li><span class="twocol-head" role="heading" aria-level="2" id="collex_exhibits">Exhibits</span>
-                                        <ul class="list-unstyled" role="region" aria-labelledby="collex_exhibits">
-                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                            <li><a href="/collex/?view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; All Exhibits">All Exhibits</a></li>
-                                            <li><a href="/collex/?digital=on&view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Web Exhibits">Web Exhibits</a></li>
-                                        </ul>
-                                    </li>
-                                    <!-- // Collection/Exhibits > Exhibits sub-column -->
-                                </div>
+                                        <!-- // Collection/Exhibits > Exhibits sub-column -->
+                                        <li class="twocol-head" role="heading" aria-level="3">Exhibits</li>
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                        <li><a href="/collex/?view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; All Exhibits">All Exhibits</a></li>
+                                        <li><a href="/collex/?digital=on&view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Web Exhibits">Web Exhibits</a></li>
+                                    </ul>
+                                </li>
+                                <!-- // Collection/Exhibits > Exhibits sub-column -->
 
                                 <!-- Collection/Exhibits > Research Centers column -->
                                 <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="collex_centers">Research Centers</span>

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -30,14 +30,14 @@
 
             <!-- Top right nav --> <!-- Hidden XS + SM -->
             <ul class="nav navbar-nav hidden-xs hidden-sm navbar-right" id="navbar-right">
-              <li><a href="{{chat_url}}" data-ga-category="top-bar-links" data-ga-action="click" data-ga-label="Ask a Librarian"><i id="chat-status" class="fa fa-comment fa-lg ask-icon" data-default-ask-name="uofc-ask" aria-hidden="true"></i> Ask 
-                {% if unfriendly_a %} 
-                    an 
-                {% else %} 
-                    a 
-                {% endif %} {{self.friendly_name}} Librarian</a></li>
-              {% if settings.site_settings.EmergencyHours.enable %}
-                  <li>
+                <li><a href="{{chat_url}}" data-ga-category="top-bar-links" data-ga-action="click" data-ga-label="Ask a Librarian"><i id="chat-status" class="fa fa-comment fa-lg ask-icon" data-default-ask-name="uofc-ask" aria-hidden="true"></i> Ask 
+                    {% if unfriendly_a %} 
+                        an 
+                    {% else %} 
+                        a 
+                    {% endif %} {{self.friendly_name}} Librarian</a></li>
+                  {% if settings.site_settings.EmergencyHours.enable %}
+                <li>
                     <a href="{{hours_page_url}}" data-ga-category="top-bar-links" data-ga-action="click" data-ga-label="Library Hours">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                         {% if settings.site_settings.EmergencyHours.link_text %}
@@ -46,27 +46,29 @@
                             View Hours
                         {% endif %}
                     </a>
-                  </li>
+                </li>
               {% else %}
-                  <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-ga-category="top-bar-links" data-ga-action="pulldown" data-ga-label="Library Hours" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                <li class="dropdown" role=”heading” id="library_hours_buildings">
+                    <a href="#" class="dropdown-toggle" data-ga-category="top-bar-links" data-ga-action="pulldown" data-ga-label="Library Hours" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" aria-label="Library hours by building">
                         <i class="fa fa-clock-o" aria-hidden="true"></i> 
                         <span id="current-hours" data-libcalid="{{libcalid}}">
-                            <span id="current-hours-target"><i class="fa fa-refresh fa-spin fa-fw" aria-hidden="true"></i> 
+                            <span id="current-hours-target">
+                                <i class="fa fa-refresh fa-spin fa-fw" aria-hidden="true"></i> 
                                 <span>Loading...</span>
                             </span>
-                        </span> <span class="caret"></span>
+                        </span>
+                        <span class="caret"></span>
                     </a>
-                    <ul id="hours-dropdown" class="dropdown-menu">
+                    <ul id="hours-dropdown" class="dropdown-menu" role=”region” aria-labelledby="library_hours_buildings">
                         {% for hours in all_building_hours %}
                             {% if hours != current_building_hours %}
-                            <li><a href="#">{{hours}}</a></li>
+                                <li><a href="#">{{hours}}</a></li>
                             {% endif %}
                         {% endfor %}
-                        <li class="divider"></li>
+                        <li class="divider" aria-role="presentation"></li>
                         <li><a href="{{hours_page_url}}">View all hours <span class="glyphicon glyphicon-chevron-right" style="font-size:0.8em;"></span></a></li>
                     </ul>
-                  </li>
+                </li>
               {% endif %}
               <li><a href="/about/thelibrary/supportus/" data-ga-category="top-bar-links" data-ga-action="click" data-ga-label="Support the Library"><i class="fa fa-gift" aria-hidden="true"></i> Support the Library</a></li>
               <li><a href="http://www.lib.uchicago.edu/myaccount" data-ga-category="top-bar-links" data-ga-action="click" data-ga-label="My Library Account"><i class="fa fa-user" aria-hidden="true"></i> My Library Account</a></li>
@@ -79,22 +81,26 @@
 
                         <!-- Search Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Search" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Search<span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop">
-                                <li>
-                                    <ul class="list-unstyled col-sm-6 ul-left">
-                                        <li class="twocol-head">Catalogs</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Search" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            <span role="heading" aria-level="2" id="navigation_search">Search</span><span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_search">
+                                <!-- Search > Catalog column -->
+                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="3" id="search_catalogs">Catalogs</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="search_catalogs">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/h/3" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Library Catalog">Library Catalog</a></li>
                                         <li><a href="/h/ub" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; UBorrow">UBorrow</a></li>
                                         <li><a href="/h/borrowdirect" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; BorrowDirect">BorrowDirect</a></li>
                                         <li><a href="http://proxy.uchicago.edu/login?qurl={{'http://lib.uchicago.edu/h/worldcat'|urlencode:''}}" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; WorldCat">WorldCat</a></li>
                                         <li><a href="/search/catalogs/other" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Other Catalogs">Other Catalogs</a>&nbsp;<br/>&nbsp;</li>
                                     </ul>
+                                </li>
+                                <!-- // Search > Catalog column -->
 
-                                    <ul class="list-unstyled col-sm-6">
-                                        <li class="twocol-head">Other Search Tools</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                <!-- Search > Other Tools column -->
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="3" id="search_other_tools">Other Search Tools</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="search_other_tools">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="http://proxy.uchicago.edu/login?qurl={{'http://lib.uchicago.edu/h/articlesplus'|urlencode:''}}" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Articles Plus">Articles Plus</a></li>
                                         <li><a href="/h/atoz" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Database Finder">Database Finder</a></li>
                                         <li><a href="/search/tools/database-trials/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Database Trials">Database Trials</a></li>
@@ -103,35 +109,41 @@
                                         <li id="web-search"><a href="/#tab-3" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Website Search">Website Search</a></li>
                                     </ul>
                                 </li>
+                                <!-- //Search > Other Tools column -->
                             </ul>
                         </li>
                         <!-- // Search Dropdown -->
 
                         <!-- Borrow/Request Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Borrow &amp; Request" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Borrow<span class="hidden-sm hidden-md"> &amp; Request</span> <span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop">
-                                <li>
-                                    <ul class="list-unstyled col-sm-6 ul-left">
-                                        <li class="twocol-head">Borrow</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Borrow &amp; Request" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            <span role="heading" aria-level="2" id="navigation_request">Borrow<span class="hidden-sm"> &amp; Request</span></span> <span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_request">
+                                <!-- Borrow/Request > Borrow column -->
+                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="3" id="request_borrow">Borrow</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="request_borrow">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/borrow/borrowing/due-dates-and-loan-periods/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Due Dates &amp; Loan Periods">Due Dates &amp; Loan Periods</a></li>
                                         <li><a href="/borrow/borrowing/renewing-and-returning-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Renewing &amp; Returning Items">Renewing &amp; Returning Items</a></li>
                                         <li><a href="/borrow/borrowing/fines-and-lost-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Fines &amp; Lost Items">Fines &amp; Lost Items</a></li>
                                         <li><a href="/borrow/borrowing/course-reserves" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Course Reserves">Course Reserves</a></li>
                                         <li><a href="/borrow/borrowing/checkout" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Checkout UChicago">Checkout UChicago</a></li>
-                                        <li><a href="http://www.lib.uchicago.edu/myaccount" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; My Library Account">My Library Account</a><p class="hidden-xs" style="padding-bottom:8em"></p></li>
+                                        <li><a href="http://www.lib.uchicago.edu/myaccount" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; My Library Account">My Library Account</a> <!-- Padding below = quick fix to even out different sized columns -->
+                                        <p class="hidden-xs" style="padding-bottom:8em"></p></li>
                                     </ul>
+                                </li>
+                                <!-- // Borrow/Request > Borrow column -->
 
-                                    <ul class="list-unstyled col-sm-6">
-                                        <li class="twocol-head">Request</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                <!-- Borrow/Request > Request column -->
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="3" id="request_request">Request</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="request_request">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/borrow/requesting/interlibrary-loan/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Interlibrary Loan">Interlibrary Loan</a></li>
                                         <li><a href="/borrow/requesting/scan-deliver/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Scan &amp; Deliver">Scan &amp; Deliver</a></li>
                                         <li><a href="/borrow/requesting/suggest-purchase/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Suggest a Purchase">Suggest a Purchase</a></li>
-                                        <li role="separator" class="divider hidden-xs"></li>
-                                       <li class="twocol-head">Access &amp; Privileges</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                        <li role="separator" class="divider hidden-xs" role="presentation"></li>
+                                        <li class="twocol-head">Access &amp; Privileges</li>
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/borrow/access-privileges/uchicago-faculty-students-and-staff/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Faculty, Students, and Staff">Faculty, Students, and Staff</a></li>
                                         <li><a href="/borrow/access-privileges/alumni/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Alumni">Alumni</a></li>
                                         <li><a href="/borrow/access-privileges/other-colleges-universities/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Researchers from Other Colleges &amp; Universities">Researchers from Other Colleges &amp; Universities</a></li>
@@ -139,82 +151,105 @@
                                         <li><a href="/borrow/access-privileges/offcampus" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Off-Campus Access">Proxy &amp; Off-Campus Access</a></li>
                                     </ul>
                                 </li>
+                                <!-- // Borrow/Request > Request column -->
                             </ul>
                         </li>
                         <!-- // Borrow/Request Dropdown -->
 
                         <!-- Research Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Research &amp; Teaching" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Research <span class="hidden-sm">&amp; Teaching </span><span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop">
-                                <li>
-                                    <ul class="list-unstyled col-sm-5 ul-left">
-                                        <li class="twocol-head">Research Help &amp; Tools</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Research &amp; Teaching" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            <span role="heading" aria-level="2" id="navigation_research">Research <span class="hidden-sm">&amp; Teaching </span></span><span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_research">
+                            <!-- Research > Help Tools column -->
+                                <li class="col-sm-5 ul-left"><span class="twocol-head" role="heading" aria-level="3" id="research_tools">Research Help &amp; Tools</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="research_tools">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/research/help/ask-librarian/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Ask a Librarian">Ask a Librarian</a></li>
                                         <li><a href="/about/directory/?view=staff&subject=All+Subject+Specialists" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Subject Specialists">Subject Specialists</a></li>
                                         <li><a href="http://guides.lib.uchicago.edu/citation_management" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Citation Management">Citation Management</a></li>
                                         <li><a href="http://guides.lib.uchicago.edu/subjectguides/helpguides" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Help Guides">Help Guides</a></li>
-                                        <li><a href="http://guides.lib.uchicago.edu/subjectguides" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Subject Guides">Subject Guides</a><p class="hidden-xs" style="padding-bottom:8em"></p></li>
+                                        <li><a href="http://guides.lib.uchicago.edu/subjectguides" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Subject Guides">Subject Guides</a> <!-- Padding below = quick fix to even out different sized columns -->
+                                        <p class="hidden-xs" style="padding-bottom:8em"></p></li>
                                     </ul>
+                                </li>
+                                <!-- // Research > Help Tools column -->
 
-                                    <ul class="list-unstyled col-sm-7">
-                                        <li class="twocol-head">Teaching Support</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                <!-- Research > Support column -->
+                                <li class="col-sm-7"><span class="twocol-head" role="heading" aria-level="3" id="research_support">Teaching Support
+                                    <ul class="list-unstyled" role="region" aria-labelledby="research_support">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/research/teaching/course-reserves-setup/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Course Reserves Setup">Course Reserves Setup</a></li>
                                         <li><a href="/research/teaching/research-instruction-courses/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Instruction for Courses">Instruction for Courses</a></li>
                                         <li><a href="/research/teaching/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Teaching &amp; Learning Services">Teaching &amp; Learning Services</a></li>
-                                        <li role="separator" class="divider hidden-xs"></li>
+                                        <li role="separator" class="divider hidden-xs" role="presentation"></li>
                                         <li class="twocol-head">Digital Scholarship</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/research/scholar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Center for Digital Scholarship</a></li>
                                         <li><a href="/research/scholar/phd" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Dissertation Office">Dissertation Office</a></li>
                                         <li><a href="https://knowledge.uchicago.edu/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="KnowledgeUChicago">Knowledge&#64;UChicago</a></li>
                                         <li><a href="https://www.lib.uchicago.edu/copyrightinfo/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Copyright Info">Copyright Info</a></li>
                                     </ul>
                                 </li>
+                                <!-- // Research > Support column -->
                             </ul>
                         </li>
                         <!-- // Research Dropdown -->
 
                         <!-- Collection/Exhibits Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Collections &amp; Exhibits" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Collections <span class="hidden-sm">&amp; Exhibits</span> <span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop">
-                                <li>
-                                    <ul class="list-unstyled col-sm-6 ul-left">
-                                        <li class="twocol-head">Collections</li>
-                                        <li role="separator" class="divider visible-xs"></li>
-                                        <li><a href="/collex/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Notable Collections">Notable Collections</a></li>
-                                        <li><a href="/collex/?digital=on&view=collections" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Digital Collections">Digital Collections</a></li>
-                                        <li><a href="/collex/?view=subjects" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Collecting Areas by Subject">Collecting Areas by Subject</a></li>
-                                        <li><a href="/collex/collections/other-local-collections/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Other Local Collections">Other Local Collections</a></li>
-                                        <li role="separator" class="divider hidden-xs"></li>
-                                        <li class="twocol-head">Exhibits</li>
-                                        <li role="separator" class="divider visible-xs"></li>
-                                        <li><a href="/collex/?view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; All Exhibits">All Exhibits</a></li>
-                                        <li><a href="/collex/?digital=on&view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Web Exhibits">Web Exhibits</a></li>
-                                    </ul>
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Collections &amp; Exhibits" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            <span role="heading" aria-level="2" id="navigation_collex">Collections <span class="hidden-sm">&amp; Exhibits</span></span> <span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_collex">
 
-                                    <ul class="list-unstyled col-sm-6">
-                                        <li class="twocol-head">Research Centers</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                <div class="col-sm-6 ul-left">
+                                    <!-- Collection/Exhibits > Collections sub-column -->
+                                    <li><span class="twocol-head" role="heading" aria-level="3" id="collex_collections">Collections</span>
+                                        <ul class="list-unstyled" role="region" aria-labelledby="collex_collections">
+                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                            <li><a href="/collex/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Notable Collections">Notable Collections</a></li>
+                                            <li><a href="/collex/?digital=on&view=collections" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Digital Collections">Digital Collections</a></li>
+                                            <li><a href="/collex/?view=subjects" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Collecting Areas by Subject">Collecting Areas by Subject</a></li>
+                                            <li><a href="/collex/collections/other-local-collections/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Other Local Collections">Other Local Collections</a></li>
+                                            <li role="separator" class="divider hidden-xs" role="presentation"></li>
+                                        </ul>
+                                    </li>
+                                    <!-- // Collection/Exhibits > Collections sub-column -->
+
+                                    <!-- // Collection/Exhibits > Exhibits sub-column -->
+                                    <li><span class="twocol-head" role="heading" aria-level="3" id="collex_exhibits">Exhibits</span>
+                                        <ul class="list-unstyled" role="region" aria-labelledby="collex_exhibits">
+                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                            <li><a href="/collex/?view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; All Exhibits">All Exhibits</a></li>
+                                            <li><a href="/collex/?digital=on&view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Web Exhibits">Web Exhibits</a></li>
+                                        </ul>
+                                    </li>
+                                    <!-- // Collection/Exhibits > Exhibits sub-column -->
+                                </div>
+
+                                <!-- Collection/Exhibits > Research Centers column -->
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="3" id="collex_centers">Research Centers</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="collex_centers">
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/about/directory/departments/eastasia/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; East Asian Collections">East Asian Collection</a></li>
                                         <li><a href="/about/directory/departments/map-collection/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Map Collection">Map Collection</a></li>
                                         <li><a href="/about/directory/departments/southasia/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Southern Asia Collection">Southern Asia Collection</a></li>
                                         <li><a href="/scrc/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Special Collections">Special Collections</a></li>
                                     </ul>
                                 </li>
+                                <!-- // Collection/Exhibits > Research Centers column -->
                             </ul>
                         </li>
                         <!-- // Collection/Exhibits Dropdown -->
+
+                        <!-- LEFT OFF HERE - NEED TO VERIFY DIV WORKED FOR KEEPING 2 SECTIONS IN ONE COLUMN -->
 
                         <!-- Spaces  Dropdown  -->
                         <li class="dropdown">
                             <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Spaces &amp; Services" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Spaces <span class="hidden-sm">&amp; Services</span> <span class="caret"></span></a>
                             <ul class="dropdown-menu onecol-drop">
                                 <li class="twocol-head">Using Our Spaces</li>
-                                <li role="separator" class="divider visible-xs"></li>
+                                <li role="separator" class="divider visible-xs" role="presentation"></li>
                                 <li><a href="https://rooms.lib.uchicago.edu/allspaces" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Spaces &amp; Services &gt; Book a Room">Book a Room</a></li>
                                 <li><a href="/spaces/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Spaces &amp; Services &gt; Places to Study">Places to Study</a></li>
                                 <li><a href="/thelibrary/all-night-study/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Spaces &amp; Services &gt; All Night Study">All Night Study</a></li>
@@ -230,7 +265,7 @@
                             <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Libraries" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Libraries <span class="caret"></span></a>
                             <ul class="dropdown-menu dropdown-menu-right onecol-drop">
                                 <li class="twocol-head">Our Locations</li>
-                                <li role="separator" class="divider visible-xs"></li>
+                                <li role="separator" class="divider visible-xs" role="presentation"></li>
                                 <li><a href="/crerar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Crerar">Crerar</a></li>
                                 <li><a href="/law/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; D'Angelo Law">D'Angelo Law</a></li>
                                 <li><a href="/eck/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Eckhart">Eckhart</a></li>
@@ -252,7 +287,7 @@
                                 <li>
                                     <ul class="list-unstyled col-sm-6 ul-left">
                                         <li class="twocol-head">The Library</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/about/thelibrary/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Facts">About the Library</a></li>
                                         <li><a href="/research/help/infofor/information-visitors/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Visiting the Library">Visiting the Library</a></li>
                                         <li><a href="/about/thelibrary/mission/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Mission &amp; Strategic Plan">Mission &amp; Strategic Plan</a></li>
@@ -266,7 +301,7 @@
 
                                     <ul class="list-unstyled col-sm-6">
                                         <li class="twocol-head">News &amp; Events</li>
-                                        <li role="separator" class="divider visible-xs"></li>
+                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/about/news/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; News">News</a></li>
                                         <li><a href="/about/news-events/events/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Workshops &amp; Events">Workshops &amp; Events</a></li>
                                         <li><a href="/about/thelibrary/conferences/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Conferences">Conferences</a></li>

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -81,24 +81,23 @@
 
                         <!-- Search Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Search" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <span role="heading" aria-level="2" id="navigation_search">Search</span><span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_search">
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Search" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Search <span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop">
                                 <!-- Search > Catalog column -->
-                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="3" id="search_catalogs">Catalogs</span>
+                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="2" id="search_catalogs">Catalogs</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="search_catalogs">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/h/3" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Library Catalog">Library Catalog</a></li>
                                         <li><a href="/h/ub" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; UBorrow">UBorrow</a></li>
                                         <li><a href="/h/borrowdirect" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; BorrowDirect">BorrowDirect</a></li>
                                         <li><a href="http://proxy.uchicago.edu/login?qurl={{'http://lib.uchicago.edu/h/worldcat'|urlencode:''}}" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; WorldCat">WorldCat</a></li>
-                                        <li><a href="/search/catalogs/other" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Other Catalogs">Other Catalogs</a>&nbsp;<br/>&nbsp;</li>
+                                        <li><a href="/search/catalogs/other" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Other Catalogs">Other Catalogs</a> <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:1em"></p></li>
                                     </ul>
                                 </li>
                                 <!-- // Search > Catalog column -->
 
                                 <!-- Search > Other Tools column -->
-                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="3" id="search_other_tools">Other Search Tools</span>
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="search_other_tools">Other Search Tools</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="search_other_tools">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="http://proxy.uchicago.edu/login?qurl={{'http://lib.uchicago.edu/h/articlesplus'|urlencode:''}}" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Articles Plus">Articles Plus</a></li>
@@ -116,11 +115,10 @@
 
                         <!-- Borrow/Request Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Borrow &amp; Request" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <span role="heading" aria-level="2" id="navigation_request">Borrow<span class="hidden-sm"> &amp; Request</span></span> <span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_request">
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Borrow &amp; Request" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Borrow<span class="hidden-sm"> &amp; Request</span> <span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop">
                                 <!-- Borrow/Request > Borrow column -->
-                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="3" id="request_borrow">Borrow</span>
+                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="2" id="request_borrow">Borrow</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="request_borrow">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/borrow/borrowing/due-dates-and-loan-periods/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Due Dates &amp; Loan Periods">Due Dates &amp; Loan Periods</a></li>
@@ -128,14 +126,13 @@
                                         <li><a href="/borrow/borrowing/fines-and-lost-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Fines &amp; Lost Items">Fines &amp; Lost Items</a></li>
                                         <li><a href="/borrow/borrowing/course-reserves" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Course Reserves">Course Reserves</a></li>
                                         <li><a href="/borrow/borrowing/checkout" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Checkout UChicago">Checkout UChicago</a></li>
-                                        <li><a href="http://www.lib.uchicago.edu/myaccount" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; My Library Account">My Library Account</a> <!-- Padding below = quick fix to even out different sized columns -->
-                                        <p class="hidden-xs" style="padding-bottom:8em"></p></li>
+                                        <li><a href="http://www.lib.uchicago.edu/myaccount" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; My Library Account">My Library Account</a> <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:8em"></p></li>
                                     </ul>
                                 </li>
                                 <!-- // Borrow/Request > Borrow column -->
 
                                 <!-- Borrow/Request > Request column -->
-                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="3" id="request_request">Request</span>
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="request_request">Request</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="request_request">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/borrow/requesting/interlibrary-loan/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Interlibrary Loan">Interlibrary Loan</a></li>
@@ -158,53 +155,58 @@
 
                         <!-- Research Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Research &amp; Teaching" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <span role="heading" aria-level="2" id="navigation_research">Research <span class="hidden-sm">&amp; Teaching </span></span><span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_research">
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Research &amp; Teaching" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Research <span class="hidden-sm">&amp; Teaching</span> <span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop">
                             <!-- Research > Help Tools column -->
-                                <li class="col-sm-5 ul-left"><span class="twocol-head" role="heading" aria-level="3" id="research_tools">Research Help &amp; Tools</span>
+                                <li class="col-sm-5 ul-left"><span class="twocol-head" role="heading" aria-level="2" id="research_tools">Research Help &amp; Tools</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="research_tools">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/research/help/ask-librarian/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Ask a Librarian">Ask a Librarian</a></li>
                                         <li><a href="/about/directory/?view=staff&subject=All+Subject+Specialists" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Subject Specialists">Subject Specialists</a></li>
                                         <li><a href="http://guides.lib.uchicago.edu/citation_management" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Citation Management">Citation Management</a></li>
                                         <li><a href="http://guides.lib.uchicago.edu/subjectguides/helpguides" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Help Guides">Help Guides</a></li>
-                                        <li><a href="http://guides.lib.uchicago.edu/subjectguides" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Subject Guides">Subject Guides</a> <!-- Padding below = quick fix to even out different sized columns -->
-                                        <p class="hidden-xs" style="padding-bottom:8em"></p></li>
+                                        <li><a href="http://guides.lib.uchicago.edu/subjectguides" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Subject Guides">Subject Guides</a> <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:8em"></p></li>
                                     </ul>
                                 </li>
                                 <!-- // Research > Help Tools column -->
+                                
+                                <div class="col-sm-7">
+                                    <!-- Research > Support sub-column -->
+                                    <li><span class="twocol-head" role="heading" aria-level="2" id="research_support">Teaching Support</span>
+                                        <ul class="list-unstyled" role="region" aria-labelledby="research_support">
+                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                            <li><a href="/research/teaching/course-reserves-setup/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Course Reserves Setup">Course Reserves Setup</a></li>
+                                            <li><a href="/research/teaching/research-instruction-courses/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Instruction for Courses">Instruction for Courses</a></li>
+                                            <li><a href="/research/teaching/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Teaching &amp; Learning Services">Teaching &amp; Learning Services</a></li>
+                                            <li role="separator" class="divider hidden-xs" role="presentation"></li>
+                                        </ul>
+                                    </li>
+                                    <!-- // Research > Support sub-column -->
 
-                                <!-- Research > Support column -->
-                                <li class="col-sm-7"><span class="twocol-head" role="heading" aria-level="3" id="research_support">Teaching Support
-                                    <ul class="list-unstyled" role="region" aria-labelledby="research_support">
-                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                        <li><a href="/research/teaching/course-reserves-setup/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Course Reserves Setup">Course Reserves Setup</a></li>
-                                        <li><a href="/research/teaching/research-instruction-courses/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Instruction for Courses">Instruction for Courses</a></li>
-                                        <li><a href="/research/teaching/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Teaching &amp; Learning Services">Teaching &amp; Learning Services</a></li>
-                                        <li role="separator" class="divider hidden-xs" role="presentation"></li>
-                                        <li class="twocol-head">Digital Scholarship</li>
-                                        <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                        <li><a href="/research/scholar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Center for Digital Scholarship</a></li>
-                                        <li><a href="/research/scholar/phd" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Dissertation Office">Dissertation Office</a></li>
-                                        <li><a href="https://knowledge.uchicago.edu/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="KnowledgeUChicago">Knowledge&#64;UChicago</a></li>
-                                        <li><a href="https://www.lib.uchicago.edu/copyrightinfo/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Copyright Info">Copyright Info</a></li>
-                                    </ul>
-                                </li>
-                                <!-- // Research > Support column -->
+                                    <!-- Research > Digital Scholarship sub-column -->
+                                    <li><span class="twocol-head" role="heading" aria-level="2" id="research_digital">Digital Scholarship</span>
+                                        <ul class="list-unstyled" role="region" aria-labelledby="research_support">
+                                            <li role="separator" class="divider visible-xs" role="presentation"></li>
+                                            <li><a href="/research/scholar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Digital Scholarship">Center for Digital Scholarship</a></li>
+                                            <li><a href="/research/scholar/phd" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Dissertation Office">Dissertation Office</a></li>
+                                            <li><a href="https://knowledge.uchicago.edu/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="KnowledgeUChicago">Knowledge&#64;UChicago</a></li>
+                                            <li><a href="https://www.lib.uchicago.edu/copyrightinfo/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Research &amp; Teaching &gt; Copyright Info">Copyright Info</a></li>
+                                        </ul>
+                                    </li>
+                                    <!-- // Research > Digital Scholarship sub-column -->
+                                </div>
                             </ul>
                         </li>
                         <!-- // Research Dropdown -->
 
                         <!-- Collection/Exhibits Dropdown -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Collections &amp; Exhibits" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <span role="heading" aria-level="2" id="navigation_collex">Collections <span class="hidden-sm">&amp; Exhibits</span></span> <span class="caret"></span></a>
-                            <ul class="dropdown-menu twocol-drop" role="region" aria-labelledby="navigation_collex">
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Collections &amp; Exhibits" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Collections <span class="hidden-sm">&amp; Exhibits</span> <span class="caret"></span></a>
+                            <ul class="dropdown-menu twocol-drop">
 
                                 <div class="col-sm-6 ul-left">
                                     <!-- Collection/Exhibits > Collections sub-column -->
-                                    <li><span class="twocol-head" role="heading" aria-level="3" id="collex_collections">Collections</span>
+                                    <li><span class="twocol-head" role="heading" aria-level="2" id="collex_collections">Collections</span>
                                         <ul class="list-unstyled" role="region" aria-labelledby="collex_collections">
                                             <li role="separator" class="divider visible-xs" role="presentation"></li>
                                             <li><a href="/collex/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; Notable Collections">Notable Collections</a></li>
@@ -217,7 +219,7 @@
                                     <!-- // Collection/Exhibits > Collections sub-column -->
 
                                     <!-- // Collection/Exhibits > Exhibits sub-column -->
-                                    <li><span class="twocol-head" role="heading" aria-level="3" id="collex_exhibits">Exhibits</span>
+                                    <li><span class="twocol-head" role="heading" aria-level="2" id="collex_exhibits">Exhibits</span>
                                         <ul class="list-unstyled" role="region" aria-labelledby="collex_exhibits">
                                             <li role="separator" class="divider visible-xs" role="presentation"></li>
                                             <li><a href="/collex/?view=exhibits" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; All Exhibits">All Exhibits</a></li>
@@ -228,7 +230,7 @@
                                 </div>
 
                                 <!-- Collection/Exhibits > Research Centers column -->
-                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="3" id="collex_centers">Research Centers</span>
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="collex_centers">Research Centers</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="collex_centers">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/about/directory/departments/eastasia/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Collections &amp; Exhibits &gt; East Asian Collections">East Asian Collection</a></li>
@@ -242,13 +244,12 @@
                         </li>
                         <!-- // Collection/Exhibits Dropdown -->
 
-                        <!-- LEFT OFF HERE - NEED TO VERIFY DIV WORKED FOR KEEPING 2 SECTIONS IN ONE COLUMN -->
 
                         <!-- Spaces  Dropdown  -->
                         <li class="dropdown">
-                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Spaces &amp; Services" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Spaces <span class="hidden-sm">&amp; Services</span> <span class="caret"></span></a>
+                            <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Spaces &amp; Services" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true">Spaces <span class="hidden-sm hidden-md">&amp; Services</span> <span class="caret"></span></a>
                             <ul class="dropdown-menu onecol-drop">
-                                <li class="twocol-head">Using Our Spaces</li>
+                                <li class="twocol-head" role="heading" aria-level="2">Using Our Spaces</li>
                                 <li role="separator" class="divider visible-xs" role="presentation"></li>
                                 <li><a href="https://rooms.lib.uchicago.edu/allspaces" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Spaces &amp; Services &gt; Book a Room">Book a Room</a></li>
                                 <li><a href="/spaces/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Spaces &amp; Services &gt; Places to Study">Places to Study</a></li>
@@ -260,11 +261,11 @@
                         </li>
                         <!-- // Spaces Dropdown -->
 
-                         <!-- Libraries  Dropdown  -->
+                        <!-- Libraries  Dropdown  -->
                         <li class="dropdown">
                             <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="Libraries" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Libraries <span class="caret"></span></a>
                             <ul class="dropdown-menu dropdown-menu-right onecol-drop">
-                                <li class="twocol-head">Our Locations</li>
+                                <li class="twocol-head" role="heading" aria-level="2">Our Locations</li>
                                 <li role="separator" class="divider visible-xs" role="presentation"></li>
                                 <li><a href="/crerar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Crerar">Crerar</a></li>
                                 <li><a href="/law/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; D'Angelo Law">D'Angelo Law</a></li>
@@ -273,7 +274,7 @@
                                 <li><a href="/spaces/joseph-regenstein-library/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Regenstein">Regenstein</a></li>
                                 <li><a href="/scrc/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Special Collections">Special Collections</a></li>
                                 <li><a href="/ssa/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; SSA">SSA</a></li>
-                                <li><a href="/libraries/libraries-hours/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Hours">Hours</a></li>
+                                <li><a href="/libraries/libraries-hours/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Hours" aria-label="View all Library hours">Hours</a></li>
                             </ul>
                         </li>
                         <!-- // Libraries Dropdown -->
@@ -284,9 +285,10 @@
                         <li class="dropdown">
                             <a href="#" data-ga-category="main-nav-links" data-ga-action="pulldown" data-ga-label="About" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                             <ul class="dropdown-menu dropdown-menu-right twocol-drop">
-                                <li>
-                                    <ul class="list-unstyled col-sm-6 ul-left">
-                                        <li class="twocol-head">The Library</li>
+
+                                <!-- About > Library column -->
+                                <li class="col-sm-6 ul-left"><span class="twocol-head" role="heading" aria-level="2" id="about_library">The Library</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="about_library">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/about/thelibrary/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Facts">About the Library</a></li>
                                         <li><a href="/research/help/infofor/information-visitors/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Visiting the Library">Visiting the Library</a></li>
@@ -298,9 +300,12 @@
                                         <li><a href="/about/thelibrary/committees/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Library Boards &amp; Committees">Library Boards &amp; Committees</a></li>
                                         <li><a href="/about/thelibrary/supportus/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Support the Library">Support the Library</a></li>
                                     </ul>
+                                </li>
+                                <!-- // About > Library column -->
 
-                                    <ul class="list-unstyled col-sm-6">
-                                        <li class="twocol-head">News &amp; Events</li>
+                                <!-- About > News column -->
+                                <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="about_news">News &amp; Events</span>
+                                    <ul class="list-unstyled" role="region" aria-labelledby="about_news">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
                                         <li><a href="/about/news/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; News">News</a></li>
                                         <li><a href="/about/news-events/events/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Workshops &amp; Events">Workshops &amp; Events</a></li>
@@ -309,6 +314,7 @@
                                         <li><a href="/about/news-events/social-media/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="About &gt; Social Media Directory">Social Media Directory</a></li>
                                     </ul>
                                 </li>
+                                <!-- // About > News column -->
                             </ul>
                         </li>
                         <!-- // About Dropdown -->

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -162,7 +162,7 @@
         {% endif %}
         <!-- // Left Sidebar -->
 
-        <div class="{{breadcrumb_div_css}}">
+        <div class="{{breadcrumb_div_css}}" role="navigation" aria-label="breadcrumb">
             {% include "base/includes/public_site_breadcrumbs.html" %}
         </div>
         {% block above_main_content %}{% endblock %}

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -369,11 +369,11 @@
                             <h3>Find Spaces</h3>
                             <div class="studymod row">
                                 <div class="col-xs-4 nopadding">
-                                    <p><a href="{{quiet_spaces_link}}"><i class="material-icons" aria-hidden="true">local_library</i></a><br/>
-                                    <span class="hidden-xs hidden-sm hidden-md">Quiet </span>Study</p>
+                                    <p><a href="{{quiet_spaces_link}}"><i class="material-icons" aria-hidden="true" aria-role="presentation">local_library</i></a><br/>
+                                    <span class="hidden-xs hidden-sm hidden-md" aria-role="presentation">Quiet </span>Study</p>
                                 </div>
                                 <div class="col-xs-4 nopadding">
-                                    <p><a href="{{collaborative_spaces_link}}"><i class="material-icons" aria-hidden="true">people</i></a><br/>Collaboration</p>
+                                    <p><a href="{{collaborative_spaces_link}}"><i class="material-icons" aria-hidden="true" aria-role="presentation">people</i></a><br/>Collaboration</p>
                                 </div>
                                 {% if self.book_a_room_link %}
                                     <div class="col-xs-4 nopadding">


### PR DESCRIPTION
Closes #322
**Changes in this request**
- See Issue #322 for full detail of changes required

**Notes on Navigation**
- Properly nested the `ul` and `li` within each other
- Added `role="heading"` to subcategory `li` in ways that the role would only apply to the text itself (varies by type of dropdown menu
- `role="heading"` is paired with an `aria-level`
- Added `role="region"` and `aria-labelledby` to `ul` sections that are subcategories within mega dropdown items

**Issue with Hours**
The right nav drop-down version of the hours: `current_building_hours` not display any text in the DOM for a screen reader. The code loads as empty with no text. This means that screen readers do not know what the drop-down opens and the current building hours is hidden from them. This isn't an issue at the moment since we have emergency hours active, but the best solution is something that needs to be discussed.