### PR TITLE
649 search bar in lib search results page

### DIFF
--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -56,6 +56,17 @@
         {% elif search_query %}
             No results found
         {% endif %}
+	    <form action="/switchboard/" method="post">
+	      <div class="col-xs-9 col-sm-10 nopadding">
+		<input name="query" type="text" placeholder="search library website" class="form-control" id="search_form5">
+		<input type="hidden" name="which-form" value="website">
+	{% csrf_token %}
+	      </div>
+                             
+	      <div class="col-xs-3 col-sm-2 search-btn-wrapper">
+		<button class="btn btn-search btn-default" type="submit"><span class="hidden-md hidden-lg glyphicon glyphicon-search"></span><span class="hidden-xs hidden-sm">Search</span></button>
+	      </div>
+	    </form>
       </div>
     </div>
   </div>

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -60,6 +60,7 @@
 		<br>
 		<br>
 		<br>
+{% block title %}Search Again{% endblock %}
 
 	    <form action="/switchboard/" method="post">
 	      <div class="col-xs-9 col-sm-10 nopadding">

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -59,8 +59,8 @@
 		
 		<br>
 		<br>
-		<br>
-{% block title %}Search Again{% endblock %}
+
+ <h2>Try Searching Again</h2>
 
 	    <form action="/switchboard/" method="post">
 	      <div class="col-xs-9 col-sm-10 nopadding">

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -64,7 +64,7 @@
 
 	    <form action="/switchboard/" method="post">
 	      <div class="col-xs-9 col-sm-10 nopadding">
-		<input name="query" type="text" placeholder={{search_query}} class="form-control" id="search_form5">
+		<input name="query" type="text" class="form-control" value={{search_query}} id="search_form5">
 		<input type="hidden" name="which-form" value="website">
 	{% csrf_token %}
 	      </div>

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -56,6 +56,11 @@
         {% elif search_query %}
             No results found
         {% endif %}
+		
+		<br>
+		<br>
+		<br>
+
 	    <form action="/switchboard/" method="post">
 	      <div class="col-xs-9 col-sm-10 nopadding">
 		<input name="query" type="text" placeholder="search library website" class="form-control" id="search_form5">

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -74,7 +74,8 @@
                 <a href="{% url 'results' %}?query={{ search_query|urlencode }}&amp;page={{ search_results.next_page_number }}">Next</a>
             {% endif %}
         {% elif search_query %}
-            No results found
+		<br>
+		No results found
         {% endif %}
 
       </div>

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -7,9 +7,29 @@
 {% block title %}Search{% endblock %}
 
 {% block content %}
+
   <div class="row-fluid">
     <div class="col-xs-12 col-sm-12 col-md-12">
+
+<br>
+
+ <form action="/switchboard/" method="post">
+	      <div class="col-xs-9 col-sm-5 nopadding">
+		<input name="query" type="text" class="form-control" value="{{search_query}}" id="search_form5">
+		<input type="hidden" name="which-form" value="website">
+	{% csrf_token %}
+	      </div>
+                             
+	      <div class="col-xs-3 col-sm-2 search-btn-wrapper">
+		<button class="btn btn-search btn-default" type="submit"><span class="hidden-md hidden-lg glyphicon glyphicon-search"></span><span class="hidden-xs hidden-sm">Search</span></button>
+	      </div>
+	    </form>
+
       <div class="search-results">
+
+<br>
+<br>
+
         {% if search_picks %}
              <ul>
                 {% for pick in search_picks %}
@@ -56,23 +76,7 @@
         {% elif search_query %}
             No results found
         {% endif %}
-		
-		<br>
-		<br>
 
- <h2>Try Searching Again</h2>
-
-	    <form action="/switchboard/" method="post">
-	      <div class="col-xs-9 col-sm-10 nopadding">
-		<input name="query" type="text" class="form-control" value={{search_query}} id="search_form5">
-		<input type="hidden" name="which-form" value="website">
-	{% csrf_token %}
-	      </div>
-                             
-	      <div class="col-xs-3 col-sm-2 search-btn-wrapper">
-		<button class="btn btn-search btn-default" type="submit"><span class="hidden-md hidden-lg glyphicon glyphicon-search"></span><span class="hidden-xs hidden-sm">Search</span></button>
-	      </div>
-	    </form>
       </div>
     </div>
   </div>

--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -64,7 +64,7 @@
 
 	    <form action="/switchboard/" method="post">
 	      <div class="col-xs-9 col-sm-10 nopadding">
-		<input name="query" type="text" placeholder="search library website" class="form-control" id="search_form5">
+		<input name="query" type="text" placeholder={{search_query}} class="form-control" id="search_form5">
 		<input type="hidden" name="which-form" value="website">
 	{% csrf_token %}
 	      </div>

