### PR TITLE
574 index features tags from library spaces

### DIFF
--- a/public/models.py
+++ b/public/models.py
@@ -699,7 +699,6 @@ class LocationPage(PublicBasePage, Email, Address, PhoneNumber):
 
     subpage_types = ['public.StandardPage', 'public.FloorPlanPage']
 
-    # location_strings = post_process([item[0] for item in get_features()])
     location_fields = [mk_search_field(item[0]) for item in get_features()]
 
     search_fields = PublicBasePage.search_fields + [

--- a/public/models.py
+++ b/public/models.py
@@ -8,7 +8,7 @@ from base.models import (
 from django.db import models
 from django.db.models.fields import CharField
 from modelcluster.fields import ParentalKey
-from public.utils import get_features
+from public.utils import get_features, mk_search_field
 from staff.models import StaffPage
 from staff.utils import libcal_id_by_email
 from subjects.utils import get_subjects_html
@@ -699,6 +699,9 @@ class LocationPage(PublicBasePage, Email, Address, PhoneNumber):
 
     subpage_types = ['public.StandardPage', 'public.FloorPlanPage']
 
+    # location_strings = post_process([item[0] for item in get_features()])
+    location_fields = [mk_search_field(item[0]) for item in get_features()]
+
     search_fields = PublicBasePage.search_fields + [
         index.SearchField('short_description', partial_match=True),
         index.SearchField('long_description', partial_match=True),
@@ -706,7 +709,7 @@ class LocationPage(PublicBasePage, Email, Address, PhoneNumber):
         index.SearchField('location_photo'),
         index.SearchField('reservation_url'),
         index.SearchField('reservation_display_text'),
-    ]
+    ] + location_fields
 
     api_fields = [
         APIField('libcal_library_id'),

--- a/public/utils.py
+++ b/public/utils.py
@@ -271,4 +271,13 @@ def switchboard_url(form_name, form_option=''):
 
 
 def mk_search_field(string):
+    """
+    Make a 'partial match' search field out of a string.
+
+    Args:
+        a string to go into the search index
+
+    Returns:
+        a search field
+    """
     return index.SearchField(string, partial_match=True)

--- a/public/utils.py
+++ b/public/utils.py
@@ -1,8 +1,6 @@
 from library_website.settings import IDRESOLVE_URL
 from wagtail.search import index
-import re
 import requests
-import itertools
 
 FEATURES_LIST = [
     (

--- a/public/utils.py
+++ b/public/utils.py
@@ -1,5 +1,8 @@
 from library_website.settings import IDRESOLVE_URL
+from wagtail.search import index
+import re
 import requests
+import itertools
 
 FEATURES_LIST = [
     (
@@ -267,3 +270,7 @@ def switchboard_url(form_name, form_option=''):
         return '/about/news/search/'
     else:
         assert (False)
+
+
+def mk_search_field(string):
+    return index.SearchField(string, partial_match=True)


### PR DESCRIPTION
Fixes #574.

**Changes in this request**
Adds a tiny amount of code to `public/models.py` and `public/utils.py` to throw the spaces locations into the search fields for `LocationPage`-s.