### PR TITLE
Added link decoration and overflow visibility

### DIFF
--- a/base/static/base/css/global.scss
+++ b/base/static/base/css/global.scss
@@ -59,7 +59,8 @@ a {
     &:hover, &:focus {
       color: #487286;
       outline-offset: 1px;
-      text-decoration: none;
+      text-decoration: underline;
+      text-decoration-style: dotted;
     }
   &.social {
     color: #767676;

--- a/base/static/base/css/uclib-search.scss
+++ b/base/static/base/css/uclib-search.scss
@@ -10,6 +10,11 @@ Other Search Row
 @import "variables.scss";
 @import "media.scss";
 
+
+.bootstrap-select.btn-group .dropdown-toggle .filter-option { // ADA automation error silencer
+  overflow: visible!important; 
+}
+
 /*
  * Search Type Tabs
  * --------------------------------------------------


### PR DESCRIPTION
Closes #525 

**Changes in this request**
- Opted for `overflow: visible` as I've already tried auto and it did not resolve the SiteImprove error.
- Added dotted underline to hover and focus state in an attempt to silence link automation error
- Honestly unsure if either of these "fixes" will work to silence the automation errors, but I want to try.