### PR TITLE
Missing alt text on featured library expert

### DIFF
--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -310,7 +310,7 @@
                                             </ul>
                                         </div>
                                         <div class="home-profile">
-                                            <img src="{{profile_pic.url}}" alt="{{profile_pic.title}}" class="img-responsive" />
+                                            <img src="{{profile_pic.url}}" alt="{{profile_pic.alt}}" class="img-responsive" />
                                             {% if has_libcal_schedule %}
                                                 {% libcal_button staff_page email %}
                                             {% endif %}

--- a/public/templates/public/blocks/featured_library_expert.html
+++ b/public/templates/public/blocks/featured_library_expert.html
@@ -13,9 +13,9 @@
             <h6>Ask {{self.library_expert}} about:</h6>
         {% endif %}
         <ul>
-            {% for guide in self.libguides %} 
+            {% for guide in self.libguides %}
                 <li><a href="{% firstof guide.link_external guide.link_page%}">{{guide.link_text}}</a></li>
-            {% endfor %} 
+            {% endfor %}
         </ul>
         <h6>Not sure where to start?</h6>
         {{self.url}}"
@@ -25,7 +25,7 @@
     </div>
     {% if profile_pic %}
         <div class="col-xs-4 home-profile">
-            <img src="{{profile_pic.url}}" alt="{{profile_pic.title}}" class="img-responsive" />
+            <img src="{{profile_pic.url}}" alt="{{profile_pic.alt}}" class="img-responsive" />
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
Fixes #669
**Changes in this request**
- Fixed alt text on featured library expert block
- Linted

In dev you'll need to add an image for the featured library expert on the homepage. You can do this by going to the librarian's loop staff page and uploading a new image.