### PR TITLE
Added year and comma, removed date suffixes

### DIFF
--- a/news/templates/news/news_page.html
+++ b/news/templates/news/news_page.html
@@ -17,7 +17,7 @@
             </div>
           {% endif %}
           <div class="media-body">
-            <p><span class="date">{{ self.story_date|date:'F jS' }}</span></p>
+            <p><span class="date">{{ self.story_date|date:'F j, Y' }}</span></p>
             <h1>{{ self.title }}</h1>
             {% news_author self %}
             {% for block in self.body %}


### PR DESCRIPTION
Closes #413

**Changes in this request**
To Loop news pages:
- Removed date suffixes (eg: -th, -nd) 
- Added comma after date
- Added year