### PR TITLE
479 retain search term when switching source

### DIFF
--- a/base/static/base/js/transformer-tabs.js
+++ b/base/static/base/js/transformer-tabs.js
@@ -56,3 +56,23 @@ var Tabs = {
 }
 
 Tabs.init();
+
+// propagate an input element's content to all the other forms in the
+// search box
+const propagate = (element) => {
+
+    // get all the forms on the search box page
+    const form1 = document.getElementById("search_form1");
+    const form2 = document.getElementById("search_form2");
+    const form3 = document.getElementById("search_form3");
+    const form4 = document.getElementById("search_form4");
+    const form5 = document.getElementById("search_form5");
+
+    const all_the_forms = [ form1, form2, form3, form4, form5 ];
+
+    // propagate content of input element out to other forms
+    var i;
+    for (i = 0; i < all_the_forms.length; i++) {
+	all_the_forms[i].value = element.value
+    }
+};

--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -15,7 +15,6 @@
         <div class="input-group"> <!-- Input Group -->
 	  <label for="lookfor" class="visually-hidden">Search for </label>
           <input name="lookfor" type="text" placeholder="evolutionary biology" aria-label="Search for" class="form-control" id="search_form1" onchange="propagate(this)"/>
-
 	  <input type="hidden" name="which-form" value="catalog">
 	  {% csrf_token %}
           <select class="selectpicker btn-searchtype" aria-label="Limit search to" name="type">

--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -14,7 +14,8 @@
       <div class="col-xs-9 col-sm-10 nopadding"> <!-- Text Search Field --> 
         <div class="input-group"> <!-- Input Group -->
 	  <label for="lookfor" class="visually-hidden">Search for </label>
-          <input name="lookfor" type="text" placeholder="evolutionary biology" aria-label="Search for" class="form-control"/>
+          <input name="lookfor" type="text" placeholder="evolutionary biology" aria-label="Search for" class="form-control" id="search_form1" onchange="propagate(this)"/>
+
 	  <input type="hidden" name="which-form" value="catalog">
 	  {% csrf_token %}
           <select class="selectpicker btn-searchtype" aria-label="Limit search to" name="type">
@@ -63,7 +64,7 @@
       <div data-radio-button-content-panel="articles-plus">
         <h1 class="searchbox-header">Articles Plus</h1>
         <div class="col-xs-9 col-sm-10 nopadding">
-          <input type="text" name="ebscohostsearchtext" id="ebscohostsearchtext" placeholder="evolutionary biology" aria-label="..." class="form-control">
+          <input type="text" id="search_form2" onchange="propagate(this)" name="ebscohostsearchtext" id="ebscohostsearchtext" placeholder="evolutionary biology" aria-label="..." class="form-control">
 	  <input type="hidden" name="which-form" value="articles">
 	  {% csrf_token %}
 	  <input type="hidden" value="0" name="ebscohostwindow" id="ebscohostwindow">
@@ -84,7 +85,7 @@
       <form action="/switchboard/" accept-charset="UTF-8" method="post" data-ga-category="search-widget" data-ga-action="submit" data-ga-label="Articles, Journals &amp; Databases &gt; Search">
         <h1 class="searchbox-header">Ejournals</h1>
         <div class="col-xs-9 col-sm-10 nopadding">
-          <input type="text" name="param_pattern_value" placeholder="journal of evolutionary biology" aria-label="..." class="form-control">
+          <input type="text" name="param_pattern_value" placeholder="journal of evolutionary biology" aria-label="..." class="form-control" id="search_form3" onchange="propagate(this)">
 	  <input type="hidden" name="which-form" value="journals">
 	  {% csrf_token %}
         </div>
@@ -104,7 +105,7 @@
       <h1 class="searchbox-header">Database Finder</h1>
       <form action="/switchboard/" method="post" data-ga-category="search-widget" data-ga-action="submit" data-ga-label="Articles, Journals &amp; Databases &gt; Search">
         <div class="col-xs-9 col-sm-10 nopadding">
-          <input name="q" type="text" placeholder="evolutionary biology database" aria-label="..." class="form-control">
+          <input name="q" type="text" placeholder="evolutionary biology database" aria-label="..." class="form-control" id="search_form4" onchange="propagate(this)">
 	  <input type="hidden" name="which-form" value="databases">
 	  {% csrf_token %}
         </div>
@@ -144,7 +145,7 @@
     <h1 class="searchbox-header">Website Search</h1>
     <form action="/switchboard/" method="post" data-ga-category="search-widget" data-ga-action="submit" data-ga-label="Library Website &gt; Search">
       <div class="col-xs-9 col-sm-10 nopadding">
-        <input name="query" type="text" placeholder="lockers" aria-label="..." class="form-control">
+        <input name="query" type="text" placeholder="lockers" aria-label="..." class="form-control" id="search_form5" onchange="propagate(this)">
 	<input type="hidden" name="which-form" value="website">
 	{% csrf_token %}
       </div>


### PR DESCRIPTION
Fixes #479.

Add a little javascript to `transformer-tabs.js`, plus a couple extra `id`-s and `onchange` events to `search_widget.html`, to get the following effect:
- when the user types something in any of the search boxes on the main page, that something appears in all the search boxes
- when the user erases what's in any of the search boxes on the main page, they all go back to normal