### PR TITLE
Insufficient color contrast on some elements

### DIFF
--- a/base/static/base/css/footer.scss
+++ b/base/static/base/css/footer.scss
@@ -66,10 +66,10 @@ Pleeb Footer Code
   color: #fff;
   line-height: 1.7em;
     &:hover, &:focus {
-    	color: $hoveraccent;
+      color: #000;
       text-decoration: none;
     }
-	}
+  }
   h5 {
     margin-bottom: 0px;
   }

--- a/base/static/base/css/navigation.scss
+++ b/base/static/base/css/navigation.scss
@@ -235,7 +235,7 @@ i.ask-icon {
     font-size: $font-small;
     text-decoration: none;
     line-height: 2em;
-    &:hover {
+    &:hover, &:focus {
       color: #EDD4C1;
       text-decoration: underline;
     }
@@ -257,7 +257,7 @@ i.ask-icon {
       text-decoration: none;
       font-size: $font-small;
       margin-bottom: 12px;
-      &:hover {
+      &:hover, &:focus {
         color: #EDD4C1!important;
         background-color: transparent!important;
       }


### PR DESCRIPTION
Fixes #661 

**Changes in this request**
- Changed the hover color of links in the main navigation to something with a sufficient color contrast.
- Changed the hover and focus colors of footer links to something with a sufficient color contrast.