### PR TITLE
Added media parameter

### DIFF
--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -164,12 +164,14 @@ p {
   margin-left: 1em;
 }
 
-.columns {
-  display: flex;
-  padding: 0;
-  gap: 2em;
-  & .column {
-    flex: 1;
+@include respond-to(small) {
+  .columns {
+    display: flex;
+    padding: 0;
+    gap: 2em;
+    & .column {
+      flex: 1;
+    }
   }
 }
 

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -224,12 +224,16 @@ body.libnewspage .breadcrumbs, body.libnewsindexpage .breadcrumbs, .h1-banner .b
   margin-left: 1em;
 }
 
-.columns {
-  display: flex;
-  padding: 0;
-  gap: 2em;
-  & .column {
-    flex: 1;
+@include respond-to(small) {
+  .columns {
+    display: flex;
+    padding: 0;
+    .column {
+      flex: 1;
+    }
+  }
+  .column+.column {
+    margin-left: 1.5em; // workaround because gap is not supported in Safari
   }
 }
 


### PR DESCRIPTION
Closes #374 

**Changes in this request**
- Added media parameters so columsn only show up on horizontal tablet and above
- Fixed unsupported Safari flexbox item (gap)