### PR TITLE
595 add function to override header font size and kerning in collections and exhibits

### DIFF
--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -6,7 +6,7 @@ import simplejson
 from base.models import DefaultBodyFields, PublicBasePage
 from diablo_utils import lazy_dotchain
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.paginator import EmptyPage, Paginator
+from django.core.paginator import Paginator, EmptyPage
 from django.core.validators import RegexValidator
 from django.db import models
 from django.http import Http404, HttpResponse

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -2020,12 +2020,12 @@ class ExhibitPage(PublicBasePage):
     font_scaler = models.FloatField(
         blank=True,
         null=True,
-        help_text='The multiplication factor of the default font size, e.g. 0<x<1 makes the font smaller, and x>1 makes the font bigger'  # reword?
+        help_text='Enter a value between 0 and 1 for a smaller font. Enter a value greater than 1 for a larger font. e.g. 0.5, 1.5, or 2'
     )
     font_kerning = models.FloatField(
         null=True,
         blank=True,
-        help_text='A decimal value determining spacing between letters'  # reword?
+        help_text='Enter a positive number to increase spacing between letters, or a negative number to reduce spacing. Decimal values are okay. e.g. 2.5 or -1.25'
     )
 
     subpage_types = ['lib_collections.ExhibitChildPage']

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -2020,12 +2020,12 @@ class ExhibitPage(PublicBasePage):
     font_scaler = models.FloatField(
         blank=True,
         null=True,
-        help_text='The multiplication factor of the default font size'  # reword?
+        help_text='The multiplication factor of the default font size, e.g. 0<x<1 makes the font smaller, and x>1 makes the font bigger'  # reword?
     )
