### PR TITLE
Replaced staff directory tables with divs

### DIFF
--- a/base/static/base/css/_variables.scss
+++ b/base/static/base/css/_variables.scss
@@ -165,7 +165,7 @@ $divider: 1px solid $darkgray;
   position: absolute;
   width: 0;
   height: 0;
-  border-color: #642822 transparent transparent;
+  border-color: $darkred transparent transparent;
   border-style: solid;
   border-width: 11px;
   left: 50%;

--- a/base/static/base/css/sidebars.scss
+++ b/base/static/base/css/sidebars.scss
@@ -283,7 +283,7 @@ Right Sidebar: Widget Items
   li {
     margin-bottom: 0.5em;
   }
-  i {
+  i, .material-icons {
     padding-left: 1em;
   }
   .collectionpage & {

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -1813,16 +1813,15 @@ a.coll-access {
     @extend .distinct-list;
     padding: 1em;
     display: grid;
+    grid-gap: 1vw; //width of screen unit
     margin-right: -15px;
     margin-left: -15px;
     @include respond-to(small) {
       grid-template-columns: 1fr 1fr;
       grid-row-gap: 1em;
-      grid-gap: 1.5em;
     }
     @include respond-to(medium) {
       grid-template-columns: 100px 3fr 2fr 2fr;
-      grid-gap: 1.5em;
     }
     &:nth-child(odd) {
       background: #f6f6f6;
@@ -1835,6 +1834,12 @@ a.coll-access {
       font-size: 1.05em;
       margin-top: 0;
       margin-bottom: 0;
+    }
+    & p {
+      max-width: 200px;
+      @include respond-to(large) {
+        max-width: unset;
+      }
     }
     span[role=heading] {
       font-weight: 600;

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -796,9 +796,10 @@ figure.embed {
   padding: 5px 15px;
   border-radius: 0;
   &.active {
+    color: white;
+    background-color: $darkred;
     border-top: 2px solid $maroon;
     border-bottom: 2px solid $maroon;
-    color: $maroon;
     -webkit-box-shadow: none;
     box-shadow: none;   
     &:after {
@@ -806,11 +807,15 @@ figure.embed {
     }
   }
   &:hover {
-    border-top: 2px solid #d8b9b7;
-    border-bottom: 2px solid #d8b9b7;
-    color: $maroon;
+    border-top: 2px solid $maroon;
+    border-bottom: 2px solid $maroon;
     -webkit-box-shadow: none;
     box-shadow: none; 
+  }
+  &:focus {
+    box-shadow: 2px 2px 10px $crerarblue;
+    border-top: 2px solid $maroon;
+    border-bottom: 2px solid $maroon;
   }
 }
 
@@ -1041,40 +1046,52 @@ table.etable>tbody>tr {
 }
 
 .searchbox-input{
-    top:0;
-    right:0;
-    border:0;
-    outline:0;
-    background:#dcddd8;
-    width:100%;
-    height:30px;
-    margin:0;
-    padding:0px 55px 0px 20px;
-    font-size:1em;
-    color:$maroon;
+  top:0;
+  right:0;
+  border:0;
+  outline:0;
+  background:#dcddd8;
+  width:100%;
+  height:30px;
+  margin:0;
+  padding:0px 55px 0px 20px;
+  font-size:1em;
+  color:$maroon;
+  &:focus {
+    box-shadow: 2px 2px 10px $crerarblue;
+  }
 }
 
 .searchbox-icon,
 .searchbox-submit,
 .searchbox > input[type="submit"] {
-    content: "\f002";
-    width:30px;
-    height:30px;
-    display:block;
-    position:absolute;
-    top:0;
-    font-family:verdana;
-    font-size:1em;
-    right:0;
-    padding:0;
-    margin:0;
-    border:0;
-    outline:0;
-    line-height:30px;
-    text-align:center;
-    cursor:pointer;
-    color:#ddd;
-    background:$maroon;
+  content: "\f002";
+  width:30px;
+  height:30px;
+  display:block;
+  position:absolute;
+  top:0;
+  font-family:verdana;
+  font-size:1em;
+  right:0;
+  padding:0;
+  margin:0;
+  border:0;
+  outline:0;
+  line-height:30px;
+  text-align:center;
+  cursor:pointer;
+  color:#ddd;
+  background:$maroon;
+  &:hover {
+    color: black;
+    background-color: $hovercalmlight;
+  }
+  &:focus {
+    box-shadow: 0px 1px 5px $crerarblue;
+    color: black;
+    background-color: $hovercalmlight;
+  }
 }
 
 .byline{
@@ -1632,6 +1649,16 @@ td.time, td.event-nav {
  * --------------------------------------------------
  */
 
+ .btn-obvious {
+  &:hover {
+    background-color: $hovercalmlight;
+  }
+  &:focus {
+    box-shadow: 0px 1px 5px $crerarblue;
+    background-color: $hovercalmlight;
+  }
+ }
+
 .listings-dropdown {
   margin-top: 0;
   background-color: $hovercalm;
@@ -1766,34 +1793,11 @@ a.coll-access {
   }
 }
 
-.sdir-wrap {
-  @extend .news-wrap;
-  padding: 0;
-  h3 {
-    font-size: 1.1em;
-    margin-bottom: 0;
-  }
-  a, a:active, a:focus, a:hover {
-    color: $crerarblue;
-    text-decoration: underline;
-  }
-  .col-xs-12 {
-    padding-bottom: 1em;
-    margin-top: 1em;
-    @include respond-to(medium) {
-      &:nth-child(3n+2) {
-        border-right: 1px solid #eee;
-        border-left: 1px solid #eee;
-      }
-    }
-  }
-}
-
 .sdir {
   margin: 2em 0 0.25em 0;
   padding-left: 0;
   h2 {
-    font-family: "Cormorant Garamond", serif;
+    font-family: $accent-font;
     color: $reggreen;
     font-size: 1.3em;
     padding-left: 15px;
@@ -1805,8 +1809,44 @@ a.coll-access {
       text-decoration: none;
     }
   }
-  span {
-    padding-left: 15px;
+  article {
+    @extend .distinct-list;
+    padding-top: 1em;
+    padding-bottom: 1em;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-row-gap: 1em;
+    @include respond-to(small) {
+      grid-template-columns: 100px 2fr 1fr 1fr;
+      grid-gap: 1.5em;
+    }
+    &:nth-child(odd) {
+      background: #f6f6f6;
+    }
+    &+article {
+      border-top: 1px solid #D2CDCC;
+    }
+    h3 {
+      font-family: $base-font;
+      font-size: 1.05em;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    span[role=heading] {
+      font-weight: 600;
+      display: block;
+    }
+    .profile-image {
+      grid-row-start: 1;
+      grid-column-start: 1;
+      @include respond-to(small) {
+        padding-left: 0.55em;
+      }
+    }
+    ul {
+      padding-left: 0px;
+      list-style: none;
+    }
   }
 }
 

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -1811,13 +1811,17 @@ a.coll-access {
   }
   article {
     @extend .distinct-list;
-    padding-top: 1em;
-    padding-bottom: 1em;
+    padding: 1em;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-row-gap: 1em;
+    margin-right: -15px;
+    margin-left: -15px;
     @include respond-to(small) {
-      grid-template-columns: 100px 2fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr;
+      grid-row-gap: 1em;
+      grid-gap: 1.5em;
+    }
+    @include respond-to(medium) {
+      grid-template-columns: 100px 3fr 2fr 2fr;
       grid-gap: 1.5em;
     }
     &:nth-child(odd) {
@@ -1835,12 +1839,17 @@ a.coll-access {
     span[role=heading] {
       font-weight: 600;
       display: block;
+      padding-top: 1em;
+      @include respond-to(small) {
+        padding-top: 0;
+      }
     }
     .profile-image {
+      padding-bottom: 1em;
       grid-row-start: 1;
       grid-column-start: 1;
       @include respond-to(small) {
-        padding-left: 0.55em;
+        padding-bottom: 0;
       }
     }
     ul {

--- a/staff/templates/staff/staff_directory_listing.html
+++ b/staff/templates/staff/staff_directory_listing.html
@@ -3,39 +3,40 @@
 {% load wagtailimages_tags %}
 
 {% cache 86400 staff_directory_listing staff_page.cnetid %}
-  <tr>
-      <td scope="row">
-          {% if staff_page.profile_picture %}
-              {% image staff_page.profile_picture fill-100x100 %}
-          {% else %}
-              {% image default_image fill-100x100 %}
-          {% endif %}
-      </td>
-      <td>
-          <strong>{% staff_public_page_link staff_page %}</strong>
-          {% if staff_page.pronouns %}
-            <span class="pronouns-listing">{{ staff_page.pronouns }}</span>
-          {% endif %}
-          <p>
-            {{ staff_page.position_title }}<br/>
-            <a href=".?view=staff&amp;department={{ staff_page.staff_page_units.first.library_unit.get_full_name|urlencode }}">{{ staff_page.staff_page_units.first.library_unit.title }}</a><br/>
-          </p>
-      </td>
-      <td>
-          <strong>Contact</strong>
-          <br/>
-          {% staff_email_addresses staff_page %}
-          {% staff_faculty_exchanges_phone_numbers staff_page %}
-          {% staff_libcal_schedules staff_page %}
-      </td>
-      <td>
-          {% if staff_page.staff_subject_placements.all %}
-	      <strong>Subject Specialties</strong><br/>
-              {% staff_subjects staff_page %}
-          {% endif %}
-          {% if staff_page.libguide_url %}
-              <a href="{{ staff_page.libguide_url }}" class="guide-link"> Subject Guides</a>
-          {% endif %}
-      </td>
-  </tr>
+  <article>
+    <div>
+      <h3>{% staff_public_page_link staff_page %}</h3>
+      {% if staff_page.pronouns %}
+        <span class="pronouns-listing">{{ staff_page.pronouns }}</span>
+      {% endif %}
+      <p>
+        {{ staff_page.position_title }}<br/>
+        <a href=".?view=staff&amp;department={{ staff_page.staff_page_units.first.library_unit.get_full_name|urlencode }}">{{ staff_page.staff_page_units.first.library_unit.title }}</a><br/>
+      </p>
+    </div>
+    <div>
+      <span role="heading">Contact<span class="visually-hidden"> {{ staff_page.first_name }}</span></span>
+      {% staff_email_addresses staff_page %}
+      {% staff_faculty_exchanges_phone_numbers staff_page %}
+      {% staff_libcal_schedules staff_page %}
+    </div>
+    <div>
+      {% if staff_page.staff_subject_placements.all %}
+      <span role="heading"><span class="visually-hidden">{{ staff_page.first_name }}'s</span> Subject Specialties</span>
+      <ul>
+        {% staff_subjects staff_page %}
+      </ul>
+      {% endif %}
+      {% if staff_page.libguide_url %}
+          <a href="{{ staff_page.libguide_url }}" class="guide-link"> Subject Guides</a>
+      {% endif %}
+    </div>
+    <div class="profile-image">
+      {% if staff_page.profile_picture %}
+          {% image staff_page.profile_picture fill-100x100 %}
+      {% else %}
+          {% image default_image fill-100x100 %}
+      {% endif %}
+    </div>
+  </article>
 {% endcache %}

--- a/staff/templates/staff/staff_subjects.html
+++ b/staff/templates/staff/staff_subjects.html
@@ -1,3 +1,3 @@
 {% for subject in subjects %}
-  <a href="/collex/?view=subjects&amp;subject={{ subject|urlencode }}">{{ subject }}</a><br/>
+  <li><a href="/collex/?view=subjects&amp;subject={{ subject|urlencode }}">{{ subject }}</a></li>
 {% endfor %}

--- a/units/templates/units/unit_index_page.html
+++ b/units/templates/units/unit_index_page.html
@@ -35,7 +35,7 @@
 
     <section>
       {% if query %}
-        <div class="col-xs-12 sdir" style="padding-top: 0; margin-top: 0">
+        <div class="row sdir" style="padding-top: 0; margin-top: 0">
           <h2>Matching Departments</h2>
             {% for department in departments %}
               {% include "units/unit_directory_listing.html" %}
@@ -45,7 +45,7 @@
             {% endfor %}
         </div>
 
-        <div class="col-xs-12 sdir">
+        <div class="row sdir">
           <h2>Matching Staff</h2>
             {% for staff_page in staff_pages %}
               {% include "staff/staff_directory_listing.html" %}
@@ -57,7 +57,7 @@
         </div>
 
       {% elif view == 'staff' %} 
-        <div class="col-xs-12 sdir">
+        <div class="row sdir">
           <h2>
             {% if subject and library %}
                 {{ library }} {{ subject }} Staff

--- a/units/templates/units/unit_index_page.html
+++ b/units/templates/units/unit_index_page.html
@@ -7,96 +7,78 @@
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 
 {% block content %}
-	<article>
-    <div class="col-xs-12 col-md-9 centermain">
-      <div class="row">
-        <div class="col-xs-12">
-          <form action="." class="searchbox" method="GET">
-  	        <input name="query" placeholder="Search by name or department" required="required" type="search" aria-label="..." class="searchbox-input" value="{% if query %}{{ query }}{% endif %}"/>
-            <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
-              <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;">
-            </span>
-          </form>
-        </div>
- 
-        <div class="col-xs-12">
-          <div class="btn-group spaces-toggle">
-            <a class="btn btn-list-toggle{% if view == 'staff' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=staff">Staff</a>
-            <a class="btn btn-list-toggle{% if view == 'department' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=department">Departments</a>
-            <a class="btn btn-list-toggle{% if view == 'org' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=org">Org Chart</a>
-          </div><!-- /btn-group-->
-        </div><!-- / col-xs-12 col-sm-6 -->
-        {% if view == 'staff' %} 
-          {% include "units/browse_by_pulldowns.html" %}
-        {% endif %}
-      </div><!-- / row -->
+  <div class="col-xs-12 col-md-9 centermain">
+    <div class="row">
 
+      <div class="col-xs-12">
+        <form action="." class="searchbox" method="GET">
+	        <input name="query" placeholder="Search by name or department" required="required" type="search" aria-label="search by department or staff name" class="searchbox-input" value="{% if query %}{{ query }}{% endif %}"/>
+          <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
+            <input type="submit" class="searchbox-submit" role="button" aria-label="submit search" style="background-color: transparent; color: transparent;">
+          </span>
+        </form>
+      </div>
+ 
+      <div class="col-xs-12">
+        <div class="btn-group spaces-toggle">
+          <a class="btn btn-list-toggle{% if view == 'staff' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=staff">Staff</a>
+          <a class="btn btn-list-toggle{% if view == 'department' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=department">Departments</a>
+          <a class="btn btn-list-toggle{% if view == 'org' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=org">Org Chart</a>
+        </div><!-- /btn-group-->
+      </div>
+
+      {% if view == 'staff' %} 
+        {% include "units/browse_by_pulldowns.html" %}
+      {% endif %}
+
+    </div><!-- / row -->
+
+    <section>
       {% if query %}
         <div class="col-xs-12 sdir" style="padding-top: 0; margin-top: 0">
-          <h2><a href="#">Matching Departments</a></h2>
-          <div class="col-xs-12 sdir-wrap">
+          <h2>Matching Departments</h2>
             {% for department in departments %}
               {% include "units/unit_directory_listing.html" %}
             {% empty %}
               <p class="empty-state"><span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.</p>
               <span><a class="viewall" href=".?view=department">View all departments</a></span>
             {% endfor %}
-          </div>
         </div>
 
-        <table class="table table-striped directory-list">
-          <thead>
-            <tr class="sdir">
-              <td colspan="4">
-                <h2>Matching Staff</h2>
-              </td>
-            </tr>   
-          </thead>
-          <tbody>
+        <div class="col-xs-12 sdir">
+          <h2>Matching Staff</h2>
             {% for staff_page in staff_pages %}
               {% include "staff/staff_directory_listing.html" %}
             {% empty %}
-              <tr>
-                <td colspan="4">
-                  <p class="empty-state">
-                    <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
-                  </p>
-                </td>
-              </tr>
+            <p class="empty-state">
+              <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
+            </p>
             {% endfor %}
-          </tbody>
-        </table>
+        </div>
+
       {% elif view == 'staff' %} 
-        <table class="table table-striped directory-list">
-          <tbody>
-            <tr class="etable-header">
-              <td colspan="4">
-                {% if subject and library %}
-                    {{ library }} {{ subject }} Staff
-                {% elif subject and not library %}
-                    {{ subject }} Staff
-                {% elif not subject and library %}
-                    {{ library }} Staff
-                {% elif department %}
-                    {{ department }} Staff
-                {% else %}
-                    All Staff
-                {% endif %}
-              </td>
-            </tr>
+        <div class="col-xs-12 sdir">
+          <h2>
+            {% if subject and library %}
+                {{ library }} {{ subject }} Staff
+            {% elif subject and not library %}
+                {{ subject }} Staff
+            {% elif not subject and library %}
+                {{ library }} Staff
+            {% elif department %}
+                {{ department }} Staff
+            {% else %}
+                All Staff
+            {% endif %}
+          </h2>
             {% for staff_page in staff_pages %}
               {% include "staff/staff_directory_listing.html" %}
             {% empty %}
-              <tr>
-                <td colspan="4">
-                  <p class="empty-state">
-                    <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
-                  </p>
-                </td>
-              </tr>
+              <p class="empty-state">
+                <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
+              </p>
             {% endfor %}
-          </tbody>
-        </table>
+          </div>
       {% elif view == 'department' %}
         {% cache 86400 department_directory_list %}
           {% include "units/unit_division_listing.html" %}
@@ -108,7 +90,8 @@
           {% endif %}
         </div>
       {% endif %}
-    </div><!--/centermain-->
+    </section>
+  </div><!--/centermain-->
 
     <div class="col-xs-12 col-md-3 rightside" role="complementary"><!-- Right Sidebar Content -->
       <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
@@ -123,14 +106,13 @@
       <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
         <h2>Ask A Librarian</h2>
         <ul>
-          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/"><i class="fa fa-comments-o fa-1x" aria-hidden="true"></i> Chat</a></li>
-          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/ask-contact/"><span class="material-icons ask-icons" aria-hidden="true">mail_outline</span> Email</a></li>
+          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/"><i class="fa fa-comments-o fa-1x" aria-hidden="true"></i> Chat <span class="visually-hidden">with a Librarian</span></a></li>
+          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/ask-contact/"><span class="material-icons ask-icons" aria-hidden="true">mail_outline</span> Email <span class="visually-hidden">a Librarian for help</span></a></li>
 <!--           <li style="margin-bottom: 0.5em;"><a href="tel:773-702-4685"><span class="material-icons ask-icon" aria-hidden="true">phone</span>773-702-4685</a></li> -->          
-          <li><a href="sms:773-825-6777"><span class="material-icons ask-icon" aria-hidden="true">textsms</span> 773-825-6777 (text)</a></li>
-          <li><a href="https://www.lib.uchicago.edu/libraries/libraries-hours/"><span class="material-icons ask-icon" aria-hidden="true">location_on</span> Visit</a></li>
+          <li><a href="sms:773-825-6777"><span class="material-icons ask-icon" aria-hidden="true">textsms</span> <span class="visually-hidden">Send a text for Library help to: </span>773-825-6777 (text)</a></li>
+          <li><a href="https://www.lib.uchicago.edu/libraries/libraries-hours/"><span class="material-icons ask-icon" aria-hidden="true">location_on</span> Visit <span class="visually-hidden">our locations</span></a></li>
         </ul>
       </div>
     </div>
-	</article>
 {% endblock %}
 

--- a/units/templates/units/unit_index_page.html
+++ b/units/templates/units/unit_index_page.html
@@ -21,9 +21,9 @@
  
       <div class="col-xs-12">
         <div class="btn-group spaces-toggle">
-          <a class="btn btn-list-toggle{% if view == 'staff' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=staff">Staff</a>
-          <a class="btn btn-list-toggle{% if view == 'department' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=department">Departments</a>
-          <a class="btn btn-list-toggle{% if view == 'org' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=org">Org Chart</a>
+          <a {% if view == 'staff' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'staff' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=staff">Staff</a>
+          <a {% if view == 'department' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'department' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=department">Departments</a>
+          <a {% if view == 'org' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'org' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=org">Org Chart</a>
         </div><!-- /btn-group-->
       </div>
 


### PR DESCRIPTION
Closes #327

**Changes in this request**
Please review original detailed ticket for problem code examples.
- Added descriptive `aria-label` to search box input
- Added `aria-label` to search box button
- Added hover and focus styling  to search button, directory toggle menu, and drop downs
- Added `aria-current="page"` to menu toggle (PLEASE DOUBLE CHECK)
- Added focus styling to search input
- Removed table from directory listing and restructured as divs
- Structurally placed staff image last and placed staff name in `h3` so this is properly read by a screen reader
- Added header tags and descriptive `aria-label` to subheadings per staff entry
- Added descriptive `aria-label` to sidebar Ask a Librarian links

**Question**
Please pay extra attention to the `{% if view == 'staff' %}aria-current="page"{% endif %} ` part of the directory toggle menu. This shows up oddly in my code editor but does not error out on my local machine.