### PR TITLE
Move front page browse-search options from Javascript into Django

### DIFF
--- a/base/static/base/js/library_website.js
+++ b/base/static/base/js/library_website.js
@@ -152,32 +152,6 @@ $(document).ready(function(){
         $(this).closest('form').submit();
     });
 
-    /*
-     * Search Widget, Catalog search, Begins-With searches.
-     */
-
-    // If this script is running (i.e., JavaScript is enabled) add dropdown elements for browses. 
-    $('#search_widget_catalog_search').each(function() {
-        var select = $(this).find('select[name="type"]');
-        select.append('<option value="browse_title">Title begins with</option><option value="browse_journal">Journal begins with</option><option value="browse_lcc">Call Number begins with</option>');
-    });
-
-    // Modify browses before the form is submitted.
-    $('#search_widget_catalog_search').submit(function() {
-        // If the field pulldown's value begins with "browse_"...
-        var type = $(this).find('select[name="type"]').val();
-        if (type.substring(0, 7) == 'browse_') {
-            // Make a new hidden element called "source" for everything after "browse_". 
-            $('#search_widget_catalog_search').append('<input name="source" type="hidden" value="' + type.substring(7) + '"/>');
-            // Remove the original "type" element.
-            $(this).find('select[name="type"]').remove();
-            // Change the name of the text input from "lookfor" to "from". 
-            $(this).find('input[name="lookfor"]').attr('name', 'from');
-            // Change the action of the form so it points to the browse result pages. 
-            $(this).attr('action', 'https://catalog.lib.uchicago.edu/vufind/Alphabrowse/Home');
-        }
-    });
-
     // Render events widget html in the right sidebar
     renderEvents();
 

--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -24,6 +24,9 @@
             <option value="Author">Author</option>
             <option value="JournalTitle">Journal Title</option>
             <option value="StandardNumbers">ISBN, ISSN, etc.</option>
+	    <option value="browse_title">Title begins with</option>
+	    <option value="browse_journal">Journal begins with</option>
+	    <option value="browse_lcc">Call Number begins with</option>
           </select>
         </div> <!-- // Input Group -->
       </div> <!-- // Text Search Field --> 

--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -18,15 +18,15 @@
 	  <input type="hidden" name="which-form" value="catalog">
 	  {% csrf_token %}
           <select class="selectpicker btn-searchtype" aria-label="Limit search to" name="type">
-	    <option value="AllFields">All Fields</option>
-	    <option value="Title">Title</option>
-	    <option value="Subject">Subject</option>
-	    <option value="Author">Author</option>
-	    <option value="JournalTitle">Journal Title</option>
-	    <option value="StandardNumbers">ISBN, ISSN, etc.</option>
-	    <option value="browse_title">Title begins with</option>
-	    <option value="browse_journal">Journal begins with</option>
-	    <option value="browse_lcc">Call Number begins with</option>
+	      <option value="AllFields">All Fields</option>
+	      <option value="Title">Title</option>
+	      <option value="Subject">Subject</option>
+	      <option value="Author">Author</option>
+	      <option value="JournalTitle">Journal Title</option>
+	      <option value="StandardNumbers">ISBN, ISSN, etc.</option>
+	      <option value="browse_title">Title begins with</option>
+	      <option value="browse_journal">Journal begins with</option>
+	      <option value="browse_lcc">Call Number begins with</option>
           </select>
         </div> <!-- // Input Group -->
       </div> <!-- // Text Search Field --> 

--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -18,12 +18,12 @@
 	  <input type="hidden" name="which-form" value="catalog">
 	  {% csrf_token %}
           <select class="selectpicker btn-searchtype" aria-label="Limit search to" name="type">
-            <option value="AllFields">All Fields</option>
-            <option value="Title">Title</option>
-            <option value="Subject">Subject</option>
-            <option value="Author">Author</option>
-            <option value="JournalTitle">Journal Title</option>
-            <option value="StandardNumbers">ISBN, ISSN, etc.</option>
+	    <option value="AllFields">All Fields</option>
+	    <option value="Title">Title</option>
+	    <option value="Subject">Subject</option>
+	    <option value="Author">Author</option>
+	    <option value="JournalTitle">Journal Title</option>
+	    <option value="StandardNumbers">ISBN, ISSN, etc.</option>
 	    <option value="browse_title">Title begins with</option>
 	    <option value="browse_journal">Journal begins with</option>
 	    <option value="browse_lcc">Call Number begins with</option>

