### PR TITLE
Fix libguides ebook search

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -528,3 +528,5 @@ MARKLOGIC_BASE = "http://marklogic.lib.uchicago.edu"
 MARKLOGIC_FINDINGAIDS_PORT = 8011
 
 # "http://marklogic.lib.uchicago.edu:8011/admin/gimme.xqy?collection=institution%2FUniversity%20of%20Chicago")
+
+EBOOKS_SEARCH = 'https://catalog.lib.uchicago.edu/vufind/Search/Results?filter%5B%5D=format%3A%22Book%22&filter%5B%5D=format%3A%22E-Resource%22&type=AllFields&lookfor='

--- a/library_website/urls.py
+++ b/library_website/urls.py
@@ -13,7 +13,7 @@ from public.views import navigation as navigation_view
 from public.views import spaces as spaces_view
 from public.views import switchboard
 from results.views import results as results_view
-from search.views import loop_search as search_view
+from search.views import loop_search as search_view, ebooks_search
 from staff.views import staff, staff_api
 from units.views import units as unit_view
 from wagtail.admin import urls as wagtailadmin_urls
@@ -36,6 +36,7 @@ urlpatterns = [
     url(r'^results/$', results_view, name='results'),
     url(r'^ltdrfr/$', ltdrfr, name='ltdrfr'),
     url(r'^loop-search/$', search_view, name='search'),
+    url(r'^ebooks-search/$', ebooks_search, name='ebooks'),
     url(r'^api/v2/', api_router.urls),
     url('^inventory\.xml$', sitemap),
     # url(r'^spaces/$', spaces_view, name='spaces'),

--- a/search/views.py
+++ b/search/views.py
@@ -2,14 +2,30 @@ from base.wagtail_hooks import (
     get_required_groups, has_permission, redirect_users_without_permissions
 )
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.shortcuts import render
+from django.shortcuts import redirect, render
+from library_website.settings import EBOOKS_SEARCH
 from units.models import UnitIndexPage
 from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.core.models import Page, Site
 from wagtail.search.models import Query
 
 
+def ebooks_search(request):
+    """
+    View for processing a form submission and forwarding
+    a request to an ebooks search in the catalog.
+    """
+    if request.method == 'GET':
+        query = request.GET.get('q')
+        if not query:
+            query = '*'
+        return redirect(EBOOKS_SEARCH + query)
+
+
 def loop_search(request):
+    """
+    Loop search results.
+    """
     loop_homepage = Site.objects.get(site_name='Loop').root_page
     if not has_permission(request.user, get_required_groups(loop_homepage)):
         return redirect_users_without_permissions(


### PR DESCRIPTION
Fixes #415 

**Changes in this request**
- Adds a new view that takes a query and forwards it on as an ebooks search in the catalog.