### PR TITLE
Removed name requirements for reports pages

### DIFF
--- a/group/models.py
+++ b/group/models.py
@@ -475,13 +475,6 @@ class GroupReportsIndexPage(BasePage):
     content_panels = Page.content_panels + BasePage.content_panels
     subpage_types = ['group.GroupReportsPage']
 
-    def clean(self):
-        """
-        Make sure page titles adhere to strict
-        formatting policy.
-        """
-        enforce_name_as_reports(self.title)
-
     def get_context(self, request):
         """
         Get reports from children.
@@ -519,13 +512,6 @@ class GroupReportsPage(BasePage):
     ]
 
     subpage_types = ['base.IntranetPlainPage']
-
-    def clean(self):
-        """
-        Make sure page titles adhere to strict
-        formatting policy.
-        """
-        enforce_name_as_year(self.title)
 
     def get_context(self, request):
         """

--- a/group/models.py
+++ b/group/models.py
@@ -67,16 +67,6 @@ def enforce_name_as_year(title):
         )
 
 
-def enforce_name_as_reports(title):
-    """
-    Helper function for making sure
-    page titles adhere to a strict
-    formatting policy.
-    """
-    if not title.strip() == "Reports":
-        raise ValidationError({'title': ('The title should be "Reports"')})
-
-
 def get_page_objects_grouped_by_date(obj):
     """
     Helper function for getting page objects and

--- a/intranetunits/models.py
+++ b/intranetunits/models.py
@@ -38,13 +38,6 @@ class IntranetUnitsReportsIndexPage(BasePage):
     content_panels = Page.content_panels + BasePage.content_panels
     subpage_types = ['intranetunits.IntranetUnitsReportsPage']
 
-    def clean(self):
-        """
-        Make sure page titles adhere to strict
-        formatting policy.
-        """
-        enforce_name_as_reports(self.title)
-
     def get_context(self, request):
         """
         Get reports from children.
@@ -58,7 +51,8 @@ class IntranetUnitsReportsIndexPage(BasePage):
         data = []
         for page in year_pages:
             year_title = page.title
-            year_reports = page.intranetunitsreportspage.get_reports_grouped_by_date()
+            year_reports = page.intranetunitsreportspage.get_reports_grouped_by_date(
+            )
             data.append((year_title, year_reports))
 
         context['data'] = data
@@ -71,18 +65,13 @@ class IntranetUnitsReportsPage(BasePage):
     ] + BasePage.content_panels
 
     search_fields = BasePage.search_fields + [
-        index.SearchField('get_report_summaries_for_indexing', partial_match=True),
-        index.SearchField('get_report_doc_links_for_indexing', partial_match=True),
+        index.
+        SearchField('get_report_summaries_for_indexing', partial_match=True),
+        index.
+        SearchField('get_report_doc_links_for_indexing', partial_match=True),
     ]
 
     subpage_types = ['base.IntranetPlainPage']
-
-    def clean(self):
-        """
-        Make sure page titles adhere to strict
-        formatting policy.
-        """
-        enforce_name_as_year(self.title)
 
     def get_context(self, request):
         """
@@ -277,9 +266,7 @@ class IntranetUnitsPage(BasePage, Email, PhoneNumber):
                 except AttributeError:
                     email = None
                 phone_numbers = staff_page.staff_page_phone_faculty_exchange.all(
-                ).values_list(
-                    'phone_number', flat=True
-                )
+                ).values_list('phone_number', flat=True)
                 titles = [staff_page.position_title]
 
                 department_members.append(

--- a/intranetunits/models.py
+++ b/intranetunits/models.py
@@ -10,8 +10,7 @@ from wagtail.search import index
 from base.models import BasePage, DefaultBodyFields, Email, PhoneNumber, Report
 from base.utils import get_doc_titles_for_indexing, get_field_for_indexing
 from group.models import (
-    enforce_name_as_reports, enforce_name_as_year, get_page_objects_as_list,
-    get_page_objects_grouped_by_date
+    get_page_objects_as_list, get_page_objects_grouped_by_date
 )
 from staff.models import StaffPage
 


### PR DESCRIPTION
Closes #481 

**Changes in this request**
- Removed name requirement of "Reports" from `GroupReportsIndexPage` and `IntranetUnitsReportsIndexPage`
- Removed name requirement of Year from `GroupReportsPage` and `IntranetUnitsReportsPage` 