### PR TITLE
Fix dev environment for new installs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,8 @@ Vagrant.configure("2") do |config|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = false
     # Customize the amount of memory on the VM:
-    vb.memory = "4096"
+    vb.memory = "10240"
+    vb.cpus = 8
   end
   #
   # View the documentation for the provider you are using for more
@@ -93,7 +94,7 @@ Vagrant.configure("2") do |config|
 
     # Pip install project dependencies
     echo "Pip installing project dependencies"
-    source lw/bin/activate && cd /vagrant/ && pip install -r requirements.txt
+    source lw/bin/activate && cd /vagrant/ && pip install -r requirements.txt && pip install -r requirements-dev.txt
    
     # Start Elasticsearch
     systemctl enable elasticsearch

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,19 +1,19 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
-Vagrant.configure("2") do |config|
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "torchbox/wagtail-stretch64"
-  config.vm.box_version = "1.0.0"
+  # https://app.vagrantup.com/ubuntu/boxes/jammy64
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.box_version = "20220902.0.0"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -50,6 +50,20 @@ Vagrant.configure("2") do |config|
     # Customize the amount of memory on the VM:
     vb.memory = "10240"
     vb.cpus = 8
+
+    up_message = <<-MSG
+
+    WRITE SOME CODE!!!
+         ___________________________            ____
+    ...  \____DLDC_220_________|_// __=*=__.--"----"--._________
+                        \  |        /-------.__________.--------'
+                   /=====\ |======/      '     "----"
+                      \________          }]
+                               `--------'
+    MAKE IT SO!!!
+    MSG
+
+config.vm.post_up_message = up_message
   end
   #
   # View the documentation for the provider you are using for more
@@ -71,54 +85,136 @@ Vagrant.configure("2") do |config|
     VIRTUALENV_DIR=/home/vagrant/lw
     PYTHON=$VIRTUALENV_DIR/bin/python
 
+    # Silence "dpkg-preconfigure: unable to re-open stdin" warnings
+    export DEBIAN_FRONTEND=noninteractive
+
     # Create the django error log
-    echo "Creating /var/log/django-errors.log"
+    echo "============== Creating /var/log/django-errors.log =============="
+    echo "..."
     touch /var/log/django-errors.log
     chown vagrant /var/log/django-errors.log
     chgrp vagrant /var/log/django-errors.log
 
-    # Install dependencies
-    echo "Installing dependencies" 
-    apt-get update
+    # Update repos
+    echo ""
+    echo "============== Updating repos =============="
+    rm -rf /var/lib/apt/lists/partial
+    apt-get update -y -o Acquire::CompressionTypes::Order::=gz
+    #apt-get update -y
+
+    # Jammy ships wih Python 10. We need Python 9.
+    # Remove this to go to Python 10 in the future.
+    echo ""
+    echo "============== Downgrading to Python 3.9 =============="
+    apt-get install -y software-properties-common
+    add-apt-repository ppa:deadsnakes/ppa
+    apt-get install -y python3.9
+    apt-get -y install python3.9-distutils
+    apt-get install -y python3-pip python3.9-dev python3.9-venv
+
+    # Install Wagtail dependencies and useful dev tools
+    echo -e ""
+    echo "============== Installing Wagtail dependencies and useful dev tools =============="
+    apt-get install -y vim git curl gettext build-essential
+    apt-get install -y libjpeg-dev libtiff-dev zlib1g-dev libfreetype6-dev liblcms2-dev libllvm11
+    apt-get install -y redis-server postgresql libpq-dev
+
+    # Install UChicago dependencies
+    echo ""
+    echo "============== Installing UChicago dependencies =============="
+    apt-get update -y
     apt-get install -y libxml2-dev
     apt-get install -y libxslt-dev
 
+    # Java for Elasticsearch
+    echo ""
+    echo "============== Installing Java for Elsasticsearch =============="
+    apt-get update -y
+    apt-get install -y openjdk-11-jre-headless ca-certificates-java
+
+    # Install poetry and Fabric
+    # We need virtualenv >13.0.0 in order to get pip 7 to automatically install
+    echo ""
+    echo "============== Pip installing poetry, Fabric, and virtualenv =============="
+    pip3 install poetry Fabric
+    pip3 install virtualenv
+
+    # NVM and Node JS
+    echo ""
+    echo "============== Installing NVM and NodeJS =============="
+    su - vagrant -c "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash"
+    su - vagrant -c "export NVM_DIR=\$HOME/.nvm && \. \$NVM_DIR/nvm.sh && nvm install 12.16"
+
     # Create a Postgres user and database
-    echo "Creating Postgres user and database"
-    sudo -u postgres createuser owning_user
+    echo ""
+    echo "============== Creating Postgres user and database =============="
+    echo "..."
+    su - postgres -c "createuser -s vagrant"
     sudo -u postgres createdb -O vagrant lib_www_dev
 
+    # Elasticsearch
+    echo ""
+    echo "============== Downloading Elasticsearch =============="
+    wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.23.deb
+    dpkg -i elasticsearch-6.8.23.deb
+    # reduce JVM heap size from 2g to 512m
+    sed -i 's/^\(-Xm[sx]\)2g$/\1512m/g' /etc/elasticsearch/jvm.options
+    rm elasticsearch-6.8.23.deb
+
     # Create a Python virtualenv
-    echo "Creating a Python virtualenv"
-    cd /home/vagrant && virtualenv lw 
+    echo ""
+    echo "============== Creating a Python virtualenv =============="
+    echo "..."
+    cd /home/vagrant && python3.9 -m venv lw
 
     # Pip install project dependencies
-    echo "Pip installing project dependencies"
-    source lw/bin/activate && cd /vagrant/ && pip install -r requirements.txt && pip install -r requirements-dev.txt
+    echo ""
+    echo "============== Pip installing project dependencies =============="
+    source lw/bin/activate
+    pip install --upgrade pip
+    cd /vagrant/
+    pip install -r requirements.txt && pip install -r requirements-dev.txt
    
     # Start Elasticsearch
+    echo ""
+    echo "============== Starting Elasticsearch =============="
     systemctl enable elasticsearch
     systemctl start elasticsearch
 
     # Remove packages we don't need
-    echo "Removing pacakages we don't need" 
+    echo ""
+    echo "============== Cleaning up =============="
     apt-get autoremove -y
+    # Remove Python tests pycache (only used for testing Python itself. Saves 29.5MB)
+    rm -rf /usr/local/lib/python3.7/test/__pycache__
+    apt-get clean
 
     # Run migrations, load the dev db and build a search index
-    echo "Running django migrations and loading the dev database"
+    echo ""
+    echo "============== Running django migrations and loading the dev database =============="
     su - vagrant -c "$PYTHON $PROJECT_DIR/manage.py migrate --noinput && \
                      $PYTHON $PROJECT_DIR/manage.py loaddata /vagrant/base/fixtures/test.json && \
                      $PYTHON $PROJECT_DIR/manage.py update_index"
 
     # Create the static news feed JSON file
-    echo "Installing the news feed test file"
+    echo ""
+    echo "============== Creating the news feed test file =============="
+    echo "..."
     mkdir -p /vagrant/static/lib_news/files
     cp /vagrant/base/fixtures/news-feed-test.json /vagrant/static/lib_news/files/lib-news.json
 
     # Setup /etc/hosts
-    echo "Setting up /etc/hosts"
+    echo ""
+    echo "============== Setting up /etc/hosts =============="
+    echo "..."
     sudo su -
     echo "127.0.0.1 wwwdev" >> /etc/hosts
     echo "127.0.0.1 loopdev" >> /etc/hosts
+
+    # Fix git permissions
+    echo ""
+    echo "============== Fixing git permissions =============="
+    echo "..."
+    sudo chown -R vagrant /home/vagrant
   SHELL
 end

--- a/lib_collections/tests.py
+++ b/lib_collections/tests.py
@@ -455,8 +455,11 @@ class TestCollectingAreaPages(TestCase):
         page = self.collecting_area
         subject_specialist = page._build_subject_specialist(
             self.captain, self.site)
-        self.assertEqual(subject_specialist, ('Jean-Luc Picard', 'Captain of the USS Enterprise',
-                                              '/jean-luc-picard-public/', 'picard@starfleet.io', (('012-345-6789', 'Bridge'),), None))
+        self.assertEqual(subject_specialist[0], 'Jean-Luc Picard')
+        self.assertEqual(subject_specialist[1], 'Captain of the USS Enterprise')
+        self.assertEqual(subject_specialist[2], '/jean-luc-picard-public/')
+        self.assertEqual(subject_specialist[3].email, 'picard@starfleet.io')
+        self.assertEqual(subject_specialist[4], (('012-345-6789', 'Bridge'),), None)
 
     def test_build_subject_specialist_with_wrong_page_type(self):
         page = self.collecting_area

--- a/public/models.py
+++ b/public/models.py
@@ -28,7 +28,9 @@ from wagtail.images.models import Image
 from wagtail.search import index
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
-from public.utils import get_features, mk_search_field
+from public.utils import get_features
+
+from units.utils import get_default_unit
 
 # TEMPORARY: Fix issue # 2267:https://github.com/torchbox/wagtail/issues/2267
 # from wagtail.admin.forms import WagtailAdminPageForm
@@ -973,7 +975,11 @@ class StaffPublicPage(PublicBasePage):
             else:
                 return (unit, unit.get_parent())
 
-        unit = s.staff_page_units.first().library_unit
+        unit = get_default_unit()
+        try:
+            unit = s.staff_page_units.first().library_unit
+        except AttributeError:
+            pass
 
         parent_unit_list = [u.title for u in unfold(next_unit, unit)]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.8.2
 bleach==3.3.0
 DateTime>=4,<5
 defusedxml
--e git+https://github.com/bbusenius/Diablo-Python.git#egg=diablo_python 
+-e git+https://github.com/bbusenius/Diablo-Python.git#egg=diablo_python
 Django==3.1.12
 django-appconf==1.0.4
 django-bleach==0.6.1
@@ -13,7 +13,7 @@ django-localflavor==1.2
 django-macros==0.4.0
 django-redis
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django_shibboleth_remoteuser
--e git+https://github.com/cafehaine/django-static-precompiler.git@5499f745e5823f6eb9136a7591f9c0d5e2485a18#egg=django-static-precompiler
+django-static-precompiler
 django-taggit==1.2.0
 django-treebeard==4.3.1
 django-webpack-loader==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,18 +8,17 @@ django-appconf==1.0.4
 django-bleach==0.6.1
 django-compressor==2.4
 django-cors-headers==3.2.1
-django-libsass==0.8
+django-libsass
 django-localflavor==1.2
 django-macros==0.4.0
 django-redis
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django_shibboleth_remoteuser
 django-static-precompiler
 django-taggit==1.2.0
-django-treebeard==4.3.1
 django-webpack-loader==0.7.0
-elasticsearch>=>=6.4.0,<7.0.0
+elasticsearch>=6.4.0,<7.0.0
 html5lib==1.0.1
-libsass==0.19.4
+libsass
 lxml
 networkx
 openpyxl
@@ -27,11 +26,9 @@ Pillow>=8.2.0,<9
 -e git+https://github.com/owncloud/pyocclient.git@aa6b4374a779bf0f9e060117b2e8d1e810342bc8#egg=pyocclient
 -e git+https://github.com/uchicago-library/pyiiif.git#egg=pyiiif
 pocli==0.1.10
-psycopg2>=2.8,<2.9
+psycopg2
 Pygments==2.7.4
-pytz==2019.3
 python-dateutil
-rcssmin==1.0.6
 requests>=2.25.1,<2.26.0
 rjsmin==1.1.0
 simplejson==3.11.1


### PR DESCRIPTION
Fixes #602 

**Changes in this request**
- Fixes `django-static-precompiler` package in `requirements.txt`
- Gets unit tests passing again
- Fixes `--parallel` testing in the Vagrant environment
- Allocates more memory and cpu to Virtualbox
- New Vagrantfile and dev version of the site that runs on Ubuntu jammy and `Python 3.9`.
- Tweaks to `requirements.txt` for `Python 3.9`