### PR TITLE
ADA fixes and Social Work link update

### DIFF
--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -149,6 +149,11 @@ body.libnewspage .breadcrumbs, body.libnewsindexpage .breadcrumbs, .h1-banner .b
  * --------------------------------------------------
  */
 
+ a:focus {  // For SiteImprove ADA; Overrides `-webkit-focus-ring-color` from Bootstrap
+  outline: auto!important;
+  outline-offset: unset!important;
+}
+
 .breadcrumbs {
   padding-top: 5px;
   padding-left: 20px;

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -305,8 +305,8 @@
                                 <li><a href="/eck/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Eckhart">Eckhart</a></li>
                                 <li><a href="/mansueto/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Mansueto">Mansueto</a></li>
                                 <li><a href="/spaces/joseph-regenstein-library/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Regenstein">Regenstein</a></li>
+                                <li><a href="/ssa/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Social Work">Social Work</a></li>
                                 <li><a href="/scrc/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Special Collections">Special Collections</a></li>
-                                <li><a href="/ssa/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; SSA">SSA</a></li>
                                 <li><a href="/libraries/libraries-hours/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Libraries &gt; Hours" aria-label="View all Library hours">Hours</a></li>
                             </ul>
                         </li>

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -193,7 +193,7 @@
                     <div id="carousel-example-generic" class="carousel slide" data-ride="carousel" data-interval="false">
 
                         {% if carousel_multi %} 
-                            <ol class="carousel-indicators" role="listbox">
+                            <ol class="carousel-indicators">
                                 {% for i in carousel_items %}
                                     <li data-target="#carousel-example-generic" data-slide-to="{{forloop.counter0}}" {% if forloop.first %}class="active"{% endif %}></li>
                                 {% endfor %}

--- a/lib_collections/templates/lib_collections/collection_page.html
+++ b/lib_collections/templates/lib_collections/collection_page.html
@@ -68,7 +68,7 @@
       </span>
     </div>
 
-    <section class="browse-list" id="content" role="main">
+    <section class="browse-list">
       {% include "includes/general_listing.html" %}
     </section>
 {% else %}

--- a/staff/templates/staff/staff_directory_listing.html
+++ b/staff/templates/staff/staff_directory_listing.html
@@ -29,7 +29,7 @@
       </ul>
       {% endif %}
       {% if staff_page.libguide_url %}
-          <a href="{{ staff_page.libguide_url }}" class="guide-link"> Subject Guides</a>
+          <a href="{{ staff_page.libguide_url }}" class="guide-link"><span class="visually-hidden">{{ staff_page.first_name }}'s </span>Subject Guides</a>
       {% endif %}
     </div>
     <div class="profile-image">


### PR DESCRIPTION
Closes #507 

**Changes in this request**
- Updated SSA nav link to `Social Work` per Library name change
- Overrode Bootstrap focus CSS with code the Center for Digital Accessibility gave to us.
- Added screen reader only name label to Subject Guide links on Staff Browse to make links unique.
- Removed duplicate `id` in Digital Collections Browse template