### PR TITLE
Loop News Previews Should Display More Rich Text

### DIFF
--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -326,7 +326,6 @@ figure.center-block {
   font-style: italic; }
 
 .media-body .rich-text {
-  font-size: 1.2em;
   line-height: 1.7em;
   max-width: 46em; }
 

--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -326,6 +326,7 @@ figure.center-block {
   font-style: italic; }
 
 .media-body .rich-text {
+  font-size: 1.2em;
   line-height: 1.7em;
   max-width: 46em; }
 

--- a/news/templates/news/news_excerpt.html
+++ b/news/templates/news/news_excerpt.html
@@ -1,4 +1,9 @@
-<div class="rich-text">{{ excerpt|safe }}</div>
-{% if read_more %}
-  <p><a class="view-more" href="{{ news_page.url }}">Read more &gt;&gt;</a></p>
-{% endif %}
+{% load wagtailcore_tags %}
+<div class="rich-text">
+  {% if rt %}
+    {{ excerpt|truncatewords_html:70|richtext }}
+  {% else %}
+    {{ excerpt|truncatewords:70 }}
+  {% endif %}
+</div>
+<p><a class="view-more" href="{{ news_page_url }}">Read more &gt;&gt;</a></p>

--- a/news/templates/news/news_excerpt.html
+++ b/news/templates/news/news_excerpt.html
@@ -3,7 +3,7 @@
   {% if rt %}
     {{ excerpt|truncatewords_html:70|richtext }}
   {% else %}
-    {{ excerpt|truncatewords:70 }}
+    {{ excerpt|truncatewords_html:70 }}
   {% endif %}
 </div>
 <p><a class="view-more" href="{{ news_page_url }}">Read more &gt;&gt;</a></p>

--- a/news/templates/news/news_excerpt.html
+++ b/news/templates/news/news_excerpt.html
@@ -3,7 +3,7 @@
   {% if rt %}
     {{ excerpt|truncatewords_html:70|richtext }}
   {% else %}
-    {{ excerpt|truncatewords_html:70 }}
+    {{ excerpt|striptags|truncatewords:70 }}
   {% endif %}
 </div>
 <p><a class="view-more" href="{{ news_page_url }}">Read more &gt;&gt;</a></p>

--- a/news/templatetags/news_tags.py
+++ b/news/templatetags/news_tags.py
@@ -24,50 +24,27 @@ def news_author(news_page):
         'author_url': author_url
     }
 
+
 @register.inclusion_tag('news/news_excerpt.html')
 def news_excerpt(news_page):
-    '''Output an excerpt for a Loop news page. 
-    '''
-
+    """
+    Output an excerpt for a Loop news page.
+    """
     def simplify_text(s):
-        # strip out every HTML tag except opening and closing <a> tags. 
+        # strip out every HTML tag except opening and closing <a> tags.
         s = re.sub(r"<(?!\/?a(?=>|\s.*>))\/?.*?>", " ", s)
         s = re.sub(r"\s+", " ", s)
         return s.strip()
 
-    # get the first num_words (e.g. 50) words. 
-    # don't allow unclosed anchor tags through.
-    def get_excerpt_safely(words, num_words):
-        excerpt_words = words[:num_words]
-        opening_anchor_tag_count = sum('<a' not in word for word in excerpt_words)
-        closing_anchor_tag_count = sum('</a>' not in word for word in excerpt_words)
-        if opening_anchor_tag_count != closing_anchor_tag_count:
-            while True:
-                last_word = excerpt_words.pop()
-                if not last_word:
-                    break
-                if '<a' in last_word:
-                    break
-        return ' '.join(excerpt_words)
-    
-    simplified_text = simplify_text(news_page.excerpt)
-    if simplified_text:
-        words = simplified_text.split(" ")
-        excerpt = get_excerpt_safely(words, 50)
-        read_more = True
+    if simplify_text(news_page.excerpt):
+        excerpt = news_page.excerpt
+        richtext = True
     else:
-        simplified_text = simplify_text(" ".join([s.render() for s in news_page.body]))
-        words = simplified_text.split(" ")
-        excerpt = get_excerpt_safely(words, 50)
-
-        if len(words) > 50:
-            excerpt = excerpt + "..."
-            read_more = True
-        else:
-            read_more = False
+        excerpt = news_page.body
+        richtext = False
 
     return {
         'excerpt': excerpt,
-        'news_page': news_page,
-        'read_more': read_more
+        'news_page_url': news_page.url,
+        'rt': richtext
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.8.2
 bleach==3.3.0
-DateTime==4.0.1
+DateTime>=4,<5
 defusedxml
 -e git+https://github.com/bbusenius/Diablo-Python.git#egg=diablo_python 
 Django==3.1.12


### PR DESCRIPTION
Fixes #569 

**Changes in this request**
- Fixes a Vagrant build bug by upgrading `DateTime`.
- Adds the display of `RichText` for news stories on the Loop homepage. `RichText` beyond anchors only displays for stories when the excerpt field has been filled out.
- Switches to built in Django template tags for truncation and away from a home brewed solution, simplifying the code.