### PR TITLE
Small color changes for ADA fixes

### DIFF
--- a/base/static/base/css/collex-digital.scss
+++ b/base/static/base/css/collex-digital.scss
@@ -182,9 +182,6 @@ body.collectionpage {
 		.rightside-mod {
 			padding-bottom: 1em;
 		}
-		a {
-			text-decoration: underline;
-		}
 	}
 
 	#hiddenCitation {

--- a/base/static/base/css/sidebars.scss
+++ b/base/static/base/css/sidebars.scss
@@ -168,9 +168,11 @@ Right Sidebar: Widget Items
   padding: 20px 15px 0px 15px;
   a {
     color:  $active-hover;
-    &:hover {
+    &:hover, &:focus {
       color: $default-link;
-      text-decoration: none;
+      outline-offset: 1px;
+      text-decoration: underline;
+      text-decoration-style: dotted;
     }
   }
   h2, h3 {

--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -62,6 +62,10 @@ body.libnewspage .breadcrumbs, body.libnewsindexpage .breadcrumbs, .h1-banner .b
    @include visually-hidden;
 }
 
+body.libnewsindexpage article .img-object .preload span {
+  color: #000000;
+}
+
  .h1-banner, #p-4898 h1, #p-3378 h1:not(.searchbox-header) {  // Hide h1 on homepages with banners
   @include visually-hidden;
 }
@@ -479,6 +483,7 @@ figure.coll-thumb {
 }
 
 .carousel-inner {
+  background-color: #575757;
   &>.item>a>img, &>.item>img, .img-responsive, .thumbnail a>img, .thumbnail>img {
     width: 100%
   }
@@ -2020,7 +2025,7 @@ body.staffpublicpage {
     border-radius: 8px;
   }
   abbr[title] {
-    color: #FF3399;
+    color: #a01f60;
     font-size: 1.3em;
     font-weight: 900;
     margin-left: 0.25em;
@@ -2068,6 +2073,9 @@ body.staffpublicpage {
     font-weight: 600;
     line-height: 1.42857143;
     border-radius: 4px;
+  }
+  input[type="checkbox"], input[type="radio"] {
+    margin-bottom: 1em;
   }
   .ty-message {
     padding: 1em 0;


### PR DESCRIPTION
Fixes #538

**Changes in this request**
- Color change to required mark on forms (Can be see on local at `/about/directory/staff/jean-luc-picard/test-cgimail-form/`)
- Focus and hover changes to sidebar links. (Can be seen on local at `collex/collections/19th-century-maps-middle-east-north-africa-and-central-asia/`)
- Made temp load text for News images be black. Internet too fast to check; will see if successful in SiteImprove report next week)