### PR TITLE
Fix unit tests for upgrade

### DIFF
--- a/lib_collections/tests.py
+++ b/lib_collections/tests.py
@@ -59,7 +59,7 @@ class test_lib_collections_view(TestCase):
         response = collections(request)
 
         self.assertContains(
-            response, '<input name="digital" type="checkbox" arial-label="limit to digital collections" id="checkboxdigital" checked="checked">', html=True)
+            response, '<input name="digital" type="checkbox" aria-label="limit to digital collections" id="checkboxdigital" checked="checked">', html=True)
 
     def test_collections_format(self):
         formats_list = ['Archives & Manuscripts', 'Audio', 'Books & Journals',

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-redis
 django-taggit==1.2.0
 django-treebeard==4.3.1
 djangorestframework==3.11.0
-django-webpack-loader
+django-webpack-loader==0.7.0
 elasticsearch>=5.0.0,<6.0.0
 feedparser==5.2.1
 html5lib==1.0.1
@@ -30,7 +30,7 @@ Pillow>=7.1.0,<8
 -e git+https://github.com/owncloud/pyocclient.git@aa6b4374a779bf0f9e060117b2e8d1e810342bc8#egg=pyocclient
 -e git+https://github.com/uchicago-library/pyiiif.git#egg=pyiiif
 pocli==0.1.10
-psycopg2
+psycopg2>=2.8,<2.9
 Pygments==2.0.2
 pytz==2019.3
 python-dateutil


### PR DESCRIPTION
Fixes #526

**Changes in this request**
- Pegged `psycopg2` and `django-webpack-loader` to version numbers.
- Updated the html of a test to match what is in the template. The template changed as part of the ADA updates and the test needed to be altered to reflect that.