### PR TITLE
Added styling to Loop staff directory

### DIFF
--- a/base/static/base/css/_variables.scss
+++ b/base/static/base/css/_variables.scss
@@ -36,7 +36,6 @@ $font-large: 2.5em;
 $font-medium: 1.5em;
 $font-small: 1.1em;
 
-//For Collex (Collections and Exhibits)
 $base-font: 'Helvetica Neue',Helvetica,Arial,sans-serif;
 $accent-font: 'Cormorant Garamond', serif;
 

--- a/base/static/base/css/loop-navigation.css
+++ b/base/static/base/css/loop-navigation.css
@@ -11,6 +11,13 @@ Footer
  * Accessibility
  * --------------------------------------------------
  */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px); }
+
 /*
  * Colors
  * --------------------------------------------------

--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -17,6 +17,13 @@ Group Home Page
  * Accessibility
  * --------------------------------------------------
  */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px); }
+
 /*
  * Colors
  * --------------------------------------------------
@@ -384,11 +391,14 @@ input[type=checkbox], input[type=radio] {
 
 .staff-headers .pronouns {
   color: #575757;
-  font-size: 0.9em;
+  font-size: 0.95em;
   padding-left: 0.25em; }
 
 .staff-headers h2 {
   margin-top: 0; }
+
+.pronouns-listing {
+  color: #525252; }
 
 .bg-directory {
   padding: 15px 0 15px 0;
@@ -433,6 +443,65 @@ select {
   .btn-directory:hover, .btn-directory.active {
     color: #fff;
     background-color: #ADB17D; }
+
+.sdir {
+  margin: 2em 0 0.25em 0;
+  padding-left: 0; }
+  .sdir h2 {
+    font-family: "Cormorant Garamond", serif;
+    color: #616530;
+    font-size: 1.3em;
+    padding-left: 15px;
+    margin-right: 2em;
+    margin-bottom: 0.25em;
+    border-bottom: 2px solid #ADB17D; }
+    .sdir h2 a, .sdir h2 a:active, .sdir h2 a:focus, .sdir h2 a:hover {
+      color: #525252;
+      text-decoration: none; }
+  .sdir article {
+    padding: 1em;
+    display: grid;
+    grid-gap: 1vw;
+    margin-right: -15px;
+    margin-left: -15px; }
+    @media (min-width: 48em) {
+      .sdir article {
+        grid-template-columns: 1fr 1fr;
+        grid-row-gap: 1em; } }
+    @media (min-width: 62em) {
+      .sdir article {
+        grid-template-columns: 100px 3fr 2fr 2fr; } }
+    .sdir article:nth-child(odd) {
+      background: #f6f6f6; }
+    .sdir article + article {
+      border-top: 1px solid #D2CDCC; }
+    .sdir article h3 {
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 1.05em;
+      margin-top: 0;
+      margin-bottom: 0; }
+    .sdir article p {
+      max-width: 200px; }
+      @media (min-width: 75em) {
+        .sdir article p {
+          max-width: unset; } }
+    .sdir article span[role=heading] {
+      font-weight: 600;
+      display: block;
+      padding-top: 1em; }
+      @media (min-width: 48em) {
+        .sdir article span[role=heading] {
+          padding-top: 0; } }
+    .sdir article .profile-image {
+      padding-bottom: 1em;
+      grid-row-start: 1;
+      grid-column-start: 1; }
+      @media (min-width: 48em) {
+        .sdir article .profile-image {
+          padding-bottom: 0; } }
+    .sdir article ul {
+      padding-left: 0px;
+      list-style: none; }
 
 /*
  *  Tables

--- a/base/static/base/css/loop/_loop-variables.scss
+++ b/base/static/base/css/loop/_loop-variables.scss
@@ -1,3 +1,6 @@
+$base-font: 'Helvetica Neue',Helvetica,Arial,sans-serif;
+$accent-font: 'Cormorant Garamond', serif;
+
 /*
  * Accessibility
  * --------------------------------------------------
@@ -11,12 +14,20 @@
   clip: rect(1px, 1px, 1px, 1px);
 }
 
+.visually-hidden { // For ADA helper text
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+}
 
 /*
  * Colors
  * --------------------------------------------------
  */
 