--- a/results/views.py
+++ b/results/views.py
@@ -1,19 +1,16 @@
-from itertools import chain
-
-from ask_a_librarian.utils import (get_chat_status, get_chat_status_css,
-                                   get_unit_chat_link)
-from base.utils import get_hours_and_location
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import render
-from library_website.settings import PUBLIC_HOMEPAGE, RESTRICTED
-from public.models import StandardPage
-from searchable_content.models import (LibGuidesAssetsSearchableContent,
-                                       LibGuidesSearchableContent)
-from units.models import UnitIndexPage
-from wagtail.contrib.search_promotions.models import SearchPromotion
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from wagtail.models import Page, Site
 from wagtail.search.backends import get_search_backend
 from wagtail.search.models import Query
+from wagtail.contrib.search_promotions.models import SearchPromotion
+from public.models import StandardPage
+from library_website.settings import PUBLIC_HOMEPAGE, RESTRICTED
+from base.utils import get_hours_and_location
+from ask_a_librarian.utils import get_chat_status, get_chat_status_css, get_unit_chat_link
+from units.models import UnitIndexPage
+from searchable_content.models import LibGuidesAssetsSearchableContent, LibGuidesSearchableContent
+from itertools import chain
 
 
 def results(request):
@@ -25,17 +22,10 @@ def results(request):
         homepage = Site.objects.get(site_name="Public").root_page
         unit_index_page = UnitIndexPage.objects.first()
         restricted = StandardPage.objects.live().get(id=RESTRICTED)
-        search_results1 = Page.objects.live().descendant_of(
-            homepage).not_descendant_of(
-                unit_index_page, True).not_descendant_of(
-                    restricted, True).search(
-                        search_query, operator="and").annotate_score('score')
+        search_results1 = Page.objects.live().descendant_of(homepage).not_descendant_of(unit_index_page, True).not_descendant_of(restricted, True).search(search_query, operator="and").annotate_score('score')
         search_backend = get_search_backend()
 
-        search_results2 = search_backend.search(
-            search_query,
-            LibGuidesSearchableContent.objects.all(),
-            operator="and").annotate_score('score')
+        search_results2 = search_backend.search(search_query, LibGuidesSearchableContent.objects.all(), operator="and").annotate_score('score')
         r = 0
         while r < len(search_results2):
             search_results2[r].score = search_results2[r].score * 1.5
@@ -46,20 +36,16 @@ def results(request):
             search_results2[r].searchable_content = 'guides'
             r += 1
 
-        search_results3 = search_backend.search(
-            search_query,
-            LibGuidesAssetsSearchableContent.objects.all(),
-            operator="and").annotate_score('score')
+        search_results3 = search_backend.search(search_query, LibGuidesAssetsSearchableContent.objects.all(), operator="and").annotate_score('score')
         r = 0
         while r < len(search_results3):
             search_results3[r].searchable_content = 'assets'
             r += 1
 
-        search_results = list(
-            chain(search_results1, search_results2, search_results3))
+        search_results = list(chain(search_results1, search_results2, search_results3))
         try:
             search_results.sort(key=lambda r: r.score, reverse=True)
-        except (TypeError):
+        except(TypeError):
             pass
 
         query = Query.get(search_query)
@@ -88,22 +74,20 @@ def results(request):
     location = str(location_and_hours['page_location'])
     unit = location_and_hours['page_unit']
 
-    return render(
-        request, 'results/results.html', {
-            'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
-            'content_div_css':
-            'container body-container col-xs-12 col-lg-11 col-lg-offset-1',
-            'search_query': search_query,
-            'search_results': search_results,
-            'search_picks': search_picks,
-            'page_unit': str(unit),
-            'page_location': location,
-            'address': location_and_hours['address'],
-            'chat_url': get_unit_chat_link(unit, request),
-            'chat_status': get_chat_status('uofc-ask'),
-            'chat_status_css': get_chat_status_css('uofc-ask'),
-            'hours_page_url': home_page.get_hours_page(request),
-            'self': {
-                'title': 'Search Results'
-            }
-        })
+    return render(request, 'results/results.html', {
+        'breadcrumb_div_css': 'col-md-12 breadcrumbs hidden-xs hidden-sm',
+        'content_div_css': 'container body-container col-xs-12 col-lg-11 col-lg-offset-1',
+        'search_query': search_query,
+        'search_results': search_results,
+        'search_picks': search_picks,
+        'page_unit': str(unit),
+        'page_location': location,
+        'address': location_and_hours['address'],
+        'chat_url': get_unit_chat_link(unit, request),
+        'chat_status': get_chat_status('uofc-ask'),
+        'chat_status_css': get_chat_status_css('uofc-ask'),
+        'hours_page_url': home_page.get_hours_page(request),
+        'self': {
+            'title': 'Search Results'
+        }
+    })


### PR DESCRIPTION
Fixes #649.

**Changes in this request**
<!-- A description of the changes proposed in the pull request. -->
- adds a search bar underneath the search results
- the search bar has the previously searched term preloaded allowing the user to re-search based on previous search
- search bar is small on larger screen sizes