-    font_kerning = models.IntegerField(
+    font_kerning = models.FloatField(
         null=True,
         blank=True,
-        help_text='The spacing between letters'  # reword?
+        help_text='A decimal value determining spacing between letters'  # reword?
     )
 
     subpage_types = ['lib_collections.ExhibitChildPage']

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -41,6 +41,7 @@ from .utils import (CBrowseURL, CitationInfo, DisplayBrowse, IIIFDisplay,
 
 DEFAULT_WEB_EXHIBIT_FONT = '"Helvetica Neue", Helvetica, Arial, sans-serif'
 DEFAULT_WEB_EXHIBIT_FONT_SIZE = 16.8
+DEFAULT_WEB_EXHIBIT_FONT_KERNING = 1
 
 
 def get_current_exhibits():
@@ -2022,7 +2023,7 @@ class ExhibitPage(PublicBasePage):
         help_text='The multiplication factor of the default font size'  # reword?
     )
     font_kerning = models.IntegerField(
-        default=1,
+        null=True,
         blank=True,
         help_text='The spacing between letters'  # reword?
     )
@@ -2288,6 +2289,10 @@ class ExhibitPage(PublicBasePage):
         if self.font_scaler:
             font_size = self.font_scaler * font_size
 
+        font_kerning = DEFAULT_WEB_EXHIBIT_FONT_KERNING
+        if self.font_kerning:
+            font_kerning = self.font_kerning
+
         unit_title = lazy_dotchain(lambda: self.unit.title, '')
         unit_url = lazy_dotchain(lambda: self.unit.public_web_page.url, '')
         unit_email_label = lazy_dotchain(lambda: self.unit.email_label, '')
@@ -2314,7 +2319,7 @@ class ExhibitPage(PublicBasePage):
         context['staff_url'] = staff_url
         context['branding_color'] = self.branding_color
         context['font_family'] = font
-        context['font_kerning'] = self.font_kerning
+        context['font_kerning'] = font_kerning
         context['font_size'] = font_size
         context['google_font_link'] = self.google_font_link
         context['footer_img'] = footer_img

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -1,29 +1,30 @@
 import datetime
-
-import simplejson
-import requests
-from base.models import DefaultBodyFields, PublicBasePage
 from collections import OrderedDict
+
+import requests
+import simplejson
+from base.models import DefaultBodyFields, PublicBasePage
 from diablo_utils import lazy_dotchain
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.paginator import Paginator, EmptyPage
+from django.core.paginator import EmptyPage, Paginator
 from django.core.validators import RegexValidator
 from django.db import models
 from django.http import Http404, HttpResponse
 from django.template.response import TemplateResponse
 from django.utils.text import slugify
-from library_website.settings import (
-    CRERAR_BUILDING_ID, CRERAR_EXHIBIT_FOOTER_IMG, SCRC_BUILDING_ID,
-    SCRC_EXHIBIT_FOOTER_IMG, APA_PATH, CHICAGO_PATH, MLA_PATH,
-    COLLECTION_OBJECT_TRUNCATE
-)
+from library_website.settings import (APA_PATH, CHICAGO_PATH,
+                                      COLLECTION_OBJECT_TRUNCATE,
+                                      CRERAR_BUILDING_ID,
+                                      CRERAR_EXHIBIT_FOOTER_IMG, MLA_PATH,
+                                      SCRC_BUILDING_ID,
+                                      SCRC_EXHIBIT_FOOTER_IMG)
 from modelcluster.fields import ParentalKey
 from public.models import StaffPublicPage
 from staff.models import StaffPage
-from wagtail.admin.edit_handlers import (
-    FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel, ObjectList,
-    PageChooserPanel, StreamFieldPanel, TabbedInterface
-)
+from wagtail.admin.edit_handlers import (FieldPanel, FieldRowPanel,
+                                         InlinePanel, MultiFieldPanel,
+                                         ObjectList, PageChooserPanel,
+                                         StreamFieldPanel, TabbedInterface)
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable, Page, Site
@@ -35,12 +36,8 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet
 
 from .marklogic import get_record_for_display, get_record_no_parsing
-from .utils import (CBrowseURL,
-                    CitationInfo,
-                    DisplayBrowse,
-                    LBrowseURL,
-                    IIIFDisplay,
-                    )
+from .utils import (CBrowseURL, CitationInfo, DisplayBrowse, IIIFDisplay,
+                    LBrowseURL)
 
 DEFAULT_WEB_EXHIBIT_FONT = '"Helvetica Neue", Helvetica, Arial, sans-serif'
 
@@ -570,24 +567,18 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
             lambda: self.staff_contact.staff_page_email.first().email, ''
         )
         staff_phone_number = default(
-            lambda: (self
-                     .staff_contact
-                     .staff_page_phone_faculty_exchange
-                     .first())
-            .phone_number, ''
+            lambda: (
+                self.staff_contact.staff_page_phone_faculty_exchange.first()
+            ).phone_number, ''
         )
         staff_faculty_exchange = default(
-            lambda: (self
-                     .staff_contact
-                     .staff_page_phone_faculty_exchange
-                     .first())
-            .faculty_exchange, ''
+            lambda: (
+                self.staff_contact.staff_page_phone_faculty_exchange.first()
+            ).faculty_exchange, ''
         )
         staff_url = default(
-            lambda: (StaffPublicPage
-                     .objects
-                     .get(cnetid=self.staff_contact.cnetid)
-                     .url),
+            lambda:
+            (StaffPublicPage.objects.get(cnetid=self.staff_contact.cnetid).url),
             ''
         )
 
