### PR TITLE
Added for loop directly in Reports Index template

### DIFF
--- a/group/templates/group/group_reports_page.html
+++ b/group/templates/group/group_reports_page.html
@@ -7,7 +7,16 @@
 	<article>
         <h1>{{ self.title }}</h1>
         {% with table=self.get_reports_grouped_by_date %}
-            {% include "base/minutes_and_reports_outer_table.html" %}
+            <dl>
+                {% for date, items in table.items %}
+                  <dt>{{date}}</dt>
+                  {% for item in items %}
+                    <dd>
+                      <a href="{{item.url}}">{{item.summary}}</a>
+                    </dd>
+                  {% endfor %}
+                {% endfor %}
+            </dl>
         {% endwith %}
 	</article>
 {% endblock %}


### PR DESCRIPTION
Fixes #546 .

**Changes in this request**
- Moved for loop with dictionary list into the Report Page Index
- The structure was calling both child pages and uploaded links/docs specified from "Year" page. Moving `dl` to index seems to skip over this erroneous call. 
- Reviewed by EE, who reported the issue, so verify concern was resolved.

![Screen Shot 2021-08-12 at 1 01 14 PM](https://user-images.githubusercontent.com/10147408/129247038-51b3baa6-3477-46a8-865c-d10b88605c60.png)
![Screen Shot 2021-08-12 at 1 01 18 PM](https://user-images.githubusercontent.com/10147408/129247045-959120b7-37ff-42e8-9fe6-7e59d8268296.png)

