### PR TITLE
Nav and footer changes for buildings reopening

### DIFF
--- a/base/templates/base/includes/footer.html
+++ b/base/templates/base/includes/footer.html
@@ -10,10 +10,6 @@
                 <li><a href="/about/directory/?view=department" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Library Departments">Library Departments</a></li>
                 <li><a href="/about/directory/?view=staff" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Contact &gt; Staff Directory">Staff Directory</a></li>
             </ul>
-            <span class="footer-heading" id="policies_label">Policies</span>
-            <ul aria-labelledby="policies_label">
-                <li><a href="/about/thelibrary/policies/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Policies &gt; Library Policies">Library Policies</a></li>
-            </ul>
         </div>
         <!-- // Contact -->
 
@@ -25,18 +21,16 @@
             {% if is_law %}
                 <li><a href="http://guides.lib.uchicago.edu/lawfacultyservices" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Faculty">Law Faculty</a></li>
                 <li><a href="http://guides.lib.uchicago.edu/lawstudents" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Students">Law Students</a></li>
-            {% else %}
-                <li><a href="/research/help/infofor/faculty/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Faculty">Faculty</a></li>
-                <li><a href="/research/help/infofor/students/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Students">Students</a></li>
-            {% endif %}
-                <li><a href="/research/help/infofor/staff/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; University Staff">University Staff</a></li>
-            {% if is_law %}
                 <li><a href="/law/about/access/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Visitors">Visiting the Law Library</a></li>
-            {% else %}
-                <li><a href="/research/help/infofor/information-visitors/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Visitors">Visitors</a></li>
             {% endif %}
-                <li><a href="/research/help/infofor/alumni/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Alumni &amp; Library Friends">Alumni &amp; Library Friends</a></li>
                 <li><a href="/research/help/infofor/accessibility/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Information for &gt; Patrons with Disabilities">Patrons with Disabilities</a></li>
+            </ul>
+
+            <span class="footer-heading" id="policies_label">Policies</span>
+            <ul aria-labelledby="policies_label">
+                <li><a href="/about/thelibrary/policies/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Policies &gt; Library Policies">Library Policies</a></li>
+                <li><a href="/about/thelibrary/policies/privacy/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Policies &gt; Privacy Statement">Privacy Statement</a></li>
+                <li><a href="https://accessibility.uchicago.edu/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Policies &gt; University Accessibility">University Accessibility</a></li>
             </ul>
         </div>
         <!-- // Information -->
@@ -83,9 +77,7 @@
                 <a href="//www.uchicago.edu/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="The University of Chicago"><img alt="The University of Chicago" src="{% static "base/images/unvlogo-white.png" %}" width="150" /></a>
                 <!-- Library Location: Address -->
                 <p><span>{{page_location}}</span><br/><span>{{address}}</span></p>
-                <small><a href="/about/thelibrary/policies/privacy/" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Privacy Statement">Privacy Statement</a><br/>
-                <a href="https://accessibility.uchicago.edu/">University Accessibility</a><br/>
-                &copy; <span>The University of Chicago</span><br/>
+                <small>&copy; <span>The University of Chicago</span><br/>
                 <span class="staff-login"><a href="/admin" data-ga-category="footer-links" data-ga-action="click" data-ga-label="Staff Login">Staff Login</a></span>
                 </small>
             </div>

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -126,7 +126,7 @@
                                         <li><a href="/borrow/borrowing/renewing-and-returning-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Renewing &amp; Returning Items">Renewing &amp; Returning Items</a></li>
                                         <li><a href="/borrow/borrowing/fines-and-lost-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Fines &amp; Lost Items">Fines &amp; Lost Items</a></li>
                                         <li><a href="/borrow/borrowing/course-reserves" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Course Reserves">Course Reserves</a></li>
-                                        <!-- <li><a href="/borrow/borrowing/checkout" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Checkout UChicago">Checkout UChicago</a></li> -->
+                                        <li><a href="/borrow/borrowing/checkout" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; Checkout UChicago">Checkout UChicago</a></li>
                                         <li><a href="http://www.lib.uchicago.edu/myaccount" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Borrow &amp; Request &gt; My Library Account">My Library Account</a> <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:8em"></p></li>
                                     </ul>
                                 </li>
@@ -280,8 +280,8 @@
                                 <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="onsite_services">On-Site Services</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="onsite_services">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                        <li><a href="https://rooms.lib.uchicago.edu/r" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Book a Seat">Book a Seat</a></li>
-                                        <li><a href="/research/help/infofor/bookstacks/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Bookstacks Access">Bookstacks Access</a></li>
+                                        <!-- <li><a href="https://rooms.lib.uchicago.edu/r" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Book a Seat">Book a Seat</a></li> -->
+                                        <!-- <li><a href="/research/help/infofor/bookstacks/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Bookstacks Access">Bookstacks Access</a></li> -->
                                         <li><a href="/borrow/borrowing/paging/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Paging &amp; Pickup">Paging &amp; Pickup</a></li>
                                         <li><a href="/borrow/borrowing/renewing-and-returning-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Returns">Returns</a></li>
                                         <li><a href="https://rooms.lib.uchicago.edu/reserve/carding" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; UChicago Card Services">UChicago Card Services</a>

--- a/library_website/urls.py
+++ b/library_website/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
     url(r'^ebooks-search/$', ebooks_search, name='ebooks'),
     url(r'^api/v2/', api_router.urls),
     url('^inventory\.xml$', sitemap),
-    # url(r'^spaces/$', spaces_view, name='spaces'),
+    url(r'^spaces/$', spaces_view, name='spaces'),
     url(r'^staff/$', staff, name='staff'),
     url(r'^staff_api/$', staff_api, name='staff_api'),
     url(r'^about/directory/$', unit_view, name='unit'),
@@ -61,9 +61,7 @@ urlpatterns = [
     url(r'^workflowautomator/', include('workflowautomator.urls')),
     url(r'rss/(?P<slug>[-\w]+)/$', RSSFeeds()),
     url(r'', include(wagtail_urls)),
-] + static(
-    settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
-)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # Prepend the shibboleth logout url if the application
 # is configured for shibboleth
@@ -76,5 +74,4 @@ if settings.DEBUG:
 
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
-    urlpatterns += static(settings.MEDIA_URL,
-                          document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Fixes #539

**Changes in this request**
- Removed and added links in nav to match services for buildings reopening
- Rearranged footer links per Web Content Group discussion
- Unsuppressed Spaces browse