### PR TITLE
fix redundant inclusion of uclib-print.css in public/base template

### DIFF
--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -74,7 +74,6 @@
         <script src="https://api3.libcal.com/js/hours_grid.js?002"></script>
         <script src="https://api3.libcal.com/js/hours_today.js"></script>
     {% endif %}
-    <link rel="stylesheet" href="{% static "base/css/uclib-print.css" %}"/>
     {% block styles %}{% endblock %}
 </head>
 


### PR DESCRIPTION
Fixes #582.

The issue ended up being that the `public_base` template had *both* a reference to `uclib-print.scss` *and* a reference to `uclib-print.css`.  Perhaps this is because after the scss template was added to the 'compress' section, the old css include was accidentally left in.  In any event...