### PR TITLE
Add permissions check to staff view

### DIFF
--- a/staff/views.py
+++ b/staff/views.py
@@ -4,7 +4,7 @@ from base.wagtail_hooks import (
 from django.db.models import Q
 from django.shortcuts import render
 from django.core.exceptions import PermissionDenied
-from django.http import JsonResponse, HttpResponse
+from django.http import JsonResponse
 from intranetunits.models import IntranetUnitsIndexPage, IntranetUnitsPage
 from public.models import LocationPage
 from subjects.models import Subject


### PR DESCRIPTION
Fixes #486.

**Changes in this request**
Add a simple check to staff/views.py to make sure user is authenticated before trying to view Loop staff page.  Follows same approach we used to deal with #391.