### PR TITLE
654 404 page left margin for smaller screens

### DIFF
--- a/library_website/templates/404.html
+++ b/library_website/templates/404.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="col-xs-12 centermain" style="padding-top:2em;">
-<div class="container-fluid main-container"> <!-- Main Container Wrapper -->
+  <div class="container-fluid main-container"> <!-- Main Container Wrapper -->
 
    
     <h1>Page not found</h1>
@@ -113,7 +113,7 @@
 	<p>{{ helptext1 }}{{ helptext2 }}</p>
     {% endif %}  
 
-</div>
+  </div>
 </div>
 
 {% endblock %}

--- a/library_website/templates/404.html
+++ b/library_website/templates/404.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 <div class="col-xs-12 centermain" style="padding-top:2em;">
+<div class="container-fluid main-container"> <!-- Main Container Wrapper -->
 
    
     <h1>Page not found</h1>
@@ -112,6 +113,7 @@
 	<p>{{ helptext1 }}{{ helptext2 }}</p>
     {% endif %}  
 
+</div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #654 .

**Changes in this request**
<!-- A description of the changes proposed in the pull request. -->
- added a fluid div in order to fix the smaller screen module problem
- decided that if we want to make this a 404 return instead of 200 that can be done in a different update