@@ -669,9 +660,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
             final breadcrumb text (which is different because it isn't
             a link)
         """
-        breadcrumbs = list(
-            filter(lambda x: x != "", request.path.split('/'))
-        )
+        breadcrumbs = list(filter(lambda x: x != "", request.path.split('/')))
 
         trimmed_crumbs = breadcrumbs[2:-1]
         final_crumb = breadcrumbs[-1]
@@ -727,17 +716,18 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
         mk_lbrowse_url_wagtail = LBrowseURL.mk_lbrowse_url_wagtail
 
         return OrderedDict(
-            [(CollectionPage.override(x.link_text_override, x.label),
-              mk_cbrowse_type_url_wagtail(slug, slugify(x.label)))
-             for x in CollectionPageClusterBrowse
-             .objects
-             .filter(page=self)]
-            +
-            [(CollectionPage.override(x.link_text_override, x.label),
-              mk_lbrowse_url_wagtail(slug, slugify(x.label)))
-             for x in CollectionPageListBrowse
-             .objects
-             .filter(page=self)]
+            [
+                (
+                    CollectionPage.override(x.link_text_override, x.label),
+                    mk_cbrowse_type_url_wagtail(slug, slugify(x.label))
+                )
+                for x in CollectionPageClusterBrowse.objects.filter(page=self)
+            ] + [
+                (
+                    CollectionPage.override(x.link_text_override, x.label),
+                    mk_lbrowse_url_wagtail(slug, slugify(x.label))
+                ) for x in CollectionPageListBrowse.objects.filter(page=self)
+            ]
         )
 
     # Main Admin Panel Fields
@@ -886,12 +876,14 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
             final_crumb = object_title
         elif 'Title' in marklogic.keys():
             object_title = marklogic['Title'].split(',')[0]
-            final_crumb = truncate_crumb(object_title,
-                                         COLLECTION_OBJECT_TRUNCATE)
+            final_crumb = truncate_crumb(
+                object_title, COLLECTION_OBJECT_TRUNCATE
+            )
         elif 'Description' in marklogic.keys():
             object_title = marklogic['Description'].split(',')[0]
-            final_crumb = truncate_crumb(object_title,
-                                         COLLECTION_OBJECT_TRUNCATE)
+            final_crumb = truncate_crumb(
+                object_title, COLLECTION_OBJECT_TRUNCATE
+            )
         else:
             object_title = 'Object'
             final_crumb = object_title
@@ -1068,9 +1060,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
         sidebar_browse_types = self.build_browse_types()
 
         all_browse_types = (
-            CollectionPageClusterBrowse
-            .objects
-            .filter(page=self)
+            CollectionPageClusterBrowse.objects.filter(page=self)
         )
 
         try:
@@ -1123,7 +1113,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
 
         return TemplateResponse(request, template, context)
 
-    @ route(r'^cluster-browse/(?P<browse_type>[-\w]+)/(?P<browse>[-\w]+)/$')
+    @route(r'^cluster-browse/(?P<browse_type>[-\w]+)/(?P<browse>[-\w]+)/$')
     def cluster_browse(self, request, *args, **kwargs):
         """
         Route for listing a particular cluster browse.  For example: the
@@ -1139,9 +1129,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
         browse_type_s = kwargs['browse_type']
 
         all_browse_types = (
-            CollectionPageClusterBrowse
-            .objects
-            .filter(page=self)
+            CollectionPageClusterBrowse.objects.filter(page=self)
         )
 
         names = [x.label.lower() for x in all_browse_types]
@@ -1156,8 +1144,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
                 browse_type_s,
             )
             internal_error = False
-        except (KeyError,
-                simplejson.JSONDecodeError):
+        except (KeyError, simplejson.JSONDecodeError):
             objects = ''
             internal_error = True
 
@@ -1188,7 +1175,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
 
         return TemplateResponse(request, template, context)
 
