### PR TITLE
LibAnswers phasing out old domain names

### DIFF
--- a/ask_a_librarian/models.py
+++ b/ask_a_librarian/models.py
@@ -9,7 +9,7 @@ from wagtail.models import Page
 from wagtail.search import index
 
 from base.models import ContactFields, DefaultBodyFields, PublicBasePage, RawHTMLBlock, ReusableContentBlock
-from library_website.settings import PHONE_ERROR_MSG, PHONE_FORMAT
+from library_website.settings import LIBCHAT_WIDGET_URL, PHONE_ERROR_MSG, PHONE_FORMAT
 
 
 class AskPage(PublicBasePage, ContactFields):
@@ -149,5 +149,6 @@ class AskPage(PublicBasePage, ContactFields):
     def get_context(self, request):
         context = super(AskPage, self).get_context(request)
         context['ask_pages'] = AskPage.objects.live()
+        context['libchat_widget_url'] = LIBCHAT_WIDGET_URL
 
         return context

--- a/ask_a_librarian/templates/ask_a_librarian/ask_page.html
+++ b/ask_a_librarian/templates/ask_a_librarian/ask_page.html
@@ -6,13 +6,13 @@
 {% block content %}
     {{ self.intro }}
     {% if self.ask_widget_name == 'dissertation-office' %}
-        <script src="https://v2.libanswers.com/load_chat.php?hash=946689341a093741c4e12f427047faa2"></script>
+        <script src="{{libchat_widget_url}}946689341a093741c4e12f427047faa2"></script>
         <div id="libchat_946689341a093741c4e12f427047faa2"></div>
     {% elif self.ask_widget_name == 'law' %}
-        <script src="https://v2.libanswers.com/load_chat.php?hash=a4866467f8e4db1dd88568e7c8b01c05"></script>
+        <script src="{{libchat_widget_url}}a4866467f8e4db1dd88568e7c8b01c05"></script>
         <div id="libchat_a4866467f8e4db1dd88568e7c8b01c05"></div>
     {% else %}
-        <script src="https://v2.libanswers.com/load_chat.php?hash=7d40a704e1d39b1c6a20f5c35faf1aaf"></script>
+        <script src="{{libchat_widget_url}}7d40a704e1d39b1c6a20f5c35faf1aaf"></script>
         <div id="libchat_7d40a704e1d39b1c6a20f5c35faf1aaf"></div>
     {% endif %}
     {{ self.body }}

--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -460,8 +460,14 @@ CACHES = {
     }
 }
 
+# Base URL for LibAnswers services
+LIBANSWERS_BASE = 'https://uchicago.libanswers.com'
+
+# LibChat JavaScript for widgets
+LIBCHAT_WIDGET_URL = LIBANSWERS_BASE + '/load_chat.php?hash='
+
 # Base url for the LibChat status API
-LIBCHAT_STATUS_URL = 'https://uchicago.libanswers.com/1.0/chat/widgets/status/'
+LIBCHAT_STATUS_URL = LIBANSWERS_BASE + '/1.0/chat/widgets/status/'
 
 # Map LibraryH3lp chat widget names to LibChat widget IDs
 # Implemented to avoid changing function signatures and


### PR DESCRIPTION
Related to issue #628 

**Changes in this request**
- Update LibAnswers domain to use the new syntax.
- Offloaded more to the config file and removed repetitive code.