### PR TITLE
Need ability to suppress staff from directory sync command

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -603,3 +603,8 @@ FOLIO_BASE_URL = ''
 FOLIO_TYPE_ISBN_ID = '8261054f-be78-422d-bd51-4ed9f33c3422'
 FOLIO_TYPE_ISSN_ID = '913300b2-03ed-469a-8179-c1092c991227'
 FOLIO_TYPE_LINKING_ISSN_ID = '5860f255-a27f-4916-a830-262aa900a6b9'
+
+# CNetIDs for people in the University or Library directory that
+# we wish to keep out of sync. People listed here will not show
+# up in the "out of sync staff members" email report.
+DO_NOT_SYNC = []

--- a/staff/utils.py
+++ b/staff/utils.py
@@ -13,7 +13,7 @@ import requests
 
 from base.utils import get_xml_from_directory_api
 from django.contrib.auth.models import User
-from library_website.settings import LIBCAL_TOKEN_ENDPOINT, LIBCAL_ENDPOINT, LIBCAL_CREDENTIALS
+from library_website.settings import DO_NOT_SYNC, LIBCAL_TOKEN_ENDPOINT, LIBCAL_ENDPOINT, LIBCAL_CREDENTIALS
 from openpyxl import Workbook
 from staff.models import EMPLOYEE_TYPES, StaffPage, StaffPageLibraryUnits
 from units.models import UnitPage
@@ -374,17 +374,9 @@ class WagtailStaffReport:
             value = '' if value is None else str(value)
             return '{} -{}- ({})'.format(cnetid, self._clean(value), field)
 
-        # Don't sync up some staff accounts. Former library directors may
-        # appear in the campus directory, but they shouldn't appear in
-        # staff listings on the library website. In other cases, staff
-        # might have phone numbers connected with non-library jobs. If they
-        # want those numbers to appear on the library website, they can add
-        # them manually but we won't keep their information in sync.
-        skip_cnetids = ['judi']
-
         api_staff_info = set()
         for cnetid in get_all_library_cnetids_from_directory():
-            if cnetid in skip_cnetids:
+            if cnetid in DO_NOT_SYNC:
                 continue
             api_staff_info.add(cnetid)
             xml_string = get_xml_from_directory_api(
@@ -415,7 +407,7 @@ class WagtailStaffReport:
 
         wag_staff_info = set()
         for s in StaffPage.objects.live():
-            if s.cnetid in skip_cnetids:
+            if s.cnetid in DO_NOT_SYNC:
                 continue
             wag_staff_info.add(s.cnetid)
             wag_staff_info.add(


### PR DESCRIPTION
Fixes #630 
**Changes in this request**
- Made the suppression of staff from the out of sync report configurable.

_Note: I tried to write a unit test for this but found that 1. this part of the code is very difficult to test (even after some refactoring) and 2. it adds too much time to the unit tests (more than 1 minute). We will need to rewrite significant portions of this part of the code to make it more testable._ 