### PR TITLE
Removed Cultural from Area and Cultural Studies

### DIFF
--- a/lib_collections/views.py
+++ b/lib_collections/views.py
@@ -256,15 +256,15 @@ def collections(request):
 
     # for the subject pulldown, find subjects that are first generation children- their parents should have no parent.
     # still need these:
-    # Area and Cultural Studies
+    # Area Studies
     # Social Sciences
     # Biological Sciences
     # Physical Sciences
 
     subjects_pulldown = [
-        'Area & Cultural Studies', 'Arts', 'Biological Sciences', 'Business',
-        'Humanities', 'Law', 'Literature', 'Medicine', 'Physical Sciences',
-        'Social Sciences', 'Social Services', 'Special Collections'
+        'Area Studies', 'Arts', 'Biological Sciences', 'Business', 'Humanities',
+        'Law', 'Literature', 'Medicine', 'Physical Sciences', 'Social Sciences',
+        'Social Services', 'Special Collections'
     ]
 
     default_image = None


### PR DESCRIPTION
Closes #351 351

**Changes in this request**
- Removed `Cultural` from `Area & Cultural Studies`
- Grepped for other instances of `Cultural`