### PR TITLE
Item servlet fails in some cases

### DIFF
--- a/item_servlet/tests.py
+++ b/item_servlet/tests.py
@@ -69,7 +69,7 @@ class TestItemServletUtils(TestCase):
         self.assertTrue(holdings == {})
 
     def test_get_item_with_bad_data(self):
-        item = get_item({'foo': 'bar'}, 'badbarcode', 'badtoken')
+        item = get_item('badbarcode', 'badtoken')
         self.assertTrue(item == {})
 
     def test_get_location_with_bad_data(self):

--- a/item_servlet/utils.py
+++ b/item_servlet/utils.py
@@ -68,7 +68,7 @@ def get_instances(bib, token):
         return json.loads(response.content)['instances'][0]
     except (
         requests.exceptions.Timeout, json.decoder.JSONDecodeError,
-        requests.exceptions.ConnectionError
+        requests.exceptions.ConnectionError, IndexError
     ):
         return dict()
 

--- a/item_servlet/utils.py
+++ b/item_servlet/utils.py
@@ -104,13 +104,11 @@ def get_holdings(instance_id, token):
         return dict()
 
 
-def get_item(holdings, barcode, token):
+def get_item(barcode, token):
     """
     Queries the Folio item storage API.
 
     Args:
-        holdings: dict
-
         barcode: string
 
         token: string, token from get_auth dict
@@ -118,12 +116,9 @@ def get_item(holdings, barcode, token):
     Returns:
         dict
     """
-    if holdings and barcode and token:
+    if barcode and token:
         try:
-            holding = holdings['holdingsRecords'][0]
-            holdings_record_id = holding['id']
-            q = '(holdingsRecordId=="' + holdings_record_id + \
-                '" AND barcode=' + barcode + ' NOT discoverySuppress==true)'
+            q = '(barcode=' + barcode + ' NOT discoverySuppress==true)'
             headers = GENERIC_HEADERS
             headers.update({'X-Okapi-Token': token})
             url = settings.FOLIO_BASE_URL + '/item-storage/items?query=%s' % q
@@ -131,7 +126,7 @@ def get_item(holdings, barcode, token):
             return json.loads(response.content)['items'][0]
         except (
             requests.exceptions.Timeout, json.decoder.JSONDecodeError,
-            requests.exceptions.ConnectionError, KeyError
+            requests.exceptions.ConnectionError, IndexError, KeyError
         ):
             pass
     return dict()

--- a/item_servlet/views.py
+++ b/item_servlet/views.py
@@ -4,7 +4,7 @@ from library_website.settings import (
 )
 
 from .utils import (
-    get_auth, get_holdings, get_instances, get_item, get_location
+    get_auth, get_instances, get_item, get_location
 )
 
 # Lookup for identifier types
@@ -110,8 +110,7 @@ def item_servlet(request):
         auth = get_auth()
         token = auth['x-okapi-token']
         instances = get_instances(bib, token)
-        holdings = get_holdings(instances.get('id'), token)
-        item = get_item(holdings, barcode, token)
+        item = get_item(barcode, token)
         location_id = item.get('effectiveLocationId')
         location = dict()
         if location_id:


### PR DESCRIPTION
Fixes #585 

**Changes in this request**
- Allow bib level data to populate if items data is not present (was failing in select cases)
- Get items by barcode instead of filtering holdings > items by barcode.

**Testing Notes**:
- Fail case: https://catalog.lib.uchicago.edu/vufind/Record/1299992
- http://wwwdev:8000/item-servlet/?p=true&bib=1299992&barcode=088440577 should populate with item information, if it does not, empty the Wagtail cache in the admin.