### PR TITLE
Staff browse returns nothing when searching SSA and SCRC

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -418,8 +418,8 @@ QUICK_NUMS = {
     }],
 }
 
-# This setting is used in units.models. The code needs to be updated
-# to use LocationPage.objects.live().filter(is_building=True) instead.
+# This setting is used in units/models.py and staff/templatetags/staff_tags.py.
+# The code should be updated to use LocationPage.objects.live().filter(is_building=True) instead.
 BUILDINGS = (
     (1, 'The John Crerar Library'),
     (2, 'The D\'Angelo Law Library'),

--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -399,7 +399,7 @@ QUICK_NUMS = {
             'link': None
         }
     ],
-    'special-collections-research-center': [
+    'the-hanna-holborn-gray-special-collections-research-center': [
         {
             'label': 'SCRC Front Desk',
             'number': '773-702-8705',
@@ -410,13 +410,25 @@ QUICK_NUMS = {
             'link': SCRC_ASK_PAGE
         }
     ],
-    'social-service-administration-library':
+    'the-social-service-administration-library':
     [{
         'label': 'SSA Library',
         'number': '773-702-1199',
         'link': None
     }],
 }
+
+# This setting is used in units.models. The code needs to be updated
+# to use LocationPage.objects.live().filter(is_building=True) instead.
+BUILDINGS = (
+    (1, 'The John Crerar Library'),
+    (2, 'The D\'Angelo Law Library'),
+    (3, 'Eckhart Library'),
+    (4, 'The Joe and Rika Mansueto Library'),
+    (5, 'The Joseph Regenstein Library'),
+    (6, 'The Hanna Holborn Gray Special Collections Research Center'),
+    (7, 'The Social Service Administration Library')
+)
 
 # Location pages
 SCRC_BUILDING_ID = 2971

--- a/staff/templatetags/staff_tags.py
+++ b/staff/templatetags/staff_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from library_website.settings import BUILDINGS
 from public.models import LocationPage, StaffPublicPage
 from staff.utils import libcal_id_by_email
 
@@ -89,18 +90,12 @@ def libcal_button(staff_page, email):
 @register.inclusion_tag('staff/staff_faculty_exchanges_phone_numbers.html')
 def staff_faculty_exchanges_phone_numbers(staff_page):
     libraries = {
-        'JCL':
-        LocationPage.objects.get(title='The John Crerar Library'),
-        'JRL':
-        LocationPage.objects.get(title='The Joseph Regenstein Library'),
-        'LBQ':
-        LocationPage.objects.get(title='The D\'Angelo Law Library'),
-        'Mansueto':
-        LocationPage.objects.get(title='The Joe and Rika Mansueto Library'),
-        'MAN':
-        LocationPage.objects.get(title='The Joe and Rika Mansueto Library'),
-        'SSA':
-        LocationPage.objects.get(title='Social Service Administration Library')
+        'JCL': LocationPage.objects.get(title=BUILDINGS[0][1]),
+        'JRL': LocationPage.objects.get(title=BUILDINGS[4][1]),
+        'LBQ': LocationPage.objects.get(title=BUILDINGS[1][1]),
+        'Mansueto': LocationPage.objects.get(title=BUILDINGS[3][1]),
+        'MAN': LocationPage.objects.get(title=BUILDINGS[3][1]),
+        'SSA': LocationPage.objects.get(title=BUILDINGS[6][1])
     }
 
     lib_room_phone = []

--- a/units/models.py
+++ b/units/models.py
@@ -1,26 +1,15 @@
+from base.models import BasePage, Email, FaxNumber, LinkedText, PhoneNumber
 from django.db import models
-from library_website.settings import PHONE_FORMAT, PHONE_ERROR_MSG
-from wagtail.core.models import Orderable, Page
-from wagtail.core.fields import RichTextField, StreamField
-from wagtail.admin.edit_handlers import FieldPanel, FieldRowPanel, \
-    InlinePanel, MultiFieldPanel, ObjectList, PageChooserPanel, \
-    StreamFieldPanel, TabbedInterface
-from wagtail.documents.edit_handlers import DocumentChooserPanel
-from wagtail.search import index
-from wagtail.snippets.models import register_snippet
-from wagtail.snippets.edit_handlers import SnippetChooserPanel
+from library_website.settings import BUILDINGS
 from modelcluster.fields import ParentalKey
-from django.core.validators import RegexValidator
-from base.models import BasePage, DefaultBodyFields, Email, FaxNumber, \
-    LinkedText, PhoneNumber
-
-BUILDINGS = (
-    (1, 'The John Crerar Library'), (2, 'The D\'Angelo Law Library'),
-    (3, 'Eckhart Library'), (4, 'The Joe and Rika Mansueto Library'),
-    (5, 'The Joseph Regenstein Library'),
-    (6, 'Special Collections Research Center'),
-    (7, 'Social Service Administration Library')
+from wagtail.admin.edit_handlers import (
+    FieldPanel, InlinePanel, ObjectList, PageChooserPanel, TabbedInterface
 )
+from wagtail.core.fields import RichTextField
+from wagtail.core.models import Orderable, Page
+from wagtail.search import index
+from wagtail.snippets.edit_handlers import SnippetChooserPanel
+from wagtail.snippets.models import register_snippet
 
 
 class Tree(object):


### PR DESCRIPTION
Fixes #502

This fixes the staff browse problems related to page name changes.

**Changes in this request**
- Moved the `BUILDINGS` constant in `units/models.py` into config
- Updated the `QUICK_NUMS` constant in config. Note: these changes had already been applied in `local.py` they were added here in `base.py` for consistency. 
- Assigned some staff to SCRC and SSA and preserved those changes in the test db fixtures
- Removed unused imports.