### PR TITLE
Added ADA changes to directory and Loop

### DIFF
--- a/base/static/base/css/_variables.scss
+++ b/base/static/base/css/_variables.scss
@@ -46,6 +46,7 @@ $accent-font: 'Cormorant Garamond', serif;
  */
 
 $default-link: #2A5DB0;
+$dark-link: #487286;
 
 // Unv Color Palette
 
@@ -62,7 +63,7 @@ $ssaorange: #9A5324;
 
 // Palette Variations
 
-$mid-dark: #525252;
+$mid-dark: #494949; //#525252
 $darkneutral: #7B4943;
 $midneutral: #D2CDCC;
 $neutral: #e2ddd7;

--- a/base/static/base/css/global.scss
+++ b/base/static/base/css/global.scss
@@ -71,6 +71,10 @@ a {
  * --------------------------------------------------
  */
 
+ h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty, a:empty, p:empty, ul:empty {
+    display: none; // ADA: Hides empty header tags
+}
+
  h1 {
   font-size: 1.4em;
   color: #800000;

--- a/base/static/base/css/loop-navigation.css
+++ b/base/static/base/css/loop-navigation.css
@@ -65,7 +65,7 @@ Footer
 
 .btn-default {
   color: #fff;
-  background-color: #8A9045;
+  background-color: #6e7337;
   border-color: #ccc; }
   .btn-default:hover {
     background-color: #ADB17D; }
@@ -93,7 +93,7 @@ Footer
     background-color: #fff; }
 
 .navbar-toggle {
-  background: #8A9045; }
+  background: #6e7337; }
   .navbar-toggle:hover, .navbar-toggle:visited, .navbar-toggle:focus {
     background: #ADB17D; }
 
@@ -121,9 +121,9 @@ Footer
         float: none;
         text-align: center; } }
     .navbar .nav li:hover, .navbar .nav li.current {
-      background-image: linear-gradient(to bottom, #8A9045, #666A35); }
+      background-image: linear-gradient(to bottom, #6e7337, #666A35); }
     .navbar .nav li a {
-      color: #696e34; }
+      color: #4d5127; }
       @media (min-width: 48em) {
         .navbar .nav li a {
           font-size: 1.1em;
@@ -163,7 +163,7 @@ html, body {
     .swside-home ul li {
       margin-bottom: 0.35em; }
   .swside-home a {
-    color: #8A9045;
+    color: #6e7337;
     text-decoration: none; }
   @media (min-width: 48em) {
     .swside-home {
@@ -206,12 +206,12 @@ html, body {
       padding-left: 25px; } }
 
 .btn-sidebar {
-  background: #8A9045;
+  background: #6e7337;
   color: #fff;
   position: absolute;
   padding: 10px;
   left: 0;
-  border-color: #8A9045;
+  border-color: #6e7337;
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
   margin-left: 0; }
@@ -292,7 +292,7 @@ html {
   width: 100%;
   height: 60px;
   padding: 15px 5px 5px 5px;
-  background-image: linear-gradient(to bottom, #8A9045, #666A35); }
+  background-image: linear-gradient(to bottom, #6e7337, #666A35); }
   @media (min-width: 48em) {
     .footer {
       padding-top: 0px;

--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -69,6 +69,11 @@ a {
     background-color: #ADB17D;
     color: #fff; }
 
+.swside-home .divider {
+  border-bottom: 1px solid #ADB17D;
+  margin-top: 1em;
+  margin-bottom: 1em !important; }
+
 /*
  * Headers
  * --------------------------------------------------
@@ -78,8 +83,6 @@ h1 {
   font-size: 1.4em;
   margin-bottom: 10px;
   color: #6e7337; }
-  .swside-home h1 {
-    color: #565A25; }
 
 h2 {
   font-weight: 400;
@@ -87,7 +90,7 @@ h2 {
   margin: 2em 0 5px 0;
   color: #9A5324; }
   .swside-home h2 {
-    color: #767676; }
+    color: #565A25; }
 
 h3 {
   font-weight: 100;
@@ -95,6 +98,7 @@ h3 {
   margin: 30px 0 15px 0;
   color: #565A25; }
   .swside-home h3 {
+    color: #767676;
     font-size: 1.2em; }
   h3.description {
     margin-top: 0px;

--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -58,7 +58,7 @@ body {
   background: #fbfbfa; }
 
 a {
-  color: #8A9045; }
+  color: #6e7337; }
   a:hover {
     color: #565A25;
     text-decoration: underline; }
@@ -77,7 +77,7 @@ h1 {
   font-weight: 600;
   font-size: 1.4em;
   margin-bottom: 10px;
-  color: #8A9045; }
+  color: #6e7337; }
   .swside-home h1 {
     color: #565A25; }
 
@@ -386,6 +386,20 @@ input[type=checkbox], input[type=radio] {
  * Directory / Staff Profile
  * --------------------------------------------------
  */
+button[id^='mysched'] {
+  color: #ffffff;
+  background: #6e7337;
+  margin-top: 0.5em;
+  border: none;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px; }
+  button[id^='mysched']:hover, button[id^='mysched']:focus {
+    color: #2A5DB0;
+    background: transparent;
+    border: 1px solid #2A5DB0; }
+
 .staff-headers h1 {
   display: inline-block; }
 
@@ -485,13 +499,23 @@ select {
       @media (min-width: 75em) {
         .sdir article p {
           max-width: unset; } }
-    .sdir article span[role=heading] {
+    .sdir article h4 {
+      color: #525252;
       font-weight: 600;
+      font-style: normal;
       display: block;
-      padding-top: 1em; }
+      padding-top: 1em;
+      margin-top: 0;
+      margin-bottom: 0.25em; }
       @media (min-width: 48em) {
-        .sdir article span[role=heading] {
+        .sdir article h4 {
           padding-top: 0; } }
+      .sdir article h4 a {
+        color: #6e7337;
+        text-decoration: underline; }
+        .sdir article h4 a:hover, .sdir article h4 a:focus {
+          color: #565A25;
+          text-decoration: none; }
     .sdir article .profile-image {
       padding-bottom: 1em;
       grid-row-start: 1;

--- a/base/static/base/css/loop/_loop-variables.scss
+++ b/base/static/base/css/loop/_loop-variables.scss
@@ -32,7 +32,7 @@ $darkgray: #767676;
 $darkergray: #434343;
 $darkeraccent: #666A35;
 $darkaccent: #565A25;
-$accentlink: #8A9045;
+$accentlink: #6e7337;
 $accentlink-light: #ADB17D;
 
 

--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -460,6 +460,22 @@ figure {
  * --------------------------------------------------
  */
 
+ button[id^='mysched'] { // Springshare MyScheduler button styling for staff browse view
+  color: #ffffff;
+  background: #6e7337;
+  margin-top: 0.5em;
+  border: none;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  &:hover, &:focus {
+    color: #2A5DB0;
+    background: transparent;
+    border: 1px solid #2A5DB0;
+  }
+}
+
 .staff-headers {
   h1 {
     display: inline-block;
@@ -578,12 +594,24 @@ select {
         max-width: unset;
       }
     }
-    span[role=heading] {
+    h4 {
+      color: $mid-dark;
       font-weight: 600;
+      font-style: normal;
       display: block;
       padding-top: 1em;
+      margin-top: 0;
+      margin-bottom: 0.25em;
       @include respond-to(small) {
         padding-top: 0;
+      }
+      a {
+        color: $accentlink;
+        text-decoration: underline;
+        &:hover, &:focus {
+          color: $darkaccent;
+          text-decoration: none;
+        }
       }
     }
     .profile-image {

--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -52,6 +52,14 @@ a {
   }
 }
 
+.swside-home {
+  .divider {
+    border-bottom:1px solid #ADB17D;
+    margin-top: 1em;
+    margin-bottom: 1em !important;
+  }
+}
+
 // a.link-alert {
 //     color: #800000;
 //     &:after {
@@ -72,9 +80,6 @@ h1 {
   font-size: 1.4em;
   margin-bottom: 10px;
   color: $accentlink;
-  .swside-home & {
-    color: $darkaccent
-  }
 }
 
 h2 {
@@ -83,7 +88,7 @@ h2 {
   margin: 2em 0 5px 0;
   color:#9A5324;
   .swside-home & {
-    color: $darkgray;
+    color: $darkaccent
   }
 }
 
@@ -94,6 +99,7 @@ h3 {
   margin: 30px 0 15px 0;
   color: $darkaccent;
     .swside-home & {
+      color: $darkgray;
       font-size: 1.2em;
     }
     &.description {

--- a/base/static/base/css/sidebars.scss
+++ b/base/static/base/css/sidebars.scss
@@ -200,7 +200,7 @@ Right Sidebar: Widget Items
     max-width: 30em;
   }
   .btn-morelink {
-    margin-bottom: 10px;
+    margin: 2em 0 0;
   }
 }
 
@@ -290,9 +290,6 @@ Right Sidebar: Widget Items
   }
   li {
     margin-bottom: 0.5em;
-  }
-  i, .material-icons {
-    padding-left: 1em;
   }
   .collectionpage & {
     padding-bottom: 1em;

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -208,11 +208,6 @@ body.libnewspage .breadcrumbs, body.libnewsindexpage .breadcrumbs, .h1-banner .b
  * --------------------------------------------------
  */
 
-
-h1:empty, h2:empty, h3:empty, h4:empty, h5:empty, h6:empty {
-    display: none; // ADA: Hides empty header tags
-}
-
 #footnotes {
   font-family: 'ProximaNova-Light';
   font-size: 0.8em;
@@ -594,18 +589,19 @@ figure.coll-thumb {
     text-align: center;
   }
   a {
-    color: $eckhartpurple;    
-  }
-  a:hover {
-    text-decoration: none;
-  }
-  .material-icons, a.material-icons {
     color: $eckhartpurple;
+    text-decoration: none;  
+    &:hover, &:focus {
+      color: $default-link;
+      text-decoration: underline;
+    }  
+  }
+  .material-icons {
     vertical-align: middle;
     font-size: 2em;
+
   }
-  .fa, a.fa {  // to make-up for the size difference between the two icon families
-    color: $eckhartpurple;
+  .fa {  // to make-up for the size difference between the two icon families
     font-size:1.5em;
     padding-top: 10px;
     padding-bottom:7px;
@@ -615,12 +611,9 @@ figure.coll-thumb {
 .icon-widget {
   @extend .studymod;
   text-align: center;
-  a {
-    text-decoration: none;
-  }
-  .fa, a.fa {
+  & .fa, & .material-icons {
     display: block;
-    font-size: 3rem;
+    padding-left: 0;
   }
 }
 
@@ -893,10 +886,11 @@ figure.embed {
 
  .distinct-list { //table base
   a {
-    color: #8a4a20;
-    text-decoration: none;
-    &:hover {
-      text-decoration: underline;
+    color: $default-link;
+    text-decoration: underline;
+    &:hover, &:focus {
+      color: $dark-link;
+      text-decoration: none;
     }
   }
   .material-icons, .fa {
@@ -1812,13 +1806,12 @@ a.coll-access {
   margin: 2em 0 0.25em 0;
   padding-left: 0;
   h2 {
-    font-family: $accent-font;
-    color: $reggreen;
-    font-size: 1.3em;
+    color: $darkred;
+    font-size: 1.15em;
     padding-left: 15px;
     margin-right: 2em;
     margin-bottom: 0.25em;
-    border-bottom: 2px solid #ADB17D;
+    border-bottom: 2px solid #ddd;
       a, a:active, a:focus, a:hover {
       color: $mid-dark;
       text-decoration: none;
@@ -1856,12 +1849,28 @@ a.coll-access {
         max-width: unset;
       }
     }
-    span[role=heading] {
+    h4 {
+      font-size: 1em; 
+      color: darken($mid-dark, 10%);
       font-weight: 600;
+      font-style: normal;
       display: block;
       padding-top: 1em;
+      margin-top: 0;
+      margin-bottom: 0.25em;
       @include respond-to(small) {
         padding-top: 0;
+      }
+      a {
+        color: $default-link;
+        text-decoration: underline;
+        &:hover, &:focus {
+          color: $dark-link;
+          text-decoration: none;
+        }
+      }
+      &.staff-name {
+        font-size: 1.1em;
       }
     }
     .profile-image {
@@ -1873,8 +1882,13 @@ a.coll-access {
       }
     }
     ul {
-      padding-left: 0px;
+      padding-left: 1em;
+      text-indent: -1em;
       list-style: none;
+      li {
+        margin-bottom: 0.35rem;
+        font-size: 1.35rem;
+      }
     }
   }
 }

--- a/base/static/base/js/CGIMailForm.js
+++ b/base/static/base/js/CGIMailForm.js
@@ -139,7 +139,7 @@ InvalidJSON.propTypes = {
 };
 
 const buildField = (elm, state, handleChange) => {
-  const id = elm.name || null;
+  const id = elm.id || elm.name || null;
   const value = elm.value || state[id] || defaultFieldMappings(elm, state) || null;
   const type = elm.type || null;
   const name = elm.name || null;

--- a/base/static/base/js/CGIMailForm.js
+++ b/base/static/base/js/CGIMailForm.js
@@ -139,7 +139,7 @@ InvalidJSON.propTypes = {
 };
 
 const buildField = (elm, state, handleChange) => {
-  const id = elm.id || elm.name || null;
+  const id = elm.name || null;
   const value = elm.value || state[id] || defaultFieldMappings(elm, state) || null;
   const type = elm.type || null;
   const name = elm.name || null;

--- a/base/templates/base/intranet_base.html
+++ b/base/templates/base/intranet_base.html
@@ -7,9 +7,17 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta charset="utf-8">
-  <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
+  <title>
+    {% block title %}
+        {% if self.seo_title %}
+            {{self.seo_title}}
+        {% else %} 
+            {{ self.title }}
+        {% endif %}
+    {% endblock %} 
+  </title>
   <meta name="generator" content="Bootply" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, user-scalable=yes">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link href="{% static 'base/css/bootstrap.min.css' %}" rel="stylesheet">
   <!--[if lt IE 9]>
@@ -136,7 +144,7 @@
 
   <!-- Footer Section -->
   <footer class="container-fluid footer" role="contentinfo"> 
-    <span class="footer-brand"><a href="https://www.lib.uchicago.edu/"><img src="/static/base/images/color-logo.png"></a></span>
+    <span class="footer-brand"><a href="https://www.lib.uchicago.edu/"><img src="/static/base/images/color-logo.png" alt="Loop logo"></a></span>
       <ul>
         <li><a href="http://www.lib.uchicago.edu/cgi-bin/mail-aliases/"><span class="hidden-xs">Library </span>Email Aliases</a></li>
         <li><a href="/staff/"><span class="hidden-xs">Library Staff</span> Directory</a></li>

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -399,19 +399,18 @@
                     {% if self.has_find_spaces %}
                         <div class="rightside-mod col-xs-12 col-sm-6 col-md-12" id="widget-spaces">
                             <h3>Find Spaces</h3>
-                            <div class="studymod row">
-                                <div class="col-xs-4 nopadding">
-                                    <p><a href="{{quiet_spaces_link}}"><i class="material-icons" aria-hidden="true" aria-role="presentation">local_library</i></a><br/>
-                                    <span class="hidden-xs hidden-sm hidden-md" aria-role="presentation">Quiet </span>Study</p>
+                            <div class="studymod col-xs-12 columns icon-widget">
+                                <div class="column">
+                                    <a href="{{quiet_spaces_link}}"><i class="material-icons" aria-hidden="true" aria-role="presentation">local_library</i>Quiet Study<span class="visually-hidden"> Spaces</span></a>
                                 </div>
-                                <div class="col-xs-4 nopadding">
-                                    <p><a href="{{collaborative_spaces_link}}"><i class="material-icons" aria-hidden="true" aria-role="presentation">people</i></a><br/>Collaboration</p>
+                                <div class="column">
+                                    <a href="{{collaborative_spaces_link}}"><i class="material-icons" aria-hidden="true" aria-role="presentation">people</i>Collaboration<span class="visually-hidden"> Spaces</span></a>
                                 </div>
                                 {% if self.book_a_room_link %}
-                                    <div class="col-xs-4 nopadding">
-                                        <p><a href="{{self.book_a_room_link}}">
-                                        <i class="fa fa-calendar-plus-o fa-lg" aria-hidden="true"></i></a>
-                                        <br/><span class="hidden-xs hidden-sm hidden-md">Book a Room</span><span class="hidden-lg">Reserve</span></p>
+                                    <div class="column">
+                                        <a href="{{self.book_a_room_link}}">
+                                        <i class="fa fa-calendar-plus-o fa-lg" aria-hidden="true"></i>
+                                        Reserve<span class="visually-hidden"> a Space</span></a>
                                     </div>
                                 {% endif %}
                             </div>

--- a/intranethome/templates/intranethome/intranet_home_page.html
+++ b/intranethome/templates/intranethome/intranet_home_page.html
@@ -60,7 +60,7 @@
   <div class="col-xs-12 col-md-3 swside-home" role="complementary"> <!-- Right Sidebar -->
 
     <div class="row-fluid"> <!-- Quicklinks Row -->
-      <h1>Quicklinks</h1>
+      <h2>Quicklinks</h2>
       <ul>
         <li><a style="color: #800000;" href="https://loop.lib.uchicago.edu/covid-19-information-staff/">COVID-19 Updates <i class="fa fa-angle-double-right"></i></a></li>
         <li><a href="https://humanresources.uchicago.edu/benefits/">Benefits</a></li>
@@ -84,13 +84,16 @@
     <hr/>
 
     <div class="row-fluid"><!-- Community -->
-        <h1>Our Community</h1>
+        <h2>Our Community</h2>
         <ul>
           <li><a href="/departments/administration/directors-office/">Director's Page</a></li>
           <li><a href="/groups/staff-meeting/">All Staff Meeting</a></li>
-          <li><a href="https://loop.lib.uchicago.edu/library-community/water-cooler/">Water Cooler (Archive)</a></li>
-          <li><a href="/documentation/loop-box-documentation/loop-news-best-practices/">How to: Loop News post</a></li>
+          <!-- <li><a href="https://loop.lib.uchicago.edu/library-community/water-cooler/">Water Cooler (Archive)</a></li> -->
+          <li><a href="https://loop.lib.uchicago.edu/library-community/library-staff-kudos/">Library Staff Kudos</a></li>   
+          <li role="separator" class="divider"></li>     
           <li><a href="https://loop.lib.uchicago.edu/admin/pages/587/">Write a Loop News Post</a></li>
+          <li role="separator" class="divider"></li>
+          <a href="/documentation/loop-box-documentation/loop-news-best-practices/">How to: Loop News post</a>
           <li><a href="/documentation/loop-box-documentation/loop-guidelines-policies-tutorials/adding-meeting-minutes/">How to: Meeting Minutes</a></li>
         </ul>
     </div>
@@ -98,17 +101,17 @@
     <hr>
     
     <div class="row-fluid"><!-- Work/Life -->
-      <h1>Community Links</h1>
-      <h2>Food</h2>
+      <h2>Community Links</h2>
+<!--       <h2>Food</h2>
       <ul>
         <li><a href="https://dining.uchicago.edu/page/locations-hours">Campus Dining: locations &amp; hours</a></li>
         <li><a href="https://twitter.com/exlibtoaster">ExLibris Toaster</a></li>
       </ul>
 
-      <h2>Interests &amp; Resources</h2>
+      <h2>Interests &amp; Resources</h2> -->
         <ul>
-          <li><a href="https://loop.lib.uchicago.edu/campus/campus-webcams/">Campus Camera Feeds</a></li>
-          <li><a href="http://events.uchicago.edu/cal/main/showMain.rdo;jsessionid=C22CCF8F17687AD9F8616251F7EBF532.bw04">Campus Events</a></li>
+<!--           <li><a href="https://loop.lib.uchicago.edu/campus/campus-webcams/">Campus Camera Feeds</a></li>
+          <li><a href="http://events.uchicago.edu/cal/main/showMain.rdo;jsessionid=C22CCF8F17687AD9F8616251F7EBF532.bw04">Campus Events</a></li> -->
           <li><a href="http://athletics.uchicago.edu/facilities/index">Campus Gyms</a></li>
           <li><a href="https://voices.uchicago.edu/equity/">Equal Opportunity Programs</a></li>
           <li><a href="https://grad.uchicago.edu/life-at-uchicago/family-resources/">Family Resource Center</a></li>

--- a/library_website/templates/404.html
+++ b/library_website/templates/404.html
@@ -3,16 +3,19 @@
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}
+<div class="col-xs-12 centermain" style="padding-top:2em;">
     <h1>Page not found</h1>
     <p>You may have an outdated bookmark or we have a broken link.</p>
 
     <h2>We think we can help you</h2>
     <p>Try one of the links below:</p>
     <ul>
-    	<li>Home Page</li>
-    	<li>Site Search</li>
+    	<li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a></li>
+        <li><a href="https://www.lib.uchicago.edu/collex/">Library Digital Collections</a></li>
+    	<li><a href="https://www.lib.uchicago.edu/">Library Homepage</a></li>
     </ul>
 
     <h2>Help us help you</h2>
     <p>Let us know that we have a missing page. We will do our best to rectify the issue.</p>
+</div>
 {% endblock %}

--- a/staff/templates/staff/staff_directory_listing.html
+++ b/staff/templates/staff/staff_directory_listing.html
@@ -4,8 +4,9 @@
 
 {% cache 86400 staff_directory_listing staff_page.cnetid %}
   <article>
+      <h3 class="visually-hidden">{{ staff_page.display_name }}</h3>
     <div>
-      <h3>{% staff_public_page_link staff_page %}</h3>
+      <h4 class="staff-name"><span class="visually-hidden">About </span>{% staff_public_page_link staff_page %}</h3>
       {% if staff_page.pronouns %}
         <span class="pronouns-listing">{{ staff_page.pronouns }}</span>
       {% endif %}
@@ -15,14 +16,14 @@
       </p>
     </div>
     <div>
-      <span role="heading">Contact<span class="visually-hidden"> {{ staff_page.first_name }}</span></span>
+      <h4>Contact<span class="visually-hidden"> {{ staff_page.first_name }}</span></h4>
       {% staff_email_addresses staff_page %}
       {% staff_faculty_exchanges_phone_numbers staff_page %}
       {% staff_libcal_schedules staff_page %}
     </div>
     <div>
       {% if staff_page.staff_subject_placements.all %}
-      <span role="heading"><span class="visually-hidden">{{ staff_page.first_name }}'s</span> Subject Specialties</span>
+      <h4><span class="visually-hidden">{{ staff_page.first_name }}'s </span>Specialties</h4>
       <ul>
         {% staff_subjects staff_page %}
       </ul>

--- a/units/templates/units/unit_index_page.html
+++ b/units/templates/units/unit_index_page.html
@@ -106,11 +106,11 @@
       <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
         <h2>Ask A Librarian</h2>
         <ul>
-          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/"><i class="fa fa-comments-o fa-1x" aria-hidden="true"></i> Chat <span class="visually-hidden">with a Librarian</span></a></li>
+          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/"><i class="fa fa-comments-o fa-1x ask-icons" aria-hidden="true"></i> Chat <span class="visually-hidden">with a Librarian</span></a></li>
           <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/ask-contact/"><span class="material-icons ask-icons" aria-hidden="true">mail_outline</span> Email <span class="visually-hidden">a Librarian for help</span></a></li>
 <!--           <li style="margin-bottom: 0.5em;"><a href="tel:773-702-4685"><span class="material-icons ask-icon" aria-hidden="true">phone</span>773-702-4685</a></li> -->          
-          <li><a href="sms:773-825-6777"><span class="material-icons ask-icon" aria-hidden="true">textsms</span> <span class="visually-hidden">Send a text for Library help to: </span>773-825-6777 (text)</a></li>
-          <li><a href="https://www.lib.uchicago.edu/libraries/libraries-hours/"><span class="material-icons ask-icon" aria-hidden="true">location_on</span> Visit <span class="visually-hidden">our locations</span></a></li>
+          <li><a href="sms:773-825-6777"><span class="material-icons ask-icons" aria-hidden="true">textsms</span> <span class="visually-hidden">Send a text for Library help to: </span>773-825-6777 (text)</a></li>
+          <li><a href="https://www.lib.uchicago.edu/libraries/libraries-hours/"><span class="material-icons ask-icons" aria-hidden="true">location_on</span> Visit <span class="visually-hidden">our locations</span></a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Closes #484 

**Not resolved**
- Not able to change Loop text from px to rem right now. Attached to `body` styling from Bootstrap CSS. Will effect entire site and needs more thought.

**Changes in this request**
- Added screen-reader only h3 of staff name outside of divs
- Created h4 labels for About {{ staff name }} and Contact {{ staff name }}
- Made sidebar widgets with icons be entirely wrapped in link tag
- Resolved meta tag ADA issues on Loop templates
- Added links to 404 page (being [served on production](https://www.lib.uchicago.edu/collex/exhibits/adaptations-augie-march-novel-saul-bellow-play-david-auburn-production-directed-charles-newell-exhibition-special-collections-court-theatre/) with reference to links without linked text)
- Expanded `:empty` pseudo class to hid more empty tags from the DOM
- Bumped color contrast on links and Loop items
- Added alt text to Loop logo in footer
- Snuck in Loop sidebar link change to add Kudos link (EL request)