-    @ route(r'^list-browse/(?P<browse_name>[-\w]+/)(?P<pageno>[0-9]*/){0,1}$')
+    @route(r'^list-browse/(?P<browse_name>[-\w]+/)(?P<pageno>[0-9]*/){0,1}$')
     def list_browse(self, request, *args, **kwargs):
         """
         Route for main list browse index.
@@ -1205,11 +1192,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
 
         browse_name = paginate_name[:-1]
 
-        all_browse_types = (
-            CollectionPageListBrowse
-            .objects
-            .filter(page=self)
-        )
+        all_browse_types = (CollectionPageListBrowse.objects.filter(page=self))
 
         names = [x.label.lower() for x in all_browse_types]
 
@@ -1229,8 +1212,7 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
                 browse_name,
             )
             internal_error = False
-        except (KeyError,
-                simplejson.JSONDecodeError):
+        except (KeyError, simplejson.JSONDecodeError):
             objects = ''
             internal_error = True
 
@@ -1248,12 +1230,14 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
         unslugify_browse = DisplayBrowse.unslugify_browse
 
         current_browse = CollectionPageListBrowse.objects.filter(
-            label=unslugify_browse(browse_name), page=self).first()
+            label=unslugify_browse(browse_name), page=self
+        ).first()
 
         if current_browse:
             browse_title = CollectionPage.override(
                 current_browse.link_text_override,
-                "Browse by %s" % current_browse.label)
+                "Browse by %s" % current_browse.label
+            )
             collection_final_breadcrumb = CollectionPage.override(
                 current_browse.link_text_override,
                 unslugify_browse(final_crumb)
@@ -1720,8 +1704,9 @@ class CollectingAreaPage(PublicBasePage, LibGuide):
         url = librarian.public_page.relative_url(site)
         thumb = librarian.profile_picture
         try:
-            email = librarian.staff_page_email.values_list('email',
-                                                           flat=True)[0]
+            email = librarian.staff_page_email.values_list(
+                'email', flat=True
+            )[0]
         except:
             email = ''
         phone_and_fac = tuple(
@@ -2030,6 +2015,16 @@ class ExhibitPage(PublicBasePage):
         blank=True,
         help_text='CSS font-family value, e.g. \'Roboto\', sans-serif'
     )
+    font_size = models.IntegerField(
+        default=1,
+        blank=True,
+        help_text='The multiplication factor of the default font size'  # reword?
+    )
+    font_kerning = models.IntegerField(
+        default=1,
+        blank=True,
+        help_text='The spacing between letters'  # reword?
+    )
 
     subpage_types = ['lib_collections.ExhibitChildPage']
 
@@ -2049,6 +2044,8 @@ class ExhibitPage(PublicBasePage):
                 FieldPanel('branding_color'),
                 FieldPanel('google_font_link'),
                 FieldPanel('font_family'),
+                FieldPanel('font_size'),
+                FieldPanel('font_kerning'),
             ],
             heading='Custom color and fonts'
         ),
@@ -2312,6 +2309,8 @@ class ExhibitPage(PublicBasePage):
         context['staff_url'] = staff_url
         context['branding_color'] = self.branding_color
         context['font_family'] = font
+        context['font_kerning'] = self.font_kerning
+        context['font_size'] = self.font_size
         context['google_font_link'] = self.google_font_link
         context['footer_img'] = footer_img
         context['has_exhibit_footer'] = not (not footer_img)

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -40,6 +40,7 @@ from .utils import (CBrowseURL, CitationInfo, DisplayBrowse, IIIFDisplay,
                     LBrowseURL)
 
 DEFAULT_WEB_EXHIBIT_FONT = '"Helvetica Neue", Helvetica, Arial, sans-serif'
+DEFAULT_WEB_EXHIBIT_FONT_SIZE = 16.8
 
 
 def get_current_exhibits():
@@ -2015,9 +2016,9 @@ class ExhibitPage(PublicBasePage):
         blank=True,
         help_text='CSS font-family value, e.g. \'Roboto\', sans-serif'
     )
-    font_size = models.IntegerField(
-        default=1,
+    font_scaler = models.FloatField(
         blank=True,
+        null=True,
         help_text='The multiplication factor of the default font size'  # reword?
     )
     font_kerning = models.IntegerField(
@@ -2044,7 +2045,7 @@ class ExhibitPage(PublicBasePage):
                 FieldPanel('branding_color'),
                 FieldPanel('google_font_link'),
                 FieldPanel('font_family'),
-                FieldPanel('font_size'),
+                FieldPanel('font_scaler'),
                 FieldPanel('font_kerning'),
             ],
             heading='Custom color and fonts'
@@ -2283,6 +2284,10 @@ class ExhibitPage(PublicBasePage):
         if self.font_family:
             font = self.font_family
 
+        font_size = DEFAULT_WEB_EXHIBIT_FONT_SIZE
+        if self.font_scaler:
+            font_size = self.font_scaler * font_size
+
         unit_title = lazy_dotchain(lambda: self.unit.title, '')
         unit_url = lazy_dotchain(lambda: self.unit.public_web_page.url, '')
         unit_email_label = lazy_dotchain(lambda: self.unit.email_label, '')
@@ -2310,7 +2315,7 @@ class ExhibitPage(PublicBasePage):
         context['branding_color'] = self.branding_color
         context['font_family'] = font
         context['font_kerning'] = self.font_kerning
-        context['font_size'] = self.font_size
+        context['font_size'] = font_size
         context['google_font_link'] = self.google_font_link
         context['footer_img'] = footer_img
         context['has_exhibit_footer'] = not (not footer_img)

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -41,7 +41,7 @@ from .utils import (CBrowseURL, CitationInfo, DisplayBrowse, IIIFDisplay,
 
 DEFAULT_WEB_EXHIBIT_FONT = '"Helvetica Neue", Helvetica, Arial, sans-serif'
 DEFAULT_WEB_EXHIBIT_FONT_SIZE = 16.8
-DEFAULT_WEB_EXHIBIT_FONT_KERNING = 1
+DEFAULT_WEB_EXHIBIT_FONT_KERNING = 0
 
 
 def get_current_exhibits():

--- a/lib_collections/templates/lib_collections/exhibit_page.html
+++ b/lib_collections/templates/lib_collections/exhibit_page.html
@@ -14,7 +14,7 @@
             {% inlinecompile "scss" %}
                 /*
                  * Media Queries
-                 * --------------------------------------------------
+                 * --------------------------------------------------1
                  *
                  * Use as: @include respond-to(small) { ... }
                  *        @include respond-to(medium) { ... }
@@ -146,8 +146,10 @@
 				        background-color: rgba( $base-color, .9 );
 				        left: 0;
 				        top: 0;
-				        font-family: $display-font;
+	                                font-family: $display-font;
 				        padding: 0.5em 2em;
+	    				font-size: {{font_size}}px;
+					letter-spacing: {{font_kerning}}px;
 				        @include respond-to(small) {
 				                padding-right: 6em;
 				            }
@@ -157,6 +159,7 @@
 				            &:last-child {
 				                padding-bottom: 15px;
 				            }
+	    				
 				        }
 				        h2 {
 				            font-weight: 100;

--- a/lib_collections/templates/lib_collections/exhibit_page.html
+++ b/lib_collections/templates/lib_collections/exhibit_page.html
@@ -14,7 +14,7 @@
             {% inlinecompile "scss" %}
                 /*
                  * Media Queries
-                 * --------------------------------------------------1
+                 * --------------------------------------------------
                  *
                  * Use as: @include respond-to(small) { ... }
                  *        @include respond-to(medium) { ... }
@@ -146,7 +146,7 @@
 				        background-color: rgba( $base-color, .9 );
 				        left: 0;
 				        top: 0;
-	                                font-family: $display-font;
+					font-family: $display-font;
 				        padding: 0.5em 2em;
 	    				font-size: {{font_size}}px;
 					letter-spacing: {{font_kerning}}px;
@@ -159,7 +159,6 @@
 				            &:last-child {
 				                padding-bottom: 15px;
 				            }
-	    				
 				        }
 				        h2 {
 				            font-weight: 100;


### PR DESCRIPTION
Fixes #595 

**Changes:**
- Added the ability to customize the font size and kerning in customizable web exhibits like [the soviet imaginary page](https://www.lib.uchicago.edu/collex/exhibits/soviet-imaginary/)
- Font size:
> float value (*note: allows users to increment by 1 on the right...but this behavior might not be the same in the new wagtail)
> allows no input value and then defaults to 16.8 px, the standard font size for collections/exhibits (*note: also defaults to 16.8 for inputs of 1, 0 and negative inputs)
> inputs are multiplication factors that multiply by 16.8 px to determine the font size
> description might need tweaking

- Font kerning:
> float value (*note: allows users to increment by 1 on the right...but this behavior might not be the same in the new wagtail)
> allows no input value and then defaults to 0 px, which indicates no kerning besides that of the actual font (*note: negative values bring the font closer together)
> description might need tweaking

**To Make Actual Changes Easier to Spot** (and not the changes from the linter)
In the `models.py`:
1. added default values on lines 43 and 44
2. defined the fields for font_scaler and font_kerning from line 2020 to line 2029
3. added the above fields to the Field Panel on lines 2049 and 2050
4. defined when to use default values and when to use inputed values from line 2288 to 2295
5. added the fields to the context on lines 2322 and 2323