### PR TITLE
Vagrant builds fail because of openpyxl 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ elasticsearch>=6.4.0,<7.0.0
 libsass
 lxml
 networkx
-openpyxl
+openpyxl>=3.1.0,<3.2.0
 -e git+https://github.com/owncloud/pyocclient.git@aa6b4374a779bf0f9e060117b2e8d1e810342bc8#egg=pyocclient
 -e git+https://github.com/uchicago-library/pyiiif.git#egg=pyiiif
 pocli==0.1.10

--- a/staff/management/commands/list_staff_wagtail.py
+++ b/staff/management/commands/list_staff_wagtail.py
@@ -1,136 +1,77 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.core.management.base import BaseCommand
+
+import smtplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
-from openpyxl.writer.excel import save_virtual_workbook
+
+from base.utils import save_virtual_workbook
+from django.core.management.base import BaseCommand
 from staff.utils import WagtailStaffReport
 
-import smtplib
 
-class Command (BaseCommand):
+class Command(BaseCommand):
     """
-    Produce reports of staff in Wagtail that can be imported into Excel. 
+    Produce reports of staff in Wagtail that can be imported into Excel.
     """
 
     def add_arguments(self, parser):
+        parser.add_argument('--all', default=False, action='store_true')
+        parser.add_argument('--cnetid', type=str, action='store')
+        parser.add_argument('--department', type=str, action='store')
+        parser.add_argument('--department-and-subdepartments', type=str, action='store')
+        parser.add_argument('--group', type=str, action='store')
+        parser.add_argument('--live', default=False, action='store_true')
+        parser.add_argument('--latest-revision-created-at', type=str, action='store')
+        parser.add_argument('--position-eliminated', default=False, action='store_true')
+        parser.add_argument('--supervises-students', default=False, action='store_true')
+        parser.add_argument('--supervisor-cnetid', type=str, action='store')
+        parser.add_argument('--supervisor-override', default=False, action='store_true')
+        parser.add_argument('--position-title', type=str, action='store')
         parser.add_argument(
-            '--all',
-            default=False,
-            action='store_true'
+            '--report-out-of-sync-staff', default=False, action='store_true'
         )
         parser.add_argument(
-            '--cnetid',
-            type=str,
-            action='store'
+            '--output-format', choices=('excel', 'text'), default='text', type=str
         )
-        parser.add_argument(
-            '--department',
-            type=str,
-            action='store'
-        )
-        parser.add_argument(
-            '--department-and-subdepartments',
-            type=str,
-            action='store'
-        )
-        parser.add_argument(
-            '--group',
-            type=str,
-            action='store'
-        )
-        parser.add_argument(
-            '--live',
-            default=False,
-            action='store_true'
-        )
-        parser.add_argument(
-            '--latest-revision-created-at',
-            type=str,
-            action='store'
-        )
-        parser.add_argument(
-            '--position-eliminated',
-            default=False,
-            action='store_true'
-        )
-        parser.add_argument(
-            '--supervises-students',
-            default=False,
-            action='store_true'
-        )
-        parser.add_argument(
-            '--supervisor-cnetid',
-            type=str,
-            action='store'
-        )
-        parser.add_argument(
-            '--supervisor-override',
-            default=False,
-            action='store_true'
-        )
-        parser.add_argument(
-            '--position-title',
-            type=str,
-            action='store'
-        )
-        parser.add_argument(
-            '--report-out-of-sync-staff',
-            default=False,
-            action='store_true'
-        )
-        parser.add_argument(
-            '--output-format',
-            choices=('excel', 'text'),
-            default='text',
-            type=str
-        )
-        parser.add_argument(
-            '--filename',
-            default='',
-            type=str
-        )
-        parser.add_argument(
-            '--email-from',
-            type=str,
-            default=''
-        )
-        parser.add_argument(
-            '--email-to',
-            type=str,
-            default=''
-        )
+        parser.add_argument('--filename', default='', type=str)
+        parser.add_argument('--email-from', type=str, default='')
+        parser.add_argument('--email-to', type=str, default='')
 
     def handle(self, *args, **options):
         """
-        The actual logic of the command. Subclasses must implement this 
-        method. It may return a Unicode string which will be printed to 
+        The actual logic of the command. Subclasses must implement this
+        method. It may return a Unicode string which will be printed to
         stdout. More: https://docs.djangoproject.com/en/1.8/howto/custom
         -management-commands/#django.core.management.BaseCommand.handle
         """
