### PR TITLE
 Poorly formed navigation on SFX

### DIFF
--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -288,7 +288,7 @@
                                         <li><a href="https://rooms.lib.uchicago.edu/reserve/carding" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; UChicago Card Services">UChicago Card Services</a></li>
                                         <li><a href="/thelibrary/techbar/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; TechBar">TechBar</a></li>
                                         <li><a href="https://printing.uchicago.edu/" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="On-Site Services &gt; Printing">Printing</a></li>
-                                         <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:8em"></p></li>
+                                         <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:8em"></p>
                                     </ul>
                                 </li>
                                 <!-- // Research > Onsite column -->


### PR DESCRIPTION
Fixes #598

**Changes in this request**
- Removes a superfluous `li` end tag. 

**Testing**
- In order to test this, compare the output of [the external_include API on production](https://www.lib.uchicago.edu/external-include/?include=header) to [the one in this PR](http://wwwdev:8000/external-include/?include=header).
- You will need to empty Wagtail cache.