### PR TITLE
Added help panel with direct link to Loop staff page

### DIFF
--- a/public/models.py
+++ b/public/models.py
@@ -13,8 +13,8 @@ from staff.utils import libcal_id_by_email
 from subjects.utils import get_subjects_html
 from units.models import BUILDINGS
 from wagtail.admin.edit_handlers import (
-    FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel, ObjectList,
-    PageChooserPanel, StreamFieldPanel, TabbedInterface
+    FieldPanel, FieldRowPanel, HelpPanel, InlinePanel, MultiFieldPanel,
+    ObjectList, PageChooserPanel, StreamFieldPanel, TabbedInterface
 )
 from wagtail.api import APIField
 from wagtail.core import blocks
@@ -843,8 +843,24 @@ class StaffPublicPage(PublicBasePage):
 
     subpage_types = ['public.StandardPage']
     content_panels = Page.content_panels + [
+        HelpPanel(
+            heading='Editing your staff page',
+            template='public/blocks/staffpage_helppanel.html',
+        ),
         FieldPanel('cnetid')
     ] + PublicBasePage.content_panels
+
+    def get_staff_page_id(self):
+        """
+        Gets the page ID from a loop staff page.
+
+        Returns:
+            ID or empty string.
+        """
+        try:
+            return StaffPage.objects.all().filter(cnetid=self.cnetid)[0].id
+        except (IndexError):
+            return ''
 
     def get_bio(self):
         """

--- a/public/templates/public/blocks/staffpage_helppanel.html
+++ b/public/templates/public/blocks/staffpage_helppanel.html
@@ -1,0 +1,11 @@
+<fieldset>
+    {% if self.heading %}
+        <legend>{{ self.heading }}</legend>
+    {% endif %}
+    <div class="{{ self.classname }}">
+    	<h2>Want to edit your staff page?</h2>
+    	<h3>Edit your info on your <a href="/admin/pages/{{ self.instance.get_staff_page_id }}/edit/">Loop staff page</a></h3>
+    	<p>(∩｀-´)⊃━☆ﾟ.*･｡ﾟ</p>
+    	<p>This page is a container for your data on the public site. All staff info is housed in <a href="/admin/pages/38/">Loop</a> and gets duplicated onto your public staff page. Do not edit any info on this page or you will break the staff data magic.</p>
+    </div>
+</fieldset>


### PR DESCRIPTION
Closes #491

**Changes in this request**
- Decided to do a `def` only in `StaffPublicPage`
- Note on using `.instance`
   - The base EditHandler class has access to the instance as long as the data is in the model.
   - Value would not populate without `.instance` in the Wagtail admin although functions just fine if calling into a public-facing template.