-        staff_report = any((bool(options['all']),
-                            bool(options['cnetid']),
-                            bool(options['department']),
-                            bool(options['department_and_subdepartments']),
-                            bool(options['group']),
-                            bool(options['live']),
-                            bool(options['latest_revision_created_at']),
-                            bool(options['position_eliminated']),
-                            bool(options['supervises_students']),
-                            bool(options['supervisor_cnetid']),
-                            bool(options['supervisor_override']),
-                            bool(options['position_title'])))
+        staff_report = any(
+            (
+                bool(options['all']),
+                bool(options['cnetid']),
+                bool(options['department']),
+                bool(options['department_and_subdepartments']),
+                bool(options['group']),
+                bool(options['live']),
+                bool(options['latest_revision_created_at']),
+                bool(options['position_eliminated']),
+                bool(options['supervises_students']),
+                bool(options['supervisor_cnetid']),
+                bool(options['supervisor_override']),
+                bool(options['position_title']),
+            )
+        )
 
         staff_report = WagtailStaffReport(
-            sync_report = options['report_out_of_sync_staff'],
-            staff_report = staff_report,
+            sync_report=options['report_out_of_sync_staff'],
+            staff_report=staff_report,
             **options
         )
 
         if options['output_format'] == 'excel':
-            if options['email_to']:        
+            if options['email_to']:
                 virtual_workbook = save_virtual_workbook(staff_report.workbook())
 
                 msg = MIMEMultipart()
@@ -140,11 +81,10 @@ class Command (BaseCommand):
                 msg['Date'] = formatdate(localtime=True)
 
                 msg.attach(MIMEText('A report of Library staff is attached.'))
