### PR TITLE
Added Fall links to global nav

### DIFF
--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -280,7 +280,8 @@
                                 <li class="col-sm-6"><span class="twocol-head" role="heading" aria-level="2" id="onsite_services">On-Site Services</span>
                                     <ul class="list-unstyled" role="region" aria-labelledby="onsite_services">
                                         <li role="separator" class="divider visible-xs" role="presentation"></li>
-                                        <!-- <li><a href="https://rooms.lib.uchicago.edu/r" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Book a Seat">Book a Seat</a></li> -->
+                                        <li><a href="https://rooms.lib.uchicago.edu/r" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Book a Seat">Book a Room</a></li>
+                                        <li><a href="/spaces/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Places to Study">Places to Study</a></li>
                                         <!-- <li><a href="/research/help/infofor/bookstacks/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Bookstacks Access">Bookstacks Access</a></li> -->
                                         <li><a href="/borrow/borrowing/paging/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Paging &amp; Pickup">Paging &amp; Pickup</a></li>
                                         <li><a href="/borrow/borrowing/renewing-and-returning-items/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Returns">Returns</a></li>


### PR DESCRIPTION
Closes #560

**Changes in this request**
-Added "Book a Room" (rooms.lib.uchicago.edu/r/) to global navigation, under Remote & On-site Services|On-site Services
-Added "Spaces to Study" (https://www.lib.uchicago.edu/spaces/) to global navigation, under Remote & On-site Services|On-site Services