### PR TITLE
Restore external links to digital collection landing page

### DIFF
--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -1315,7 +1315,8 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
         InlinePanel(
             'supplementary_access_links', label='Supplementary Access Links'
         ),
-        InlinePanel('related_collection_placement', label='Related Collection'),
+        InlinePanel('related_collection_placement',
+                    label='Related Collection'),
         FieldPanel('collection_location'),
         InlinePanel('donor_page_list_placement', label='Donor'),
         MultiFieldPanel(
@@ -1401,11 +1402,14 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
         default_image = None
         default_image = Image.objects.get(title="Default Placeholder Photo")
 
+        show_external_link = self.highlighted_records == ''
+
         # populate context
         context = super(CollectionPage, self).get_context(request)
         context['default_image'] = default_image
         context['sidebar_browse_types'] = sidebar_browse_types
         context['objects'] = objects
+        context['show_external_link'] = show_external_link
 
         # update context with information about staff associated with the
         # relevant collection
@@ -1526,7 +1530,8 @@ class CollectingAreaPage(PublicBasePage, LibGuide):
     )
     reference_materials = RichTextField(blank=True, null=True)
     circulating_materials = RichTextField(blank=True, null=True)
-    archival_link_text = models.CharField(max_length=255, blank=True, null=True)
+    archival_link_text = models.CharField(
+        max_length=255, blank=True, null=True)
     archival_link_url = models.URLField("Archival URL", blank=True, null=True)
     first_feature = models.ForeignKey(
         'wagtailcore.Page',
@@ -1936,14 +1941,12 @@ class ExhibitPage(PublicBasePage):
     exhibit_open_date = models.DateField(
         blank=True,
         null=True,
-        help_text=
-        'Controls when an exhibit starts being featured as "current" in browse and widgets.'
+        help_text='Controls when an exhibit starts being featured as "current" in browse and widgets.'
     )
     exhibit_close_date = models.DateField(
         blank=True,
         null=True,
-        help_text=
-        'When exhibit stops being featured as "current." If "space type" is "Online" end date will not display.'
+        help_text='When exhibit stops being featured as "current." If "space type" is "Online" end date will not display.'
     )
     exhibit_location = models.ForeignKey(
         'public.LocationPage', null=True, blank=True, on_delete=models.SET_NULL
@@ -2107,8 +2110,7 @@ class ExhibitPage(PublicBasePage):
                 FieldPanel('ordering_information'),
                 FieldPanel(
                     'publication_url',
-                    help_text=
-                    'If exhibit publication is hosted outside of Library site'
+                    help_text='If exhibit publication is hosted outside of Library site'
                 ),
                 FieldPanel(
                     'web_exhibit_url',

--- a/lib_collections/templates/lib_collections/collection_page.html
+++ b/lib_collections/templates/lib_collections/collection_page.html
@@ -32,7 +32,7 @@
 		    {{ block }}
 		{% endfor %}
 
-		{% if self.primary_online_access_link_url and self.primary_online_access_link_label %}
+		{% if self.primary_online_access_link_url and self.primary_online_access_link_label and show_external_link %}
 		    <a role="button" class="btn btn-morecoll" href="{{ self.primary_online_access_link_url }}">{{ self.primary_online_access_link_label }}</i></a>
 		{% endif %}
 		

--- a/lib_collections/templates/lib_collections/collection_page.html
+++ b/lib_collections/templates/lib_collections/collection_page.html
@@ -32,6 +32,25 @@
 		    {{ block }}
 		{% endfor %}
 
+		{% if self.primary_online_access_link_url and self.primary_online_access_link_label %}
+		    <a role="button" class="btn btn-morecoll" href="{{ self.primary_online_access_link_url }}">{{ self.primary_online_access_link_label }}</i></a>
+		{% endif %}
+		
+		{% if self.access_instructions or supplementary_access_links %}
+		    <h3>Access Information</h3>
+
+		    {% if supplementary_access_links %}
+			<p>
+			    {% for l in supplementary_access_links %}
+			        <a class="coll-access" href="{{ l.supplementary_access_link_url }}">{{ l.supplementary_access_link_label }}</a><br/>
+			    {% endfor %}
+			</p>
+		    {% endif %}
+
+		    {% if self.access_instructions %}
+			<p>{{ self.access_instructions }}</p>
+		    {% endif %}
+		{% endif %}
 	    </div>
 	</div><!--/.row-->
     </article>


### PR DESCRIPTION
Fixes #505

**Changes in this request**
This change puts the old links to view a digital collection back into the template, and adds a little conditional logic to suppress them if the collection page is one of the new ones that has been onboarded onto our new framework.  Finally, it adds a sample collection page to the fixtures, which a) got lost in the deploy shuffle and b)  will be useful for testing this new code.