-                attachment = MIMEApplication(
-                    virtual_workbook,
-                    Name=options['filename']
+                attachment = MIMEApplication(virtual_workbook, Name=options['filename'])
+                attachment['Content-Disposition'] = 'attachment; filename="{}"'.format(
+                    options['filename']
                 )
-                attachment['Content-Disposition'] = 'attachment; filename="{}"'.format(options['filename'])
                 msg.attach(attachment)
 
                 s = smtplib.SMTP('localhost')

--- a/staff/wagtail_hooks.py
+++ b/staff/wagtail_hooks.py
@@ -1,31 +1,36 @@
+from base.utils import save_virtual_workbook
 from django.conf.urls import url
-from django.core import management
-from django.urls import reverse
 from django.http import HttpResponse
 from django.shortcuts import render
-from openpyxl.writer.excel import save_virtual_workbook
-from staff.models import StaffPage
-from staff.utils import WagtailStaffReport
-from wagtail.admin.menu import MenuItem
+from django.urls import reverse
 from wagtail import hooks
+from wagtail.admin.menu import MenuItem
+
+from staff.utils import WagtailStaffReport
+
 
 def admin_view(request):
     from staff.forms import StaffReportingForm
+
     if request.method == 'POST':
         form = StaffReportingForm(request.POST)
         options = {
             'filename': form.data.get('filename', 'staff_report'),
             'cnetid': form.data.get('cnetid', None),
             'department': form.data.get('department', None),
-            'department_and_subdepartments': form.data.get('department_and_subdepartments', None),
+            'department_and_subdepartments': form.data.get(
+                'department_and_subdepartments', None
+            ),
             'group': form.data.get('group', None),
             'live': form.data.get('live', None),
-            'latest_revision_created_at': form.data.get('latest_revision_created_at', None),
+            'latest_revision_created_at': form.data.get(
+                'latest_revision_created_at', None
+            ),
             'position_eliminated': form.data.get('position_eliminated', None),
             'supervises_students': form.data.get('supervises_students', False),
             'supervisor_cnetid': form.data.get('supervisor_cnetid', None),
             'supervisor_override': form.data.get('supervisor_override', None),
-            'position_title': form.data.get('position_title', None)
+            'position_title': form.data.get('position_title', None),
         }
 
         for i in ('live', 'supervises_students', 'supervisor_override'):
@@ -34,32 +39,38 @@ def admin_view(request):
                     options[i] = True
             except KeyError:
                 continue
-        options['all'] = not(bool(options['live']))
+        options['all'] = not (bool(options['live']))
 
         if form.is_valid():
             staff_report = WagtailStaffReport(
-                sync_report = False,
-                staff_report = True,
-                **options
+                sync_report=False, staff_report=True, **options
             )
             virtual_workbook = save_virtual_workbook(staff_report.workbook())
-            response = HttpResponse(virtual_workbook, content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-            response['content-disposition'] = 'attachment; filename="' + options['filename'] + '.xlsx"'
+            response = HttpResponse(
+                virtual_workbook,
+                content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            )
+            response['content-disposition'] = (
+                'attachment; filename="' + options['filename'] + '.xlsx"'
+            )
             return response
         else:
             return render(request, 'staff/staff_reporting_form.html', {'form': form})
     else:
         form = StaffReportingForm({'live': True, 'filename': 'staff_report'})
-    return render(request, 'staff/staff_reporting_form.html', {
-        'form': form
-    })
+    return render(request, 'staff/staff_reporting_form.html', {'form': form})
+
 
 @hooks.register('register_admin_urls')
 def urlconf_time():
-    return [
-        url(r'^list_staff_wagtail/$', admin_view, name='list_staff_wagtail')
-    ]
+    return [url(r'^list_staff_wagtail/$', admin_view, name='list_staff_wagtail')]
+
 
 @hooks.register('register_settings_menu_item')
 def register_frank_menu_item():
-  return MenuItem('Staff Reporting', reverse('list_staff_wagtail'), classnames='icon icon-mail', order=9990)
+    return MenuItem(
+        'Staff Reporting',
+        reverse('list_staff_wagtail'),
+        classnames='icon icon-mail',
+        order=9990,
+    )

--- a/units/management/commands/list_units_wagtail.py
+++ b/units/management/commands/list_units_wagtail.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.core.management.base import BaseCommand
+
+import smtplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.utils import formatdate
-from openpyxl.writer.excel import save_virtual_workbook
+
+from base.utils import save_virtual_workbook
+from django.core.management.base import BaseCommand
 from units.utils import WagtailUnitsReport
 
-import smtplib
 
-class Command (BaseCommand):
+class Command(BaseCommand):
     """
     Produce reports of units in Wagtail. We should be able to run this in the
     shell and produce text output or use this in cron to send Excel
@@ -17,74 +19,42 @@ class Command (BaseCommand):
     """
 
     def add_arguments(self, parser):
+        parser.add_argument('--all', action='store_true', default=False)
+        parser.add_argument('--live', action='store_true', default=False)
+        parser.add_argument('--latest-revision-created-at', type=str)
         parser.add_argument(
-            '--all',
-            action='store_true',
-            default=False
+            '--display-in-campus-directory', action='store_true', default=False
         )
         parser.add_argument(
-            '--live',
-            action='store_true',
-            default=False
+            '--report-out-of-sync-units', action='store_true', default=False
         )
         parser.add_argument(
-            '--latest-revision-created-at',
-            type=str
+            '--report-out-of-sync-intranet-units', action='store_true', default=False
         )
         parser.add_argument(
-            '--display-in-campus-directory',
-            action='store_true',
-            default=False
+            '--output-format', choices=('excel', 'text'), default='text', type=str
         )
-        parser.add_argument(
-            '--report-out-of-sync-units',
-            action='store_true',
-            default=False
-        )
-        parser.add_argument(
-            '--report-out-of-sync-intranet-units',
-            action='store_true',
-            default=False
-        )
-        parser.add_argument(
-            '--output-format',
-            choices=('excel', 'text'),
-            default='text',
-            type=str
-        )
-        parser.add_argument(
-            '--filename',
-            type=str,
-            default=''
-        )
-        parser.add_argument(
-            '--email-from',
-            type=str,
-            default=''
-        )
-        parser.add_argument(
-            '--email-to',
-            type=str,
-            default=''
-        )
+        parser.add_argument('--filename', type=str, default='')
+        parser.add_argument('--email-from', type=str, default='')
+        parser.add_argument('--email-to', type=str, default='')
 
     def handle(self, *args, **options):
         """
-        The actual logic of the command. Subclasses must implement this 
-        method. It may return a Unicode string which will be printed to 
+        The actual logic of the command. Subclasses must implement this
+        method. It may return a Unicode string which will be printed to
         stdout. More: https://docs.djangoproject.com/en/1.8/howto/custom
         -management-commands/#django.core.management.BaseCommand.handle
         """
 
         units_report = WagtailUnitsReport(
-            sync_report = options['report_out_of_sync_units'],
-            intranet_sync_report = options['report_out_of_sync_intranet_units'],
-            unit_report = options['all'] or options['live'],
+            sync_report=options['report_out_of_sync_units'],
+            intranet_sync_report=options['report_out_of_sync_intranet_units'],
+            unit_report=options['all'] or options['live'],
             **options
         )
 
         if options['output_format'] == 'excel':
-            if options['email_to']:        
+            if options['email_to']:
                 virtual_workbook = save_virtual_workbook(units_report.workbook())
 
                 msg = MIMEMultipart()
@@ -93,11 +63,10 @@ class Command (BaseCommand):
                 msg['To'] = options['email_to']
                 msg['Date'] = formatdate(localtime=True)
 
-                attachment = MIMEApplication(
-                    virtual_workbook,
-                    Name=options['filename']
+                attachment = MIMEApplication(virtual_workbook, Name=options['filename'])
+                attachment['Content-Disposition'] = 'attachment; filename="{}"'.format(
+                    options['filename']
                 )
-                attachment['Content-Disposition'] = 'attachment; filename="{}"'.format(options['filename'])
                 msg.attach(attachment)
                 s = smtplib.SMTP('localhost')
                 s.send_message(msg)


### PR DESCRIPTION
Fixes #647 

**Changes in this request**
- Added a new `save_virtual_workbook` function to `base_utils.py` [(line 470)](https://github.com/uchicago-library/library_website/pull/648/files#diff-7d6137b6e6d905f7f7cd657953ba62d3ac6e351b31b5ea30b56cc70b8122dc28R470) to replace the one deprecated in `openpyxl`.
- Changed imports to use the new function instead of the old one.
- Pinned openpyxl to a semantic version: `openpyxl>=3.1.0,<3.2.0`.
- Linted files with black.