--- a/public/utils.py
+++ b/public/utils.py
@@ -224,7 +224,7 @@ def get_first_param(request):
         return None
 
 
-def switchboard_url(form_name):
+def switchboard_url(form_name, form_option=''):
     """
     Map the name of each search form to the base URL used for the
     relevant search
@@ -235,7 +235,12 @@ def switchboard_url(form_name):
     Returns:
         the URL to post to for the relevant search box
     """
-    if form_name == 'catalog':
+
+    browse_options = ['browse_title', 'browse_journal', 'browse_lcc']
+
+    if form_name == 'catalog' and form_option in browse_options:
+        return "https://catalog.lib.uchicago.edu/vufind/Alphabrowse/Home"
+    elif form_name == 'catalog':
         return 'https://catalog.lib.uchicago.edu/vufind/Search/Results'
     elif form_name == 'articles':
         url = (

--- a/public/views.py
+++ b/public/views.py
@@ -89,17 +89,14 @@ def switchboard(request):
         if form == 'articles':
             # add a 'bquery' parameter to make the ebscohost API happy
             params['bquery'] = search_term
-            query_string = parse.urlencode(params)
         elif form == 'catalog' and params['type'] in browse_options:
             params['from'] = params['lookfor']
             del params['lookfor']
             params['source'] = trim(params['type'])
-            query_string = parse.urlencode(params)
         else:
             pass
 
         url_prefix = switchboard_url(form, form_option=params['type'])
-        del params['type']
         del params['which-form']
         query_string = parse.urlencode(params)
         url = f'{url_prefix}?{query_string}'

--- a/public/views.py
+++ b/public/views.py
@@ -86,18 +86,20 @@ def switchboard(request):
     else:
         # otherwise: pass query string along to wherever it was going
         form = params['which-form']
+        p_type = params['type']
         if form == 'articles':
             # add a 'bquery' parameter to make the ebscohost API happy
             params['bquery'] = search_term
-        elif form == 'catalog' and params['type'] in browse_options:
+        elif form == 'catalog' and p_type in browse_options:
             params['from'] = params['lookfor']
             del params['lookfor']
-            params['source'] = trim(params['type'])
+            params['source'] = trim(p_type)
+            del params['type']
         else:
             pass
 
         try:
-            formtype = params["type"]
+            formtype = p_type
         except KeyError:
             formtype = ''
 

--- a/public/views.py
+++ b/public/views.py
@@ -62,7 +62,7 @@ def switchboard(request):
     note: this code assumes that the first parameter posted by the
     search box is the search term
 
-    Args: 
+    Args:
         a POST request
 
     Returns:
@@ -86,22 +86,22 @@ def switchboard(request):
     else:
         # otherwise: pass query string along to wherever it was going
         form = params['which-form']
-        p_type = params['type']
+
+        try:
+            formtype = params['type']
+        except KeyError:
+            formtype = ''
+
         if form == 'articles':
             # add a 'bquery' parameter to make the ebscohost API happy
             params['bquery'] = search_term
-        elif form == 'catalog' and p_type in browse_options:
+        elif form == 'catalog' and formtype in browse_options:
             params['from'] = params['lookfor']
             del params['lookfor']
-            params['source'] = trim(p_type)
+            params['source'] = trim(formtype)
             del params['type']
         else:
             pass
-
-        try:
-            formtype = p_type
-        except KeyError:
-            formtype = ''
 
         url_prefix = switchboard_url(form, form_option=formtype)
         del params['which-form']

--- a/public/views.py
+++ b/public/views.py
@@ -96,7 +96,12 @@ def switchboard(request):
         else:
             pass
 
-        url_prefix = switchboard_url(form, form_option=params['type'])
+        try:
+            formtype = params["type"]
+        except KeyError:
+            formtype = ''
+
+        url_prefix = switchboard_url(form, form_option=formtype)
         del params['which-form']
         query_string = parse.urlencode(params)
         url = f'{url_prefix}?{query_string}'


### PR DESCRIPTION
Fixes #434.

Previously, 'begins with' browse searches from the main search bar were being modified by Javascript so as to be compatible with VuFind's expectations.  But that Javascript wasn't updated to fit with what the DOI hijacker is doing.  This pull request has the DOI hijacker rather than the Javascript prep the home page search box to send those 'begins with' queries off to VuFind.