### PR TITLE
News stories without excerpts blow up the news homepage

### DIFF
--- a/lib_news/models.py
+++ b/lib_news/models.py
@@ -6,7 +6,7 @@ from django.core.cache import cache, caches
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.template.response import TemplateResponse
-from django.utils import timezone
+from django.utils import text, timezone
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers
 from wagtail.admin.edit_handlers import (
@@ -401,7 +401,8 @@ class LibNewsPage(PublicBasePage):
         if self.excerpt:
             retval = self.excerpt
         else:
-            retval = self.body
+            html = str(self.body).replace('</p>', '</p> ')
+            retval = text.Truncator(html).words(100, html=True)
         # return retval
         return bleach.clean(
             retval,

--- a/lib_news/utils.py
+++ b/lib_news/utils.py
@@ -6,7 +6,7 @@ def get_first_feature_story():
         LibNewsPage object.
     """
     from .models import LibNewsPage
-    feature = LibNewsPage.objects.filter(
+    feature = LibNewsPage.objects.live().filter(
         is_feature_story=True
     ).order_by('-published_at').first()
     return feature


### PR DESCRIPTION
Fixes #387

**Changes in this request**
- Changes to the body fallback for, "short descriptions". If an excerpt is no longer present for a news story, short descriptions are created by truncating html from the news story body. This fallback will most likely never be used for an extended period of time in reality, since, this bug only appears to affect feature stories (that always have excerpts). In all likelihood this just protects the site while feature story author's are working on their stories. 
- Feature stories without excerpts no longer crash the news site homepage.
- The `get_first_feature_story` now only returns `live` published stories.

There are no migrations with this change set because the updates only affect a function that alters data after it leaves the database. It doesn't affect anything that is re-stored in the database.