+$mid-dark: #525252;
 $darkgray: #767676;
 $darkergray: #434343;
 $darkeraccent: #666A35;

--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -531,6 +531,76 @@ select {
     }
 }
 
+.sdir {
+  margin: 2em 0 0.25em 0;
+  padding-left: 0;
+  h2 {
+    font-family: $accent-font;
+    color: #616530;
+    font-size: 1.3em;
+    padding-left: 15px;
+    margin-right: 2em;
+    margin-bottom: 0.25em;
+    border-bottom: 2px solid #ADB17D;
+      a, a:active, a:focus, a:hover {
+      color: $mid-dark;
+      text-decoration: none;
+    }
+  }
+  article {
+    padding: 1em;
+    display: grid;
+    grid-gap: 1vw; //width of screen unit
+    margin-right: -15px;
+    margin-left: -15px;
+    @include respond-to(small) {
+      grid-template-columns: 1fr 1fr;
+      grid-row-gap: 1em;
+    }
+    @include respond-to(medium) {
+      grid-template-columns: 100px 3fr 2fr 2fr;
+    }
+    &:nth-child(odd) {
+      background: #f6f6f6;
+    }
+    &+article {
+      border-top: 1px solid #D2CDCC;
+    }
+    h3 {
+      font-family: $base-font;
+      font-size: 1.05em;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    & p {
+      max-width: 200px;
+      @include respond-to(large) {
+        max-width: unset;
+      }
+    }
+    span[role=heading] {
+      font-weight: 600;
+      display: block;
+      padding-top: 1em;
+      @include respond-to(small) {
+        padding-top: 0;
+      }
+    }
+    .profile-image {
+      padding-bottom: 1em;
+      grid-row-start: 1;
+      grid-column-start: 1;
+      @include respond-to(small) {
+        padding-bottom: 0;
+      }
+    }
+    ul {
+      padding-left: 0px;
+      list-style: none;
+    }
+  }
+}
+
 /*
  *  Tables
  * --------------------------------------------------

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base/public_base.html" %}
 
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 

--- a/intranethome/templates/intranethome/unit_page.html
+++ b/intranethome/templates/intranethome/unit_page.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base/intranet_base.html" %}
 {% load wagtailcore_tags %}
 
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}

--- a/library_website/settings/dev.py
+++ b/library_website/settings/dev.py
@@ -1,6 +1,5 @@
 from .base import *
 
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 TEMPLATES[0]['OPTIONS']['debug'] = True
@@ -22,7 +21,6 @@ try:
     from .local import *
 except ImportError:
     pass
-
 
 # Travis CI specific settings
 if 'TRAVIS' in os.environ:

--- a/library_website/templates/404.html
+++ b/library_website/templates/404.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base/public_base.html" %}
 
 {% block body_class %}template-404{% endblock %}
 

--- a/staff/templates/staff/staff_index_page.html
+++ b/staff/templates/staff/staff_index_page.html
@@ -9,48 +9,50 @@
 
 {% block content %}
 	<p><a href="/">Home</a></p>
-    <div class="row">
-        <div class="col-sm-12 col-md-12">
-        	<article>
-                <form action="." method="GET">
-                    <div class="row bg-directory"><h1 class="dir-header">Library Directory</h1>
-                        <div class="btn-group">
-                            <a style="padding: 5px 15px;" class="btn btn-directory{% if view == 'department' %} active{% endif %}" href=".?view=department">Department View</a>
-                            <a style="padding: 5px 15px;" class="btn btn-directory{% if view == 'staff' %} active{% endif %}" href=".?view=staff">Staff View</a>
-                        </div>
-                    </div><!--/row-->
-                    <div class="row">
-                        <div class="col-xs-12 col-xm-12 col-md-7 bg-filter">
-                            {% if view == 'staff' %} 
-                                <div class="dir-subheader">Browse</div>
-                                <div class="btn-group bg-filter">
-                                    <button style="padding: 5px 15px;" class="btn btn-directory" type="button">{% if library %}{{ library }}{% else %}Library{% endif %}</button>
-                                    <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" style="padding: 5px 10px;" class="btn btn-directory dropdown-toggle" type="button">
-                                        <span class="caret"></span>
-                                        <span class="sr-only">Toggle Dropdown</span>
-                                    </button>
-                                    <ul class="dropdown-menu">
-                                        <li><a href=".{% if query %}?query={{ query|urlencode }}{% endif %}">All Libraries</a></li>
-                                        {% for l in libraries %}
-                                            <li><a href=".?library={{ l|urlencode }}{% if query %}&query={{ query|urlencode }}{% endif %}">{{ l }}</a></li>
-                                        {% endfor %}
-                                    </ul>
-                                </div>
-                            {% endif %}
-                        </div><!--col-->
-                        <div class="col-xs-12 col-xm-12 col-md-5 bg-filter"> <!-- Directory Search -->
-                            <div class="col-md-2 dir-subheader">Search</div>
-                                <div class="input-group">
-                                    <input name="query" type="text" placeholder="{% if view == 'staff' %}professor snape{% else %}potions department{% endif %}" aria-label="..." class="form-control" value="{% if query %}{{ query }}{% endif %}"/>
-                                    {% if view == 'department' %}<input name="view" type="hidden" value="department"/>{% endif %}
-                                    {% if library %}<input name="library" type="hidden" value="{{ library }}"/>{% endif %}
-                                    <div class="input-group-btn">
-                                        <input class="btn btn-searchtype btn-default" type="submit" value="Find" />
-                                    </div><!-- /btn-group -->
-                                </div><!-- /input-group -->
-                            </div><!--/col-->
-                        </div><!--/row-->
-                        <hr/>
+        <div class="col-xs-12">
+          <form action="." method="GET">
+
+              <div class="row bg-directory">
+                <h1 class="dir-header">Library Directory</h1>
+                <div class="btn-group">
+                    <a style="padding: 5px 15px;" class="btn btn-directory{% if view == 'department' %} active{% endif %}" href=".?view=department">Department View</a>
+                    <a style="padding: 5px 15px;" class="btn btn-directory{% if view == 'staff' %} active{% endif %}" href=".?view=staff">Staff View</a>
+                </div>
+              </div><!--// bg-directory-->
+
+              <div class="row">
+                <div class="col-xs-12 col-md-7 bg-filter">
+                  {% if view == 'staff' %} 
+                    <div class="dir-subheader">Browse</div>
+                    <div class="btn-group bg-filter">
+                        <button style="padding: 5px 15px;" class="btn btn-directory" type="button">{% if library %}{{ library }}{% else %}Library{% endif %}</button>
+                        <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" style="padding: 5px 10px;" class="btn btn-directory dropdown-toggle" type="button">
+                            <span class="caret"></span>
+                            <span class="sr-only">Toggle Dropdown</span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li><a href=".{% if query %}?query={{ query|urlencode }}{% endif %}">All Libraries</a></li>
+                            {% for l in libraries %}
+                                <li><a href=".?library={{ l|urlencode }}{% if query %}&query={{ query|urlencode }}{% endif %}">{{ l }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                  {% endif %}
+                  </div><!--// bg-filter-->
+
+                  <div class="col-xs-12 col-md-5 bg-filter"> <!-- Directory Search -->
+                      <div class="col-md-2 dir-subheader">Search</div>
+                          <div class="input-group">
+                              <input name="query" type="text" placeholder="{% if view == 'staff' %}professor snape{% else %}potions department{% endif %}" aria-label="..." class="form-control" value="{% if query %}{{ query }}{% endif %}"/>
+                              {% if view == 'department' %}<input name="view" type="hidden" value="department"/>{% endif %}
+                              {% if library %}<input name="library" type="hidden" value="{{ library }}"/>{% endif %}
+                              <div class="input-group-btn">
+                                  <input class="btn btn-searchtype btn-default" type="submit" value="Find" />
+                              </div><!-- /btn-group -->
+                          </div><!-- /input-group -->
+                      </div><!--/col-->
+                  </div><!--/row-->
+                  <hr/>
     
                     {% if view == 'department' and not query %}
                         <div class="row">
@@ -65,66 +67,41 @@
                 </form>
      
                 {% if view == 'staff' %} 
-                  <table class="table table-striped directory-list">
-                    <thead>
-                      <tr class="etable-header">
-                        <td colspan="4">
-                          {% if subject and library %}
-                              {{ library }} {{ subject }} Staff
-                          {% elif subject and not library %}
-                              {{ subject }} Staff
-                          {% elif not subject and library %}
-                              {{ library }} Staff
-                          {% elif department %}
-                              {{ department }} Staff
-                          {% else %}
-                              All Staff
-                          {% endif %}
-                        </td>
-                      </tr>
-                    </thead>
-                      <tbody>
-                        <tr class="visually-hidden">
-                          <th scope="col">Staff Photo</th>
-                          <th scope="col">Staff name and title</th>
-                          <th scope="col">Contact</th>
-                          <th scope="col">Subjects</th>
-                        </tr>
-                      {% for staff_page in staff_pages %}
-                        {% include "staff/staff_directory_listing.html" %}
-                      {% empty %}
-                        <tr>
-                          <td colspan="4">
-                            <p class="empty-state">
-                              <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
-                            </p>
-                          </td>
-                        </tr>
-                      {% endfor %}
-                    </tbody>
-                  </table>
+                  <div class="row sdir">
+                    <h2>
+                      {% if subject and library %}
+                          {{ library }} {{ subject }} Staff
+                      {% elif subject and not library %}
+                          {{ subject }} Staff
+                      {% elif not subject and library %}
+                          {{ library }} Staff
+                      {% elif department %}
+                          {{ department }} Staff
+                      {% else %}
+                          All Staff
+                      {% endif %}
+                    </h2>
+                  {% for staff_page in staff_pages %}
+                    {% include "staff/staff_directory_listing.html" %}
+                  {% empty %}
+                    <p class="empty-state">
+                      <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
+                    </p>
+                  {% endfor %}
+                  </div>
                 {% elif view == 'department' %}
                     {# intranetunits_html|safe #}
                     <table class="table table-striped">
                         {% for i in flat_intranet_units %}
-                            <tr>
-                                <td><a href="{{ i.url }}">{{ i.title }}</a></td>
-                                <td>{{ i.internal_phone_number }}</td>
-                                <td>{% if i.library %}{{ i.library }}<br/>{% endif %}{{ i.internal_location }}</td>
-                            </tr>
+                          <tr>
+                              <td><a href="{{ i.url }}">{{ i.title }}</a></td>
+                              <td>{{ i.internal_phone_number }}</td>
+                              <td>{% if i.library %}{{ i.library }}<br/>{% endif %}{{ i.internal_location }}</td>
+                          </tr>
                         {% endfor %}
                     </table>
                 {% endif %}
-                <p>&nbsp;</p>
-                <p>&nbsp;</p>
-                <p>&nbsp;</p>
-                <p>&nbsp;</p>
-                <p>&nbsp;</p>
-                <p>&nbsp;</p>
-                <p>&nbsp;</p>
-        	</article>
         </div><!--/col-->
-    </div><!--/row-->
     <script type="text/javascript">
     var subjects = [
         {% for s in subjects %}'{{ s }}',{% endfor %}


### PR DESCRIPTION
closes #450

**Changes in this request**
- Added styling and removed tables from Loop staff directory
- Added correct base.html files for extending templates

**Possible issue uncovered**
- Able to view the Loop view of the staff directory at https://www.lib.uchicago.edu/staff/
- This view, along with the "No Permission" page come up as an ADA error for not having language assigned to it. Was not able to find the "No Permission" file.
