### PR TITLE
Staff directory ADA issues

### DIFF
--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -1871,20 +1871,15 @@ a.coll-access {
     &+article {
       border-top: 1px solid #D2CDCC;
     }
-    h3 {
-      font-family: $base-font;
-      font-size: 1.05em;
-      margin-top: 0;
-      margin-bottom: 0;
-    }
     & p {
       max-width: 200px;
       @include respond-to(large) {
         max-width: unset;
       }
     }
-    h4 {
-      font-size: 1em; 
+    h3, h4 {
+      font-family: $base-font;
+      font-size: 1em !important; 
       color: darken($mid-dark, 10%);
       font-weight: 600;
       font-style: normal;

--- a/lib_collections/templates/lib_collections/collecting_area_page.html
+++ b/lib_collections/templates/lib_collections/collecting_area_page.html
@@ -5,175 +5,175 @@
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 
 {% block content %}
-  <article>
-    <div class="row">
-      <div class="col-xs-12">
+    <article>
+        <div class="row">
+            <div class="col-xs-12">
 
-      <figure class="imgcaption coll-thumb">
-        {% if self.thumbnail %}
-          {% image self.thumbnail width-200 class="img-responsive" %}
-          {% if self.thumbnail_caption %}
-            <figcaption>{{ self.thumbnail_caption }}</figcaption>
-          {% endif %}
-        {% else %}
-          {% if default_image %}
-            {% image default_image width-200 %}
-          {% endif %}
-        {% endif %}
-      </figure>
+                <figure class="imgcaption coll-thumb">
+                    {% if self.thumbnail %}
+                        {% image self.thumbnail width-200 class="img-responsive" %}
+                        {% if self.thumbnail_caption %}
+                            <figcaption>{{ self.thumbnail_caption }}</figcaption>
+                        {% endif %}
+                    {% else %}
+                        {% if default_image %}
+                            {% image default_image width-200 alt="" %}
+                        {% endif %}
+                    {% endif %}
+                </figure>
 
-        {{self.collecting_statement }}
+                {{self.collecting_statement }}
 
-        {% if self.policy_link_url and self.policy_link_text %}
-          <a role="button" class="btn btn-morecoll" href="{{ self.policy_link_url }}">{{ self.policy_link_text }}</i></a>
-        {% endif %}
-
-
-        {% if lib_guides %}
-          <h2>Research Guides</h2>
-            <p>Find articles, online texts, and other resources.<br/>
-              {% for l in lib_guides %}
-                <a class="coll-access" href="{{ l.guide_link_url }}">{{ l.guide_link_text }}</a><br/>
-              {% endfor %}
-            </p>
-        {% endif %}
+                {% if self.policy_link_url and self.policy_link_text %}
+                    <a role="button" class="btn btn-morecoll" href="{{ self.policy_link_url }}">{{ self.policy_link_text }}</a>
+                {% endif %}
 
 
-          {% if self.reference_materials %}
-          <h2>Reference Materials</h2>
-            {{ self.reference_materials|richtext }}
-          {% endif %}
+                {% if lib_guides %}
+                    <h2>Research Guides</h2>
+                    <p>Find articles, online texts, and other resources.<br/>
+                        {% for l in lib_guides %}
+                            <a class="coll-access" href="{{ l.guide_link_url }}">{{ l.guide_link_text }}</a><br/>
+                        {% endfor %}
+                    </p>
+                {% endif %}
 
-          {% if self.circulating_materials %}
-          <h2>Circulating Materials</h2>
-            {{ self.circulating_materials|richtext }}
-          {% endif %}
 
-          {% if self.archival_link_url and self.archival_link_text %}
-          <h2>Archival Materials</h2>
-            <p><a class="coll-access" href="{{ self.archival_link_url }}">{{ self.archival_link_text }}</a></p>
-          {% endif %}
+                {% if self.reference_materials %}
+                    <h2>Reference Materials</h2>
+                    {{ self.reference_materials|richtext }}
+                {% endif %}
 
-          {% if self.first_feature %}
-            <div class="home-modwrapper">
-              <h2>Featured Collections &amp; Exhibits</h2>
-              <div class="news-wrap">
-               {% for title, url, abstract, thumb in features %}
-                <div class="newsblock col-xs-12 col-sm-6 col-md-3">
+                {% if self.circulating_materials %}
+                    <h2>Circulating Materials</h2>
+                    {{ self.circulating_materials|richtext }}
+                {% endif %}
 
-                  {% if thumb %}
-                    <figure class="embed">
-                      <div class="figure-wrap">
-                        <a href="{{url}}">
-                          {% if thumb %}
-                            {% image thumb width-200 class="img-responsive" %}
-                          {% endif %}
-                        </a>
-                      </div>
-                    </figure>
-                  {% endif %}
-                  <a href="{{url}}"><h3>{{title}}</h3></a>
-                  <p>{{abstract}}</p>
-                </div>
-              {% endfor %}
-              </div>
+                {% if self.archival_link_url and self.archival_link_text %}
+                    <h2>Archival Materials</h2>
+                    <p><a class="coll-access" href="{{ self.archival_link_url }}">{{ self.archival_link_text }}</a></p>
+                {% endif %}
+
+                {% if self.first_feature %}
+                    <div class="home-modwrapper">
+                        <h2>Featured Collections &amp; Exhibits</h2>
+                        <div class="news-wrap">
+                            {% for title, url, abstract, thumb in features %}
+                                <div class="newsblock col-xs-12 col-sm-6 col-md-3">
+
+                                    {% if thumb %}
+                                        <figure class="embed">
+                                            <div class="figure-wrap">
+                                                <a href="{{url}}">
+                                                    {% if thumb %}
+                                                        {% image thumb width-200 class="img-responsive" %}
+                                                    {% endif %}
+                                                </a>
+                                            </div>
+                                        </figure>
+                                    {% endif %}
+                                    <a href="{{url}}"><h3>{{title}}</h3></a>
+                                    <p>{{abstract}}</p>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% if self.supplementary_header and self.supplementary_text %}
+                    <h2>{{ self.supplementary_header }}</h2>
+                    <p>{{ self.supplementary_text|richtext }}</p>
+                {% endif %}
+
+
+                {% if regional_collections %}
+                    <h2>Other Local Collections</h2>
+                    <p>
+                        {% for coll in regional_collections %}
+                            <p><a href="{{ coll.regional_collection_url }}">{{ coll.regional_collection_name }}</a><br/>{{ coll.regional_collection_description }}</p>
+                        {% endfor %}
+                    </p>
+                {% endif %}
             </div>
-          {% endif %}
-
-        {% if self.supplementary_header and self.supplementary_text %}
-          <h2>{{ self.supplementary_header }}</h2>
-          <p>{{ self.supplementary_text|richtext }}</p>
-        {% endif %}
-     
-
-        {% if regional_collections %}
-        <h2>Other Local Collections</h2> 
-          <p>
-            {% for coll in regional_collections %}
-              <p><a href="{{ coll.regional_collection_url }}">{{ coll.regional_collection_name }}</a><br/>{{ coll.regional_collection_description }}</p>
-            {% endfor %}
-          </p>
-        {% endif %}
-      </div>
-    </div><!--/.row-->
-  </article>
+        </div><!--/.row-->
+    </article>
 {% endblock %}
 
 {% block right_sidebar %}
-{% if self.collection_location %}
-  <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h2>Access Location</h2>
-        <p><a href="{{ self.collection_location.url }}">{{ self.collection_location.title }}</a></p>
-  </div>
-{% endif %}
+    {% if self.collection_location %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h2>Access Location</h2>
+            <p><a href="{{ self.collection_location.url }}">{{ self.collection_location.title }}</a></p>
+        </div>
+    {% endif %}
 
-  {% if related_subject_specialists %}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      {% for staff_title, staff_position_title, staff_url, staff_email, phone_and_fac, staff_thumb in related_subject_specialists %}
-        <h2>Subject Specialist</h2>
-        <p>
-          {% if staff_url and staff_title%}
-            <a href="{{ staff_url }}">{{ staff_title }}</a>
-          {% else %}
-            {{ staff_title }}
-          {% endif %}
+    {% if related_subject_specialists %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            {% for staff_title, staff_position_title, staff_url, staff_email, phone_and_fac, staff_thumb in related_subject_specialists %}
+                <h2>Subject Specialist</h2>
+                <p>
+                    {% if staff_url and staff_title%}
+                        <a href="{{ staff_url }}">{{ staff_title }}</a>
+                    {% else %}
+                        {{ staff_title }}
+                    {% endif %}
 
-          {% if staff_position_title %}
-            <br/><em>{{ staff_position_title }}</em><br/>
-          {% endif %}
+                    {% if staff_position_title %}
+                        <br/><em>{{ staff_position_title }}</em><br/>
+                    {% endif %}
 
-          {% if staff_email %}
-            <a href="mailto:{{ staff_email }}">{{ staff_email }}</a><br/>
-          {% endif %}
+                    {% if staff_email %}
+                        <a href="mailto:{{ staff_email }}">{{ staff_email }}</a><br/>
+                    {% endif %}
 
-          {% for staff_phone, staff_fac in phone_and_fac %}
+                    {% for staff_phone, staff_fac in phone_and_fac %}
 
-            {% if staff_phone %}
-              {{ staff_phone }}<br/>
-            {% endif %}
+                        {% if staff_phone %}
+                            {{ staff_phone }}<br/>
+                        {% endif %}
 
-            {% if staff_facu %}
-              {{ staff_fac }}
-            {% endif %}
+                        {% if staff_facu %}
+                            {{ staff_fac }}
+                        {% endif %}
 
-          {% endfor %}
-        </p>
-      {% endfor %}
-    </div>
-  {% endif %}
+                    {% endfor %}
+                </p>
+            {% endfor %}
+        </div>
+    {% endif %}
 
 
-  {% if self.related_collecting_areas.all %}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h2>Related Collecting Area</h2>
-        {% for rca in self.related_collecting_areas.all %}
-            <p><a href="{% pageurl rca.related_collecting_area %}">{{ rca.related_collecting_area.title }}</a></p>
-        {% endfor %}
-    </div>
-  {% endif %}
-  
+    {% if self.related_collecting_areas.all %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h2>Related Collecting Area</h2>
+            {% for rca in self.related_collecting_areas.all %}
+                <p><a href="{% pageurl rca.related_collecting_area %}">{{ rca.related_collecting_area.title }}</a></p>
+            {% endfor %}
+        </div>
+    {% endif %}
 
-  {% if related_collections %}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-    <h2>Related Collections</h2>
-      <ul>
-        {% for title, href in related_collections %}
-          <li><a href="{{href}}">{{title}}</a></li>
-        {% endfor %}
-      </ul>
-    </div>
-  {% endif %}
 
-  {% if related_exhibits %}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h2>Related Exhibits</h2>
-        <ul>
-          {% for title, href in related_exhibits %}
-            <li><a href="{{href}}">{{title}}</a></li>
-          {% endfor %}
-        </ul>
-    </div>
-  {% endif %}
+    {% if related_collections %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h2>Related Collections</h2>
+            <ul>
+                {% for title, href in related_collections %}
+                    <li><a href="{{href}}">{{title}}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if related_exhibits %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h2>Related Exhibits</h2>
+            <ul>
+                {% for title, href in related_exhibits %}
+                    <li><a href="{{href}}">{{title}}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block right_sidebar_classes %}coll-rightside{% endblock %}

--- a/lib_collections/templates/lib_collections/collection_page.html
+++ b/lib_collections/templates/lib_collections/collection_page.html
@@ -8,72 +8,72 @@
 
 {% block styles %}
     {% compress css %}
-	<link href="{% static "/base/css/collex-digital.scss" %}" rel="stylesheet" type="text/x-scss"/>
+        <link href="{% static "/base/css/collex-digital.scss" %}" rel="stylesheet" type="text/x-scss"/>
     {% endcompress %}
 {% endblock %}
 
 {% block content %}
     <article>
-	<div class="row">
-	    <div class="col-xs-12">
+        <div class="row">
+            <div class="col-xs-12">
 
-		<figure class="imgcaption coll-thumb">
-		    {% if self.thumbnail %}
-			{% image self.thumbnail width-200 class="img-responsive" %}
-			{% if self.thumbnail_caption %}
-			    <figcaption>{{ self.thumbnail_caption }}</figcaption>
-			{% endif %}
-		    {% elif default_image %}
-			{% image default_image width-200 %}
-		    {% endif %}
-		</figure>
+                <figure class="imgcaption coll-thumb">
+                    {% if self.thumbnail %}
+                        {% image self.thumbnail width-200 class="img-responsive" %}
+                        {% if self.thumbnail_caption %}
+                            <figcaption>{{ self.thumbnail_caption }}</figcaption>
+                        {% endif %}
+                    {% elif default_image %}
+                        {% image default_image width-200 alt="" %}
+                    {% endif %}
+                </figure>
 
-		{% for block in self.full_description %}
-		    {{ block }}
-		{% endfor %}
+                {% for block in self.full_description %}
+                    {{ block }}
+                {% endfor %}
 
-		{% if self.primary_online_access_link_url and self.primary_online_access_link_label and show_external_link %}
-		    <a role="button" class="btn btn-morecoll" href="{{ self.primary_online_access_link_url }}">{{ self.primary_online_access_link_label }}</i></a>
-		{% endif %}
-		
-		{% if self.access_instructions or supplementary_access_links %}
-		    <h3>Access Information</h3>
+                {% if self.primary_online_access_link_url and self.primary_online_access_link_label and show_external_link %}
+                    <a role="button" class="btn btn-morecoll" href="{{ self.primary_online_access_link_url }}">{{ self.primary_online_access_link_label }}</a>
+                {% endif %}
 
-		    {% if supplementary_access_links %}
-			<p>
-			    {% for l in supplementary_access_links %}
-			        <a class="coll-access" href="{{ l.supplementary_access_link_url }}">{{ l.supplementary_access_link_label }}</a><br/>
-			    {% endfor %}
-			</p>
-		    {% endif %}
+                {% if self.access_instructions or supplementary_access_links %}
+                    <h3>Access Information</h3>
 
-		    {% if self.access_instructions %}
-			<p>{{ self.access_instructions }}</p>
-		    {% endif %}
-		{% endif %}
-	    </div>
-	</div><!--/.row-->
+                    {% if supplementary_access_links %}
+                        <p>
+                            {% for l in supplementary_access_links %}
+                                <a class="coll-access" href="{{ l.supplementary_access_link_url }}">{{ l.supplementary_access_link_label }}</a><br/>
+                            {% endfor %}
+                        </p>
+                    {% endif %}
+
+                    {% if self.access_instructions %}
+                        <p>{{ self.access_instructions }}</p>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div><!--/.row-->
     </article>
 
-{% if objects %}
-    <div class="home-module">
-      <h2 class="browse"> Collection Highlights </h2>
-      <span class="browse-links">
-	<span class="headline">Browse:&nbsp; </span>
-	{% for type, link in sidebar_browse_types.items %}
-	<a href="{{ link }}">
-	  {{ type }}
-	</a>
-	{% endfor %}
-      </span>
-    </div>
+    {% if objects %}
+        <div class="home-module">
+            <h2 class="browse"> Collection Highlights </h2>
+            <span class="browse-links">
+                <span class="headline">Browse:&nbsp; </span>
+                {% for type, link in sidebar_browse_types.items %}
+                    <a href="{{ link }}">
+                        {{ type }}
+                    </a>
+                {% endfor %}
+            </span>
+        </div>
 
-    <section class="browse-list">
-      {% include "includes/general_listing.html" %}
-    </section>
-{% else %}
-{% endif %}
-    
+        <section class="browse-list">
+            {% include "includes/general_listing.html" %}
+        </section>
+    {% else %}
+    {% endif %}
+
 {% endblock %}
 
 {% block right_sidebar %}

--- a/lib_collections/templates/lib_collections/collections_index_page.html
+++ b/lib_collections/templates/lib_collections/collections_index_page.html
@@ -6,244 +6,243 @@
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 
 {% block content %}
-  <article>
-  <div class="row">
-  {% if view == 'collections' %}
-    {% include 'lib_collections/header_collections.html' %}
-    <div class="col-xs-12">
-      <table class="table table-striped coll-list">
-        <thead>
-          <tr class="etable-header">
-            {% if search %}
-              <th colspan="4">Search Results for "{{ search }}"</th>
-            {% else %}
-              <th colspan="4">Collections</th>
+    <article>
+        <div class="row">
+            {% if view == 'collections' %}
+                {% include 'lib_collections/header_collections.html' %}
+                <div class="col-xs-12">
+                    <table class="table table-striped coll-list">
+                        <thead>
+                            <tr class="etable-header">
+                                {% if search %}
+                                    <th colspan="4">Search Results for "{{ search }}"</th>
+                                {% else %}
+                                    <th colspan="4">Collections</th>
+                                {% endif %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="visually-hidden">
+                                <th scope="col">Collection Thumbnail</th>
+                                <th scope="col">Title</th>
+                                <th scope="col">Formats</th>
+                                <th scope="col">Subjects</th>
+                            </tr>
+                            {% for collection_page in collections %}
+                                <tr>
+                                    <td scope="row">
+                                        {% if collection_page.thumbnail %}
+                                            {% image collection_page.thumbnail fill-100x100 %}
+                                        {% else %}
+                                            {% if default_image %}
+                                                {% image default_image fill-100x100 alt="" %}
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                    <td><strong><a href="{{ collection_page.url }}">{{ collection_page.title }}</a></strong><br/>{{ collection_page.short_abstract }}</td>
+                                    <td><strong>Formats</strong><br/>{% collections_formats collection_page %}</td>
+                                    <td>
+                                        <strong>Subjects</strong><br/>
+                                        {% for collection_subject_placement in collection_page.collection_subject_placements.all %}
+                                            <a href=".?view=collections&amp;subject={{ collection_subject_placement.subject|urlencode }}">{{ collection_subject_placement.subject }}</a><br/>
+                                        {% endfor %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            {% if search and not collections %}
+                                <tr>
+                                    <td colspan="4">There were no results for your search.</td>
+                                </tr>
+                            {% endif %}
+                        </tbody>
+                    </table>
+                </div>
             {% endif %}
-          </tr>
-          </thead>
-          <tbody>
-          <tr class="visually-hidden">
-            <th scope="col">Collection Thumbnail</th>
-            <th scope="col">Title</th>
-            <th scope="col">Formats</th>
-            <th scope="col">Subjects</th>
-          </tr>
-          {% for collection_page in collections %}
-            <tr>
-              <td scope="row">
-                {% if collection_page.thumbnail %}
-                  {% image collection_page.thumbnail fill-100x100 %}
-                {% else %}
-                  {% if default_image %}
-                    {% image default_image fill-100x100 %}
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td><strong><a href="{{ collection_page.url }}">{{ collection_page.title }}</a></strong><br/>{{ collection_page.short_abstract }}</td>
-              <td><strong>Formats</strong><br/>{% collections_formats collection_page %}</td>
-              <td>
-                <strong>Subjects</strong><br/>
-                {% for collection_subject_placement in collection_page.collection_subject_placements.all %}
-                  <a href=".?view=collections&amp;subject={{ collection_subject_placement.subject|urlencode }}">{{ collection_subject_placement.subject }}</a><br/>
-                {% endfor %}
-              </td>
-            </tr>
-          {% endfor %}
-          {% if search and not collections %}
-            <tr>
-              <td colspan="4">There were no results for your search.</td>
-            </tr>
-          {% endif %}
-        </tbody>
-      </table>
-    </div>
-  {% endif %}
-  {% if view == 'exhibits' %}
-    {% include 'lib_collections/header_exhibits.html' %}
-    <div class="col-xs-12">
-      <table class="table table-striped coll-list">
-      {% if exhibits_current %}
-        <thead>
-          <tr class="etable-header">
-              <th colspan="4">Current Exhibits</th>
-            </tr>
-          </thead>
-          {% endif %}
-          <tbody>
-          <tr class="visually-hidden">
-            <th scope="col">Exhibit Thumbnail</th>
-            <th scope="col">Title</th>
-            <th scope="col">Locations</th>
-            <th scope="col">Subjects</th>
-          </tr>  
-          {% for exhibit in exhibits_current %}
-            <tr>
-              <td scope="row">
-                {% if exhibit.thumbnail %}
-                  {% image exhibit.thumbnail fill-100x100 %}
-                {% else %}
-                  {% if default_image %}
-                    {% image default_image fill-100x100 %}
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td>
-                <a href="{{ exhibit.url }}"><strong>{{ exhibit.title }}</strong></a>
-                <br/>
-                {{ exhibit.short_abstract }}
-              </td>
-              <td>
-                {% if exhibit.exhibit_location %}
-                  <strong>Locations</strong><br/>
-                  <a href="{{ exhibit.exhibit_location.url }}">{{ exhibit.exhibit_location.title }}</a><br/>
-                {% endif %}
-                {% if exhibit.exhibit_open_date and exhibit.exhibit_close_date %}
-                  {% if exhibit.is_online_exhibit %}
-                    <em>From {{ exhibit.exhibit_open_date|date:"N j" }}</em><br/>
-                  {% else %}
-                    <em>{{ exhibit.exhibit_open_date|date:"N j" }} &#8212; {{ exhibit.exhibit_close_date }}</em><br/>
-                {% endif %}
-                {% endif %}
-                {% if exhibit.web_exhibit or exhibit.web_exhibit_url %}
-                  {% if exhibit.web_exhibit %}
-                    <a class="viewall" href="{{ exhibit.url }}">View web exhibit</a><br/>
-                  {% else %}
-                    <a class="viewall" href="{{ exhibit.web_exhibit_url }}">View web exhibit</a><br/>
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td>
-                {% if exhibit.exhibit_subject_placements.all %}
-                  <strong>Subjects</strong>
-                  <br/>
-                  {% for subject_placement in exhibit.exhibit_subject_placements.all %}
-                    <a href=".?view=exhibits&amp;subject={{ subject_placement.subject.name|urlencode }}">{{ subject_placement.subject.name }}</a><br/>
-                  {% endfor %}
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-          {% if exhibits %}
-            <tr class="etable-header">
-              <th colspan="4">Exhibits</th>
-            </tr>
-          {% endif %}
-          {% for exhibit in exhibits %}
-            <tr>
-              <td scope="row">
-                {% if exhibit.thumbnail %}
-                  {% image exhibit.thumbnail fill-100x100 %}
-                {% else %}
-                  {% if default_image %}
-                    {% image default_image fill-100x100 %}
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td>
-                <a href="{{ exhibit.url }}"><strong>{{ exhibit.title }}</strong></a>
-                <br/>
-                {{ exhibit.short_abstract }}
-              </td>
-              <td>
-                {% if exhibit.exhibit_location %}
-                  <strong>Locations</strong>
-                  <br/>
-                  <a href="{{ exhibit.exhibit_location.url }}">{{ exhibit.exhibit_location.title }}</a><br/>
-                {% endif %}
-                {% if exhibit.exhibit_open_date and exhibit.exhibit_close_date %}
-                  <em>{{ exhibit.exhibit_open_date|date:"N j" }} &#8212; {{ exhibit.exhibit_close_date }}</em><br/>
-                {% endif %}
-                {% if exhibit.web_exhibit or exhibit.web_exhibit_url %}
-                  {% if exhibit.web_exhibit %}
-                    <a href="{{ exhibit.url }}">View web exhibit &gt;&gt;</a>
-                  {% else %}
-                    <a href="{{ exhibit.web_exhibit_url }}">View web exhibit &gt;&gt;</a>
-                  {% endif %}
-                {% endif %}
-              </td>
-              <td>
-                {% if exhibit.exhibit_subject_placements.all %}
-                  <strong>Subjects</strong>
-                  <br/>
-                  {% for subject_placement in exhibit.exhibit_subject_placements.all %}
-                    <a href=".?view=exhibits&amp;subject={{ subject_placement.subject.name|urlencode }}">{{ subject_placement.subject.name }}</a></br/>
-                  {% endfor %}
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-          
-        </tbody>
-      </table>
-    </div>
-  {% endif %}
-  {% if view == 'subjects' %}
-    {% include 'lib_collections/header_subject.html' %}
-      <div class="col-xs-12">
-        <table class="table table-striped coll-list">
-          <thead>
-            <tr class="etable-header">
-              <th colspan="4">Subjects</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr class="visually-hidden">
-              <th scope="col">Subject</th>
-              <th scope="col">Available Resources</th>
-              <th scope="col">Parent Subject</th>
-            </tr> 
-            {% for s in subjects %}
-              {% if s.see_also %}
-                <tr class="seealso">
-                  <td><strong>{{ s.name }}</strong></td>
-                  <td>See: <a href=".?view=subjects#{{ s.see_also|urlencode }}"><span class="visually-hidden">{{ s.name }} is classified under</span> {{ s.see_also }}</a></td>
-                  <td></td>
-                </tr>
-              {% else %}
-                <tr id="{{ s.name }}">
-                  <td scope="row"><strong>{{ s.name }}</strong>
-                    {% if s.has_collecting_area %}<br/>
-                      <a href="{{ s.collecting_area_url }}"><i class="material-icons" aria-hidden="true">style</i>View Collecting Area Page<span class="visually-hidden"> for {{ s.name }} </span></a><br/>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if s.has_subject_specialists %}
-                      <a href="/about/directory/?view=staff&amp;subject={{ s.name|urlencode }}"><i class="material-icons" aria-hidden="true">supervisor_account</i>
-                      <span class="visually-hidden">{{ s.name }} </span>Subject Specialists</a><br/>
-                    {% endif %}
-                    {% if s.has_exhibits %}
-                      <a href=".?view=exhibits&amp;subject={{ s.name|urlencode }}"><i class="material-icons" aria-hidden="true">insert_photo</i>
-                      <span class="visually-hidden">{{ s.name }} </span>Exhibits</a><br/>
-                    {% endif %}
-                    {% if s.has_collections %}
-                      <a href=".?view=collections&amp;subject={{ s.name|urlencode }}"><i class="material-icons" aria-hidden="true">filter</i>
-                      <span class="visually-hidden">{{ s.name }} </span>Collections</a><br/>
-                    {% endif %}
-                    {% if s.libguide_url %}
-                      <a href="{{ s.libguide_url }}"><i class="material-icons" aria-hidden="true">recent_actors</i>
-                      <span class="visually-hidden">{{ s.name }} </span>Subject Guide</a><br/>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if s.parents %}
-                      <em>Part of:</em><br/>
-                      {% for p in s.parents %}
-                        <a href="#{{ p|urlencode }}"><span class="visually-hidden">{{ s.name }} is part of </span>{{ p }}</a><br/>
-                      {% endfor %}
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endif %}
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    {% endif %}
-    {% if view == 'subjecttree' %}
-       {{ subjecttree|safe }}
-    {% endif %}
-  </div>
-  </article>
+            {% if view == 'exhibits' %}
+                {% include 'lib_collections/header_exhibits.html' %}
+                <div class="col-xs-12">
+                    <table class="table table-striped coll-list">
+                        {% if exhibits_current %}
+                            <thead>
+                                <tr class="etable-header">
+                                    <th colspan="4">Current Exhibits</th>
+                                </tr>
+                            </thead>
+                        {% endif %}
+                        <tbody>
+                            <tr class="visually-hidden">
+                                <th scope="col">Exhibit Thumbnail</th>
+                                <th scope="col">Title</th>
+                                <th scope="col">Locations</th>
+                                <th scope="col">Subjects</th>
+                            </tr>
+                            {% for exhibit in exhibits_current %}
+                                <tr>
+                                    <td scope="row">
+                                        {% if exhibit.thumbnail %}
+                                            {% image exhibit.thumbnail fill-100x100 %}
+                                        {% else %}
+                                            {% if default_image %}
+                                                {% image default_image fill-100x100 alt="" %}
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a href="{{ exhibit.url }}"><strong>{{ exhibit.title }}</strong></a>
+                                        <br/>
+                                        {{ exhibit.short_abstract }}
+                                    </td>
+                                    <td>
+                                        {% if exhibit.exhibit_location %}
+                                            <strong>Locations</strong><br/>
+                                            <a href="{{ exhibit.exhibit_location.url }}">{{ exhibit.exhibit_location.title }}</a><br/>
+                                        {% endif %}
+                                        {% if exhibit.exhibit_open_date and exhibit.exhibit_close_date %}
+                                            {% if exhibit.is_online_exhibit %}
+                                                <em>From {{ exhibit.exhibit_open_date|date:"N j" }}</em><br/>
+                                            {% else %}
+                                                <em>{{ exhibit.exhibit_open_date|date:"N j" }} &#8212; {{ exhibit.exhibit_close_date }}</em><br/>
+                                            {% endif %}
+                                        {% endif %}
+                                        {% if exhibit.web_exhibit or exhibit.web_exhibit_url %}
+                                            {% if exhibit.web_exhibit %}
+                                                <a class="viewall" href="{{ exhibit.url }}">View web exhibit</a><br/>
+                                            {% else %}
+                                                <a class="viewall" href="{{ exhibit.web_exhibit_url }}">View web exhibit</a><br/>
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if exhibit.exhibit_subject_placements.all %}
+                                            <strong>Subjects</strong>
+                                            <br/>
+                                            {% for subject_placement in exhibit.exhibit_subject_placements.all %}
+                                                <a href=".?view=exhibits&amp;subject={{ subject_placement.subject.name|urlencode }}">{{ subject_placement.subject.name }}</a><br/>
+                                            {% endfor %}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            {% if exhibits %}
+                                <tr class="etable-header">
+                                    <th colspan="4">Exhibits</th>
+                                </tr>
+                            {% endif %}
+                            {% for exhibit in exhibits %}
+                                <tr>
+                                    <td scope="row">
+                                        {% if exhibit.thumbnail %}
+                                            {% image exhibit.thumbnail fill-100x100 %}
+                                        {% else %}
+                                            {% if default_image %}
+                                                {% image default_image fill-100x100 alt="" %}
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a href="{{ exhibit.url }}"><strong>{{ exhibit.title }}</strong></a>
+                                        <br/>
+                                        {{ exhibit.short_abstract }}
+                                    </td>
+                                    <td>
+                                        {% if exhibit.exhibit_location %}
+                                            <strong>Locations</strong>
+                                            <br/>
+                                            <a href="{{ exhibit.exhibit_location.url }}">{{ exhibit.exhibit_location.title }}</a><br/>
+                                        {% endif %}
+                                        {% if exhibit.exhibit_open_date and exhibit.exhibit_close_date %}
+                                            <em>{{ exhibit.exhibit_open_date|date:"N j" }} &#8212; {{ exhibit.exhibit_close_date }}</em><br/>
+                                        {% endif %}
+                                        {% if exhibit.web_exhibit or exhibit.web_exhibit_url %}
+                                            {% if exhibit.web_exhibit %}
+                                                <a href="{{ exhibit.url }}">View web exhibit &gt;&gt;</a>
+                                            {% else %}
+                                                <a href="{{ exhibit.web_exhibit_url }}">View web exhibit &gt;&gt;</a>
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if exhibit.exhibit_subject_placements.all %}
+                                            <strong>Subjects</strong>
+                                            <br/>
+                                            {% for subject_placement in exhibit.exhibit_subject_placements.all %}
+                                                <a href=".?view=exhibits&amp;subject={{ subject_placement.subject.name|urlencode }}">{{ subject_placement.subject.name }}</a><br/>
+                                            {% endfor %}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+            {% if view == 'subjects' %}
+                {% include 'lib_collections/header_subject.html' %}
+                <div class="col-xs-12">
+                    <table class="table table-striped coll-list">
+                        <thead>
+                            <tr class="etable-header">
+                                <th colspan="4">Subjects</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="visually-hidden">
+                                <th scope="col">Subject</th>
+                                <th scope="col">Available Resources</th>
+                                <th scope="col">Parent Subject</th>
+                            </tr>
+                            {% for s in subjects %}
+                                {% if s.see_also %}
+                                    <tr class="seealso">
+                                        <td><strong>{{ s.name }}</strong></td>
+                                        <td>See: <a href=".?view=subjects#{{ s.see_also|urlencode }}"><span class="visually-hidden">{{ s.name }} is classified under</span> {{ s.see_also }}</a></td>
+                                        <td></td>
+                                    </tr>
+                                {% else %}
+                                    <tr id="{{ s.name }}">
+                                        <td scope="row"><strong>{{ s.name }}</strong>
+                                            {% if s.has_collecting_area %}<br/>
+                                                <a href="{{ s.collecting_area_url }}"><i class="material-icons" aria-hidden="true">style</i>View Collecting Area Page<span class="visually-hidden"> for {{ s.name }} </span></a><br/>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if s.has_subject_specialists %}
+                                                <a href="/about/directory/?view=staff&amp;subject={{ s.name|urlencode }}"><i class="material-icons" aria-hidden="true">supervisor_account</i>
+                                                    <span class="visually-hidden">{{ s.name }} </span>Subject Specialists</a><br/>
+                                            {% endif %}
+                                            {% if s.has_exhibits %}
+                                                <a href=".?view=exhibits&amp;subject={{ s.name|urlencode }}"><i class="material-icons" aria-hidden="true">insert_photo</i>
+                                                    <span class="visually-hidden">{{ s.name }} </span>Exhibits</a><br/>
+                                            {% endif %}
+                                            {% if s.has_collections %}
+                                                <a href=".?view=collections&amp;subject={{ s.name|urlencode }}"><i class="material-icons" aria-hidden="true">filter</i>
+                                                    <span class="visually-hidden">{{ s.name }} </span>Collections</a><br/>
+                                            {% endif %}
+                                            {% if s.libguide_url %}
+                                                <a href="{{ s.libguide_url }}"><i class="material-icons" aria-hidden="true">recent_actors</i>
+                                                    <span class="visually-hidden">{{ s.name }} </span>Subject Guide</a><br/>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if s.parents %}
+                                                <em>Part of:</em><br/>
+                                                {% for p in s.parents %}
+                                                    <a href="#{{ p|urlencode }}"><span class="visually-hidden">{{ s.name }} is part of </span>{{ p }}</a><br/>
+                                                {% endfor %}
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endif %}
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+            {% if view == 'subjecttree' %}
+                {{ subjecttree|safe }}
+            {% endif %}
+        </div>
+    </article>
 {% endblock %}
 

--- a/lib_collections/templates/lib_collections/exhibit_page.html
+++ b/lib_collections/templates/lib_collections/exhibit_page.html
@@ -7,7 +7,7 @@
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 {% block styles %}
     {% if google_font_link %}
-        <link href="{{google_font_link}}" rel="stylesheet"> 
+        <link href="{{google_font_link}}" rel="stylesheet">
     {% endif %}
     {% if branding_color %}
         <style>
@@ -22,45 +22,45 @@
                  */
 
                 @mixin respond-to($breakpoint) {
-                  // Extra small devices (phones, 544px and up)
-                  @if $breakpoint == "xsmall" {
-                    @media (min-width: 34em) {
-                      @content;
+                    // Extra small devices (phones, 544px and up)
+                    @if $breakpoint == "xsmall" {
+                        @media (min-width: 34em) {
+                            @content;
+                        }
                     }
-                  }
 
-                  // Small devices (landscape phones, 768px and up)
-                  @else if $breakpoint == "small" {
-                    @media (min-width: 48em) {
-                      @content;
+                    // Small devices (landscape phones, 768px and up)
+                    @else if $breakpoint == "small" {
+                        @media (min-width: 48em) {
+                            @content;
+                        }
                     }
-                  }
-                  // Medium devices (crappy laptops, tablets, 992px and up)
-                  @else if $breakpoint == "medium" {
-                    @media (min-width: 62em) {
-                      @content;
+                    // Medium devices (crappy laptops, tablets, 992px and up)
+                    @else if $breakpoint == "medium" {
+                        @media (min-width: 62em) {
+                            @content;
+                        }
                     }
-                  }
-                  // Large devices (desktops, 1200px and up)
-                  @else if $breakpoint == "large" {
-                    @media (min-width: 75em) {
-                      @content;
+                    // Large devices (desktops, 1200px and up)
+                    @else if $breakpoint == "large" {
+                        @media (min-width: 75em) {
+                            @content;
+                        }
                     }
-                  }
 
-                  //Extra large devices (large desktops, 1900px and up)
-                  @else if $breakpoint == "xlarge" {
-                    @media (min-width: 118em) {
-                      @content;
+                    //Extra large devices (large desktops, 1900px and up)
+                    @else if $breakpoint == "xlarge" {
+                        @media (min-width: 118em) {
+                            @content;
+                        }
                     }
-                  }
-                  
-                  // Short-cut to target extra small devices *only* (phones, 544px and up)
-                  @else if $breakpoint == "smallonly" {
-                    @media (max-width: 34em) {
-                      @content;
+
+                    // Short-cut to target extra small devices *only* (phones, 544px and up)
+                    @else if $breakpoint == "smallonly" {
+                        @media (max-width: 34em) {
+                            @content;
+                        }
                     }
-                  }
                 }
 
                 $darkgray: #767676;
@@ -71,536 +71,536 @@
                 $font-large: 2.5em;
                 $font-medium: 1.5em;
                 $font-small: 1.1em;
-                
-				.exhibitpage, .exhibitchildpage {
-				    .body-container {
-				    	h1, h2 {
-				        color: $base-color;
-				        font-family: $display-font;
-				        font-style: normal;
-				        font-size: $font-medium;
-				        font-weight: 400;
-					    }
-					
-					    h3 {
-					        color: lighten($base-color, 10%);
-					        font-style: normal;
-					        font-size: $font-small;
-					        font-weight: 600;
-					    }
-					
-					    h4 {
-					        color: $base-color;
-					        font-style: italic;
-					        font-size: $font-small;
-					        font-weight: 600;
-					    }
-					}
-				
-				    .jumbotron {
-				      min-height: 250px;
-				      overflow: hidden;
-				      padding-top: 0px;
-				      margin-bottom: 0;
-				      background-color: $darkred; //fallback if all else fails
-				      background-size: cover;
-				      h2 {
-				        color: #fff;
-				      }
-				      .container {
-				        padding: 0px;
-				        margin: 0px;
-				        position: relative;
-				        width: 100%;
-				      }
-				      .img-wrapper {
-				        display: none;
-				        @include respond-to(small) {
-				            display: block;
-				            width: 250px;
-				            overflow: hidden;
-				        }
-				        @include respond-to(medium) {
-				            width: 250px;
-				            overflow: hidden;
-				        }
-				        img {
-				            width: 200px;
-				            height: auto;
-				            @include respond-to(medium) {
-				                width: 250px;
-				            }
-				        }
-				        &+.overlaywrap {
-				            @include respond-to(small) {
-				                left: 200px;
-				            }
-				            @include respond-to(medium) {
-				                left: 250px;
-				            }
-				        }
-				      }
-				    }
-				
-				    .jumbotron .overlaywrap {
-				        background-color: rgba( $base-color, .9 );
-				        left: 0;
-				        top: 0;
-				        font-family: $display-font;
-				        padding: 0.5em 2em;
-	    				font-size: {{font_size}}px;
-					letter-spacing: {{font_kerning}}px;
-				        @include respond-to(small) {
-				                padding-right: 6em;
-				            }
-				        p {
-				            padding: 0;
-				            margin: 0;
-				            &:last-child {
-				                padding-bottom: 15px;
-				            }
-				        }
-				        h2 {
-				            font-weight: 100;
-				            font-size: $font-large*0.7;
-				            margin: 0;
-				            padding: 0px;
-				            letter-spacing: 0.03em;
-				            color: contrast-color($base-color, shade($base-color, 5%), tint($base-color, 90%), 80%);
-				            @include respond-to(small) {
-				                font-size: $font-large;
-				            }
-				        }
-				        .banner-subtitle {
-				            font-family: $display-font;
-				            color: lighten($base-color, 60%);
-				            font-size: $font-medium*0.8;
-				            padding-bottom:5px;
-				            @include respond-to(small) {
-				                font-size: $font-medium;
-				            }
-				        }
-				        .banner-loc, .banner-loc a, .banner-date {
-				            font-family: $display-font;
-				            color: #e0dddb;
-				            font-style: italic;
-				            font-size: $font-small*0.8;
-				        }
-				    }
-				
-				    .btn.webex-next {
-				        margin-top: 2em;
-				        background: transparent;
-				        border-color: $base-color;
-				        float: right;
-				        a & {
-				            color: $base-color;
-				        }
-				    }
-				
-				    .sidebar {
-				        background-color: #fff;
-				        border-right: 1px solid #ddd;
-				        @include respond-to(small) {    
-				            background-color: #fff;
-				            border-right: 1px dotted #767676;
-				        }
-				        h3 a {
-				            color: lighten($base-color, 20%);
-				        }
-				        > ul {
-				            > li { // Direct child page
-				                a {
-				                    font-weight: 200;
-				                    color: $base-color;
-				                    &:hover {
-				                        color: lighten($base-color, 25%);
-				                        text-decoration: none;
-				                    }
-				                }
-				                &.active { // Active direct child page
-				                    background-color: lighten($base-color, 75%);
-				                    margin-left: -2em; // Bleed background color past div
-				                    margin-right: -1em; // Bleed background color past div
-				                    padding: 0.5em 0.5em 0.5em 2em; // Fix text padding from bleeding background color past div
-				                    >a {
-				                        font-weight: 600;
-				                    }
-				                }
-				                > ul { // Grandchild page
-				                    padding-left: 1.5em;
-				                    border-left: 3px solid lighten($base-color, 75%);
-				                    li a {
-				                        font-style: italic;
-				                        color: lighten($base-color, 10%);
-				                    }
-				                }
-				            }
-				        }
-				    }
-				
-				    .coll-rightside {
-				        background-color: lighten($base-color, 75%);
-				        h3, h3 a {
-				            color: lighten($base-color, 10%);
-				            border-bottom-color: lighten($base-color, 10%);
-				        }
-				    }
-				} // End body.exhibitpage customizations
-				
-				.collex-loc {
-				    background-color: #eee;
-				    padding: 1.5em;
-				    display: flex;
-				    flex-wrap: wrap;
-				    & ~ #push {
-				        background-color: #eee;
-				    }
-				    .loc-title {
-				        margin-bottom: 0.5em;
-				        color: $base-color;
-				        font-weight: 600;
-				        font-size: 1em;
-				        a {
-				            font-weight: 400;   
-				            color: lighten($base-color, 15%);
-				        }
-				    }
-				    p, ul {
-				        font-size: 0.95em;
-				    }
-				    ul {
-				        list-style: none;
-				        padding-left: 0;
-				        & li {
-				            margin-bottom: 10px;
-				            .viewall {
-				                margin-top: 15px;
-				            }
-				        }
-				    }
-				}
-				
-				.loc-child {
-				    &+& {
-				        padding-top: 10px;
-				        border-top: 1px dotted #767676;
-				        @include respond-to(medium) {
-				            padding-top: initial;
-				            border-top: none;
-				        }
-				    }
-				    .loc-title~.loc-title {
-				        margin-top: 1.2em;
-				    }
-				}
-				
-				.collex-gallery {
-				    border-top: 1px dotted #767676;
-				}
-				
-				.collexbase {
-				    padding: 2em 1em;
-				    & figure {
-				       @include respond-to(medium) {
-				           display: flex;
-				       }
-				    }
-				}
-				
-				.collex-solo {
-				    @extend .collexbase;
-				    border-bottom: 1px dotted $darkgray;
-				    img {
-				        padding-bottom: 1em ;
-				        max-height: 40em;
-				        width: auto;
-				        @include respond-to(medium) {
-				        float: right;
-				            padding-bottom: 0;
-				        }
-				
-				    }
-				}
-				
-				.collex-solo, .collex-duo, .collex-trio, .collex-verso {
-				    img {
-				        border: 3px solid #c8c8c8;
-				    }
-				    .img-title {
-				        color: $base-color;
-				        font-size: $font-small;
-				        font-weight: 600;
-				    }
-				    .img-citation {
-				        color: darken($base-color, 10%);
-				        font-size: 0.95em;
-				    }
-				    .img-caption {
-				        color: #000;
-				        font-size: 1em;
-				    }
-				}
-				
-				.collex-verso {
-				    @extend .collex-solo;
-				    .modal.and.carousel {
-				      position: absolute; // Needed because the carousel overrides the position property
-				    }
-				}
-				
-				.duo-wrapper {
-				    display:flex;
-				    flex-wrap: wrap;
-				    padding: 1em;
-				    border-bottom: 1px dotted $darkgray;
-				}
-				
-				.collex-duo {
-				    padding: 0;
-				    text-align: center;
-				    & + & {
-				        border-top: 1px dotted $darkgray;
-				        @include respond-to(small) {
-				            border-top: none;
-				            border-left: 1px dotted $darkgray;
-				            padding-left: 1em;
-				        }
-				    }
-				    figure {
-				        display: inline-block;
-				        text-align: left;
-				        @include respond-to(small) {
-				            max-width: 90%;
-				        }
-				        @include respond-to(medium) {
-				            max-width: 80%;
-				        }
-				    }
-				    img {
-				        margin: 1.5em 1em 1.5em 0;
-				        @include respond-to(medium) {
-				            max-height: 30em;
-				            width: auto;
-				        }
-				    }
-				}
-				
-				.collex-trio {
-				    padding: 1em 0 2em 0;
-				    border-bottom: 1px dotted $darkgray;
-				    img {
-				        float: left;
-				        max-width: 28%;
-				        height: auto;
-				        margin: 1em;
-				        @include respond-to(large) {
-				            max-width: 25%;
-				        }
-				    }
-				    figcaption {
-				        clear: both;
-				    }
-				}
-				
-				#page-turn {
-				    position: absolute;
-				    width: 0;
-				    height: 0;
-				    right: 15px;
-				    border-top: 30px solid #fff;
-				    border-left: 30px solid #c0c0c0;
-				}
+
+                .exhibitpage, .exhibitchildpage {
+                    .body-container {
+                        h1, h2 {
+                            color: $base-color;
+                            font-family: $display-font;
+                            font-style: normal;
+                            font-size: $font-medium;
+                            font-weight: 400;
+                        }
+
+                        h3 {
+                            color: lighten($base-color, 10%);
+                            font-style: normal;
+                            font-size: $font-small;
+                            font-weight: 600;
+                        }
+
+                        h4 {
+                            color: $base-color;
+                            font-style: italic;
+                            font-size: $font-small;
+                            font-weight: 600;
+                        }
+                    }
+
+                    .jumbotron {
+                        min-height: 250px;
+                        overflow: hidden;
+                        padding-top: 0px;
+                        margin-bottom: 0;
+                        background-color: $darkred; //fallback if all else fails
+                        background-size: cover;
+                        h2 {
+                            color: #fff;
+                        }
+                        .container {
+                            padding: 0px;
+                            margin: 0px;
+                            position: relative;
+                            width: 100%;
+                        }
+                        .img-wrapper {
+                            display: none;
+                            @include respond-to(small) {
+                                display: block;
+                                width: 250px;
+                                overflow: hidden;
+                            }
+                            @include respond-to(medium) {
+                                width: 250px;
+                                overflow: hidden;
+                            }
+                            img {
+                                width: 200px;
+                                height: auto;
+                                @include respond-to(medium) {
+                                    width: 250px;
+                                }
+                            }
+                            &+.overlaywrap {
+                                @include respond-to(small) {
+                                    left: 200px;
+                                }
+                                @include respond-to(medium) {
+                                    left: 250px;
+                                }
+                            }
+                        }
+                    }
+
+                    .jumbotron .overlaywrap {
+                        background-color: rgba( $base-color, .9 );
+                        left: 0;
+                        top: 0;
+                        font-family: $display-font;
+                        padding: 0.5em 2em;
+                        font-size: {{font_size}}px;
+                        letter-spacing: {{font_kerning}}px;
+                        @include respond-to(small) {
+                            padding-right: 6em;
+                        }
+                        p {
+                            padding: 0;
+                            margin: 0;
+                            &:last-child {
+                                padding-bottom: 15px;
+                            }
+                        }
+                        h2 {
+                            font-weight: 100;
+                            font-size: $font-large*0.7;
+                            margin: 0;
+                            padding: 0px;
+                            letter-spacing: 0.03em;
+                            color: contrast-color($base-color, shade($base-color, 5%), tint($base-color, 90%), 80%);
+                            @include respond-to(small) {
+                                font-size: $font-large;
+                            }
+                        }
+                        .banner-subtitle {
+                            font-family: $display-font;
+                            color: lighten($base-color, 60%);
+                            font-size: $font-medium*0.8;
+                            padding-bottom:5px;
+                            @include respond-to(small) {
+                                font-size: $font-medium;
+                            }
+                        }
+                        .banner-loc, .banner-loc a, .banner-date {
+                            font-family: $display-font;
+                            color: #e0dddb;
+                            font-style: italic;
+                            font-size: $font-small*0.8;
+                        }
+                    }
+
+                    .btn.webex-next {
+                        margin-top: 2em;
+                        background: transparent;
+                        border-color: $base-color;
+                        float: right;
+                        a & {
+                            color: $base-color;
+                        }
+                    }
+
+                    .sidebar {
+                        background-color: #fff;
+                        border-right: 1px solid #ddd;
+                        @include respond-to(small) {
+                            background-color: #fff;
+                            border-right: 1px dotted #767676;
+                        }
+                        h3 a {
+                            color: lighten($base-color, 20%);
+                        }
+                        > ul {
+                            > li { // Direct child page
+                                a {
+                                    font-weight: 200;
+                                    color: $base-color;
+                                    &:hover {
+                                        color: lighten($base-color, 25%);
+                                        text-decoration: none;
+                                    }
+                                }
+                                &.active { // Active direct child page
+                                    background-color: lighten($base-color, 75%);
+                                    margin-left: -2em; // Bleed background color past div
+                                    margin-right: -1em; // Bleed background color past div
+                                    padding: 0.5em 0.5em 0.5em 2em; // Fix text padding from bleeding background color past div
+                                    >a {
+                                        font-weight: 600;
+                                    }
+                                }
+                                > ul { // Grandchild page
+                                    padding-left: 1.5em;
+                                    border-left: 3px solid lighten($base-color, 75%);
+                                    li a {
+                                        font-style: italic;
+                                        color: lighten($base-color, 10%);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    .coll-rightside {
+                        background-color: lighten($base-color, 75%);
+                        h3, h3 a {
+                            color: lighten($base-color, 10%);
+                            border-bottom-color: lighten($base-color, 10%);
+                        }
+                    }
+                } // End body.exhibitpage customizations
+
+                .collex-loc {
+                    background-color: #eee;
+                    padding: 1.5em;
+                    display: flex;
+                    flex-wrap: wrap;
+                    & ~ #push {
+                        background-color: #eee;
+                    }
+                    .loc-title {
+                        margin-bottom: 0.5em;
+                        color: $base-color;
+                        font-weight: 600;
+                        font-size: 1em;
+                        a {
+                            font-weight: 400;
+                            color: lighten($base-color, 15%);
+                        }
+                    }
+                    p, ul {
+                        font-size: 0.95em;
+                    }
+                    ul {
+                        list-style: none;
+                        padding-left: 0;
+                        & li {
+                            margin-bottom: 10px;
+                            .viewall {
+                                margin-top: 15px;
+                            }
+                        }
+                    }
+                }
+
+                .loc-child {
+                    &+& {
+                        padding-top: 10px;
+                        border-top: 1px dotted #767676;
+                        @include respond-to(medium) {
+                            padding-top: initial;
+                            border-top: none;
+                        }
+                    }
+                    .loc-title~.loc-title {
+                        margin-top: 1.2em;
+                    }
+                }
+
+                .collex-gallery {
+                    border-top: 1px dotted #767676;
+                }
+
+                .collexbase {
+                    padding: 2em 1em;
+                    & figure {
+                        @include respond-to(medium) {
+                            display: flex;
+                        }
+                    }
+                }
+
+                .collex-solo {
+                    @extend .collexbase;
+                    border-bottom: 1px dotted $darkgray;
+                    img {
+                        padding-bottom: 1em ;
+                        max-height: 40em;
+                        width: auto;
+                        @include respond-to(medium) {
+                            float: right;
+                            padding-bottom: 0;
+                        }
+
+                    }
+                }
+
+                .collex-solo, .collex-duo, .collex-trio, .collex-verso {
+                    img {
+                        border: 3px solid #c8c8c8;
+                    }
+                    .img-title {
+                        color: $base-color;
+                        font-size: $font-small;
+                        font-weight: 600;
+                    }
+                    .img-citation {
+                        color: darken($base-color, 10%);
+                        font-size: 0.95em;
+                    }
+                    .img-caption {
+                        color: #000;
+                        font-size: 1em;
+                    }
+                }
+
+                .collex-verso {
+                    @extend .collex-solo;
+                    .modal.and.carousel {
+                        position: absolute; // Needed because the carousel overrides the position property
+                    }
+                }
+
+                .duo-wrapper {
+                    display:flex;
+                    flex-wrap: wrap;
+                    padding: 1em;
+                    border-bottom: 1px dotted $darkgray;
+                }
+
+                .collex-duo {
+                    padding: 0;
+                    text-align: center;
+                    & + & {
+                        border-top: 1px dotted $darkgray;
+                        @include respond-to(small) {
+                            border-top: none;
+                            border-left: 1px dotted $darkgray;
+                            padding-left: 1em;
+                        }
+                    }
+                    figure {
+                        display: inline-block;
+                        text-align: left;
+                        @include respond-to(small) {
+                            max-width: 90%;
+                        }
+                        @include respond-to(medium) {
+                            max-width: 80%;
+                        }
+                    }
+                    img {
+                        margin: 1.5em 1em 1.5em 0;
+                        @include respond-to(medium) {
+                            max-height: 30em;
+                            width: auto;
+                        }
+                    }
+                }
+
+                .collex-trio {
+                    padding: 1em 0 2em 0;
+                    border-bottom: 1px dotted $darkgray;
+                    img {
+                        float: left;
+                        max-width: 28%;
+                        height: auto;
+                        margin: 1em;
+                        @include respond-to(large) {
+                            max-width: 25%;
+                        }
+                    }
+                    figcaption {
+                        clear: both;
+                    }
+                }
+
+                #page-turn {
+                    position: absolute;
+                    width: 0;
+                    height: 0;
+                    right: 15px;
+                    border-top: 30px solid #fff;
+                    border-left: 30px solid #c0c0c0;
+                }
             {% endinlinecompile %}
         </style>
     {% endif %}
 {% endblock %}
 
 {% block content %}
-  <article>
-    <div class="row">
-      <div class="col-xs-12">
-        <p>{{ self.acknowledgements }}</p>
-      </div>
-    </div>
-    <div class="row">
-        {% if not self.is_web_exhibit %} 
-          <div class="col-xs-12 col-sm-3">
-            {% if self.thumbnail %}
-              <figure class="imgcaption">
-                {% image self.thumbnail width-200 class="img-responsive" %}
-                {% if self.thumbnail_caption %}
-                  <figcaption>
-                    <p>{{ self.thumbnail_caption }}</p>
-                  </figcaption>
-                {% endif %}
-              </figure>
-            {% else %}
-              <figure>
-                {% image default_image width-200 class="img-responsive" %}
-              </figure>
+    <article>
+        <div class="row">
+            <div class="col-xs-12">
+                <p>{{ self.acknowledgements }}</p>
+            </div>
+        </div>
+        <div class="row">
+            {% if not self.is_web_exhibit %}
+                <div class="col-xs-12 col-sm-3">
+                    {% if self.thumbnail %}
+                        <figure class="imgcaption">
+                            {% image self.thumbnail width-200 class="img-responsive" %}
+                            {% if self.thumbnail_caption %}
+                                <figcaption>
+                                    <p>{{ self.thumbnail_caption }}</p>
+                                </figcaption>
+                            {% endif %}
+                        </figure>
+                    {% else %}
+                        <figure>
+                            {% image default_image width-200 class="img-responsive" alt="" %}
+                        </figure>
+                    {% endif %}
+                </div>
             {% endif %}
-          </div>
-        {% endif %}
 
-      <div class="col-xs-12{% if not self.is_web_exhibit %} col-sm-9{% endif %}">
-        {% if self.acknowledgments %}
-          <p class="acknowledgments">{{ self.acknowledgments }}</p>
-        {% endif %}
+            <div class="col-xs-12{% if not self.is_web_exhibit %} col-sm-9{% endif %}">
+                {% if self.acknowledgments %}
+                    <p class="acknowledgments">{{ self.acknowledgments }}</p>
+                {% endif %}
 
-        {% for block in self.full_description %}
-          {{ block }}
-        {% endfor %}
-  
-        {% if self.web_exhibit_url %} 
-          <a role="button" class="btn btn-morecoll" href="{{ self.web_exhibit_url }}">View Web Exhibit</a>
-        {% endif %}
-       
-        {% if self.publication_description or self.exhibit_text_document or self.exhibit_text_link_external or self.exhibit_text_link_page or self.exhibit_checklist_document or self.exhibit_checklist_link_external or self.exhibit_checklist_link_page %}
-          <h2>Exhibit Publications &amp; Documents</h2>
-  
-          {% if self.publication_description %}
-            <p>
-              {% if self.publication_url %}
-                <a href="{{ self.publication_url }}" class="btn btn-morecoll">Online Exhibit Catalog</a><br>
-              {% endif %}
-              <em>{{ self.publication_description }}</em>{% if self.publication_price %}, {{ self.publication_price }}{% endif %}</em><br/>
-              {% if self.ordering_information %}
-                <a href="/scrc/exhibits/ordering-special-collections-publications/">Ordering Information</a><br/>
-              {% endif %}
-            </p>
-          {% endif %}
-  
-          {% if self.exhibit_text_document %}
-            <p><a href="{{ self.exhibit_text_document.file.url }}">Exhibit Text</a></p>
-          {% endif %}
-          {% if self.exhibit_text_link_external %}
-            <p><a href="{{ self.exhibit_text_link_external }}">Exhibit Text</a></p>
-          {% endif %}
-          {% if self.exhibit_text_link_page %}
-            <p><a href="{{ self.exhibit_text_link_page.url }}">Exhibit Text</a></p>
-          {% endif %}
-  
-          {% if self.exhibit_checklist_document %}
-            <p><a href="{{ self.exhibit_checklist_document.file.url }}">Exhibit Checklist</a></p>
-          {% endif %}
-          {% if self.exhibit_checklist_link_external %}
-            <p><a href="{{ self.exhibit_checklist_link_external }}">Exhibit Checklist</a></p>
-          {% endif %}
-          {% if self.exhibit_checklist_link_page %}
-            <p><a href="{{ self.exhibit_checklist_link_page.url }}">Exhibit Checklist</a></p>
-          {% endif %}
-        {% endif %}
-      </div>
-    </div>
-  </article>
+                {% for block in self.full_description %}
+                    {{ block }}
+                {% endfor %}
+
+                {% if self.web_exhibit_url %}
+                    <a role="button" class="btn btn-morecoll" href="{{ self.web_exhibit_url }}">View Web Exhibit</a>
+                {% endif %}
+
+                {% if self.publication_description or self.exhibit_text_document or self.exhibit_text_link_external or self.exhibit_text_link_page or self.exhibit_checklist_document or self.exhibit_checklist_link_external or self.exhibit_checklist_link_page %}
+                    <h2>Exhibit Publications &amp; Documents</h2>
+
+                    {% if self.publication_description %}
+                        <p>
+                            {% if self.publication_url %}
+                                <a href="{{ self.publication_url }}" class="btn btn-morecoll">Online Exhibit Catalog</a><br/>
+                            {% endif %}
+                            <em>{{ self.publication_description }}{% if self.publication_price %}, {{ self.publication_price }}{% endif %}</em><br/>
+                            {% if self.ordering_information %}
+                                <a href="/scrc/exhibits/ordering-special-collections-publications/">Ordering Information</a><br/>
+                            {% endif %}
+                        </p>
+                    {% endif %}
+
+                    {% if self.exhibit_text_document %}
+                        <p><a href="{{ self.exhibit_text_document.file.url }}">Exhibit Text</a></p>
+                    {% endif %}
+                    {% if self.exhibit_text_link_external %}
+                        <p><a href="{{ self.exhibit_text_link_external }}">Exhibit Text</a></p>
+                    {% endif %}
+                    {% if self.exhibit_text_link_page %}
+                        <p><a href="{{ self.exhibit_text_link_page.url }}">Exhibit Text</a></p>
+                    {% endif %}
+
+                    {% if self.exhibit_checklist_document %}
+                        <p><a href="{{ self.exhibit_checklist_document.file.url }}">Exhibit Checklist</a></p>
+                    {% endif %}
+                    {% if self.exhibit_checklist_link_external %}
+                        <p><a href="{{ self.exhibit_checklist_link_external }}">Exhibit Checklist</a></p>
+                    {% endif %}
+                    {% if self.exhibit_checklist_link_page %}
+                        <p><a href="{{ self.exhibit_checklist_link_page.url }}">Exhibit Checklist</a></p>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div>
+    </article>
 {% endblock %}
 
 {% block right_sidebar %}
-  {% if self.exhibit_open_date or self.exhibit_close_date or self.exhibit_daily_hours or self.exhibit_location or self.exhibit_cost or self.space_type %}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h3>Exhibit Details</h3>
-      <p>
-        {% if self.space_type %}
-          {{ self.space_type }} Exhibit<br/>
-        {% endif %}
+    {% if self.exhibit_open_date or self.exhibit_close_date or self.exhibit_daily_hours or self.exhibit_location or self.exhibit_cost or self.space_type %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h3>Exhibit Details</h3>
+            <p>
+                {% if self.space_type %}
+                    {{ self.space_type }} Exhibit<br/>
+                {% endif %}
 
-        {% if self.is_online_exhibit %}
-            From {% if self.exhibit_open_date %}{{ self.exhibit_open_date }}{% endif %}
-        {% else %}
-            {% if self.exhibit_open_date %}{{ self.exhibit_open_date }}{% endif %}
-            {% if self.exhibit_open_date and self.exhibit_close_date %}&ndash;{% endif %}
-            {% if self.exhibit_close_date %}{{ self.exhibit_close_date }}{% endif %}
-        {% endif %}
-	        <br/>
+                {% if self.is_online_exhibit %}
+                    From {% if self.exhibit_open_date %}{{ self.exhibit_open_date }}{% endif %}
+                {% else %}
+                    {% if self.exhibit_open_date %}{{ self.exhibit_open_date }}{% endif %}
+                    {% if self.exhibit_open_date and self.exhibit_close_date %}&ndash;{% endif %}
+                    {% if self.exhibit_close_date %}{{ self.exhibit_close_date }}{% endif %}
+                {% endif %}
+                <br/>
 
-        {% if self.exhibit_daily_hours %}
-          {{ self.exhibit_daily_hours }}<br/>
-        {% endif %}
+                {% if self.exhibit_daily_hours %}
+                    {{ self.exhibit_daily_hours }}<br/>
+                {% endif %}
 
-        {% if self.exhibit_location %}
-          <a href="{{ self.exhibit_location.url }}">{{ self.exhibit_location.title }}</a><br/>
-        {% endif %}
+                {% if self.exhibit_location %}
+                    <a href="{{ self.exhibit_location.url }}">{{ self.exhibit_location.title }}</a><br/>
+                {% endif %}
 
-        {% if self.exhibit_cost %}
-          {{ self.exhibit_cost }}<br/>
-        {% endif %}
-      </p>
+                {% if self.exhibit_cost %}
+                    {{ self.exhibit_cost }}<br/>
+                {% endif %}
+            </p>
 
-  	{% if self.extra_exhibit_info %}
-        {{self.extra_exhibit_info|richtext}}
-	{% endif %}
-    </div>
-  {% endif %}
+            {% if self.extra_exhibit_info %}
+                {{self.extra_exhibit_info|richtext}}
+            {% endif %}
+        </div>
+    {% endif %}
 
 
-  {% if self.staff_contact or unit_contact%}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h3>Contact</h3>
-      <p>
-        {% if self.staff_contact %}
-        <a href="{{ staff_url }}">{{ self.staff_contact.title }}</a><br>
-        <em>{{ self.staff_contact.position_title }}</em><br>
-        <a href="mailto:{{ self.staff_contact.staff_page_email.first.email|urlencode }}">{{ self.staff_contact.staff_page_email.first.email }}</a><br>
-        {{ self.staff_contact.staff_page_phone_faculty_exchange.first.phone_number }}<br>
-        {{ self.staff_contact.staff_page_phone_faculty_exchange.first.faculty_exchange }}<br>
-        {% endif %}
+    {% if self.staff_contact or unit_contact%}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h3>Contact</h3>
+            <p>
+                {% if self.staff_contact %}
+                    <a href="{{ staff_url }}">{{ self.staff_contact.title }}</a><br>
+                    <em>{{ self.staff_contact.position_title }}</em><br>
+                    <a href="mailto:{{ self.staff_contact.staff_page_email.first.email|urlencode }}">{{ self.staff_contact.staff_page_email.first.email }}</a><br>
+                    {{ self.staff_contact.staff_page_phone_faculty_exchange.first.phone_number }}<br>
+                    {{ self.staff_contact.staff_page_phone_faculty_exchange.first.faculty_exchange }}<br>
+                {% endif %}
 
-        {% if self.staff_contact and unit_contact%}
-          <br/>
-        {% endif %}
+                {% if self.staff_contact and unit_contact%}
+                    <br/>
+                {% endif %}
 
-        {% if unit_contact %}
-          {% if unit_url and unit_title%}
-            <a href="{{ unit_url }}">{{ unit_title }}</a><br/>
-          {% else %}
-            {{ unit_title }}<br/>
-          {% endif %}
-          {% if unit_email %}
-            <a href="mailto:{{ unit_email }}">{% if unit_email_label %}{{ unit_email_label }}{% else %}{{ unit_email }}{% endif %}</a><br/>
-          {% endif %}
-          {% if unit_phone_number %}
-            {% if unit_phone_label %}{{ unit_phone_label }}: {% endif %}{{ unit_phone_number }}<br/>
-          {% endif %}
-          {% if unit_fax_number %}
-            Fax: {{ unit_fax_number }}<br/>
-          {% endif %}
-          {% if unit_link_external %}
-            <a href="{{ unit_link_external }}">{% if unit_link_text %}{{ unit_link_text }}{% else %}{{ unit_link_external }}{% endif %}</a><br/>
-          {% endif %}
-          {% if unit_link_page %}
-            <a href="{{ unit_link_page }}">{% if unit_link_text %}{{ unit_link_text }}{% else %}{{ unit_link_page }}{% endif %}</a><br/>
-          {% endif %}
-          {% if unit_link_document %}
-            <a href="{{ unit_link_document }}">{% if unit_link_text %}{{ unit_link_text }}{% else %}{{ unit_link_document }}{% endif %}</a><br/>
-          {% endif %}
-        {% endif %}
-      </p>
-    </div>
-  {% endif %}
+                {% if unit_contact %}
+                    {% if unit_url and unit_title%}
+                        <a href="{{ unit_url }}">{{ unit_title }}</a><br/>
+                    {% else %}
+                        {{ unit_title }}<br/>
+                    {% endif %}
+                    {% if unit_email %}
+                        <a href="mailto:{{ unit_email }}">{% if unit_email_label %}{{ unit_email_label }}{% else %}{{ unit_email }}{% endif %}</a><br/>
+                    {% endif %}
+                    {% if unit_phone_number %}
+                        {% if unit_phone_label %}{{ unit_phone_label }}: {% endif %}{{ unit_phone_number }}<br/>
+                    {% endif %}
+                    {% if unit_fax_number %}
+                        Fax: {{ unit_fax_number }}<br/>
+                    {% endif %}
+                    {% if unit_link_external %}
+                        <a href="{{ unit_link_external }}">{% if unit_link_text %}{{ unit_link_text }}{% else %}{{ unit_link_external }}{% endif %}</a><br/>
+                    {% endif %}
+                    {% if unit_link_page %}
+                        <a href="{{ unit_link_page }}">{% if unit_link_text %}{{ unit_link_text }}{% else %}{{ unit_link_page }}{% endif %}</a><br/>
+                    {% endif %}
+                    {% if unit_link_document %}
+                        <a href="{{ unit_link_document }}">{% if unit_link_text %}{{ unit_link_text }}{% else %}{{ unit_link_document }}{% endif %}</a><br/>
+                    {% endif %}
+                {% endif %}
+            </p>
+        </div>
+    {% endif %}
 
-  {% if self.exhibit_page_related_collection_placement.all or self.exhibit_subject_placements.all %}
-    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h3>Explore Related Content</h3>
-      {% if self.exhibit_page_related_collection_placement.all %}
-        <h4>Related Collections</h4>
-        <ul>
-          {% for c in self.exhibit_page_related_collection_placement.all %}
-            <li><a href="{{ c.related_collection.url }}">{{ c.related_collection.title }}</a></li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    
-      {% if self.exhibit_subject_placements.all %}
-        <h4>Exhibits by Subject</h4>
-        <ul>
-          {% for s in self.exhibit_subject_placements.all %}
-            <li><a href="/collex/?view=exhibits&amp;subject={{ s.subject.name|urlencode }}">{{ s.subject.name }}</a></li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    </div>
-  {% endif %}
+    {% if self.exhibit_page_related_collection_placement.all or self.exhibit_subject_placements.all %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h3>Explore Related Content</h3>
+            {% if self.exhibit_page_related_collection_placement.all %}
+                <h4>Related Collections</h4>
+                <ul>
+                    {% for c in self.exhibit_page_related_collection_placement.all %}
+                        <li><a href="{{ c.related_collection.url }}">{{ c.related_collection.title }}</a></li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+
+            {% if self.exhibit_subject_placements.all %}
+                <h4>Exhibits by Subject</h4>
+                <ul>
+                    {% for s in self.exhibit_subject_placements.all %}
+                        <li><a href="/collex/?view=exhibits&amp;subject={{ s.subject.name|urlencode }}">{{ s.subject.name }}</a></li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block right_sidebar_classes %}coll-rightside{% endblock %}
@@ -626,7 +626,7 @@
                             <p>When classes are in session.<br>
                             For holiday hours, please consult our <a href="{{hours_page_url}}">hours page</a>.</p>
                             -->
-            
+
                             <span class="loc-title">{{page_location}}</span>
                             <p>Please consult our <a href="{{hours_page_url}}">hours page</a>.</p>
                         </div>

--- a/public/templates/public/location_page.html
+++ b/public/templates/public/location_page.html
@@ -7,63 +7,63 @@
 {% block content %}
     {{ self.page_alerts }}
     <article>
-            <div class="col-xs-12 col-sm-4">
-                {% if self.location_photo %}
-                    {% image self.location_photo width-500 class="img-responsive spaces" %}
-                {% else %}
-                    {% image default_image width-500 class="img-responsive spaces" %}
-                {% endif %}
-                {% if self.address_1 %}
-                    <p>
-                        <strong>{{ self.address_1 }}</strong><br/>
-                        {% if self.address_2 %}
-                            {{ self.address_2 }}<br/>
-                        {% endif %}
-                        {% if self.city and self.state and self.postal_code %}
-                            {{ self.city }}, {{ self.state }} {{ self.postal_code }}<br/>
-                        {% endif %}
-                        {% if self.google_map_link %}
-                            <a href="{{ self.google_map_link }}">Google Map</a>
-                        {% endif %}
-                    </p>
-                {% endif %}
-            </div><!--/.col-->
+        <div class="col-xs-12 col-sm-4">
+            {% if self.location_photo %}
+                {% image self.location_photo width-500 class="img-responsive spaces" %}
+            {% else %}
+                {% image default_image width-500 class="img-responsive spaces" alt="" %}
+            {% endif %}
+            {% if self.address_1 %}
+                <p>
+                    <strong>{{ self.address_1 }}</strong><br/>
+                    {% if self.address_2 %}
+                        {{ self.address_2 }}<br/>
+                    {% endif %}
+                    {% if self.city and self.state and self.postal_code %}
+                        {{ self.city }}, {{ self.state }} {{ self.postal_code }}<br/>
+                    {% endif %}
+                    {% if self.google_map_link %}
+                        <a href="{{ self.google_map_link }}">Google Map</a>
+                    {% endif %}
+                </p>
+            {% endif %}
+        </div><!--/.col-->
 
-            <div class="col-xs-12 col-sm-8">
-                <h2 class="spaces">About</h2>
-                {{ self.long_description|richtext }}
-            </div><!--/.col-->
+        <div class="col-xs-12 col-sm-8">
+            <h2 class="spaces">About</h2>
+            {{ self.long_description|richtext }}
+        </div><!--/.col-->
 
         {% if has_right_sidebar %}
             {% block right_sidebar %}
                 {% if self.has_features or self.reservation_url or has_floorplans %}
-                <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-                    {% if self.has_features %}
-                        <h3>Features</h3>
-                        {% autoescape off %}
-                            {{features_html}}
-                        {% endautoescape %}
-                    {% endif %}
-                    {% if self.reservation_url %}
-                        <form action="{{ self.reservation_url }}" method="get">
-                            <button class="btn btn-reserve" type="submit">
-                                {% if self.reservation_display_text %}
-                                    {{self.reservation_display_text}}
-                                {% else %}
-                                    Reserve
-                                {% endif %}
-                            </button>
-                        </form>
-                    {% endif %}
-                    {% if has_floorplans %}
-                        <h3>Floorplans</h3>
-                        <p>
-                            {% for p in self.location_floor_placements.all %}
-                                <a href="{{ p.floor.url }}">{{ p.floor.title }}</a><br/>
-                            {% endfor %}
-                        </p>
-                    {% endif %}
-                </div><!--/.rightside-mod-->
+                    <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+                        {% if self.has_features %}
+                            <h3>Features</h3>
+                            {% autoescape off %}
+                                {{features_html}}
+                            {% endautoescape %}
+                        {% endif %}
+                        {% if self.reservation_url %}
+                            <form action="{{ self.reservation_url }}" method="get">
+                                <button class="btn btn-reserve" type="submit">
+                                    {% if self.reservation_display_text %}
+                                        {{self.reservation_display_text}}
+                                    {% else %}
+                                        Reserve
+                                    {% endif %}
+                                </button>
+                            </form>
+                        {% endif %}
+                        {% if has_floorplans %}
+                            <h3>Floorplans</h3>
+                            <p>
+                                {% for p in self.location_floor_placements.all %}
+                                    <a href="{{ p.floor.url }}">{{ p.floor.title }}</a><br/>
+                                {% endfor %}
+                            </p>
+                        {% endif %}
+                    </div><!--/.rightside-mod-->
                 {% endif %}
             {% endblock %}
         {% endif %}

--- a/public/templates/public/spaces_index_page.html
+++ b/public/templates/public/spaces_index_page.html
@@ -6,85 +6,85 @@
 
 {% block content %}
     <article>
-          <div class="row">
+        <div class="row">
             <div class="col-xs-12 col-sm-6">
                 <div class="btn-group spaces-toggle" role="navigation" aria-label="Browse Space Type">
-                  <a class="btn btn-list-toggle{% if space_type == 'is_study_space' %} active{% endif %}" aria-selected="{% if space_type == 'is_study_space' %}true{% else %}false{% endif %}" href="?space_type=is_study_space">To Study</a>
-                  <a class="btn btn-list-toggle{% if space_type == 'is_teaching_space' %} active {% endif %}" aria-selected="{% if space_type == 'is_teaching_space' %}true{% else %}false{% endif %}" href="?space_type=is_teaching_space">To Teach</a>
-                  <a class="btn btn-list-toggle{% if space_type == 'is_event_space' %} active {% endif %}" aria-selected="{% if space_type == 'is_event_space' %}true{% else %}false{% endif %}" href="?space_type=is_event_space">For Events</a>
-                  <a class="btn btn-list-toggle{% if space_type == 'is_special_use' %} active {% endif %}" aria-selected="{% if space_type == 'is_special_use' %}true{% else %}false{% endif %}" href="?space_type=is_special_use">Special Use</a>
+                    <a class="btn btn-list-toggle{% if space_type == 'is_study_space' %} active{% endif %}" aria-selected="{% if space_type == 'is_study_space' %}true{% else %}false{% endif %}" href="?space_type=is_study_space">To Study</a>
+                    <a class="btn btn-list-toggle{% if space_type == 'is_teaching_space' %} active {% endif %}" aria-selected="{% if space_type == 'is_teaching_space' %}true{% else %}false{% endif %}" href="?space_type=is_teaching_space">To Teach</a>
+                    <a class="btn btn-list-toggle{% if space_type == 'is_event_space' %} active {% endif %}" aria-selected="{% if space_type == 'is_event_space' %}true{% else %}false{% endif %}" href="?space_type=is_event_space">For Events</a>
+                    <a class="btn btn-list-toggle{% if space_type == 'is_special_use' %} active {% endif %}" aria-selected="{% if space_type == 'is_special_use' %}true{% else %}false{% endif %}" href="?space_type=is_special_use">Special Use</a>
                 </div>
             </div>
-        
+
             <div class="col-xs-12 col-sm-6 coll-dropdown" role="group" aria-label="Filter Results">
                 <span class="headline" id="filterBy">Filter by</span>
                 <div class="btn-group" aria-labelledby="filterBy">
-                  <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default btn-textonly dropdown-toggle" type="button" aria-label="filtered to {{ building }}">
-                    {% if building %}
-                        {{ building }}
-                    {% else %}
-                        Library
-                    {% endif %}
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="listings-dropdown dropdown-menu">
-                    {% if building %}
-                       <li>
-                          <a href="?{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}">All Buildings</a><br/>
-                       </li>
-                    {% endif %}
-                    {% for b in buildings %}
-                       <li>
-                          <a href="?building={{ b|urlencode }}&amp;{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}" class="dropdown-item">{{ b }}</a>
-                       </li>
-                    {% endfor %}
-                  </ul>
+                    <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default btn-textonly dropdown-toggle" type="button" aria-label="filtered to {{ building }}">
+                        {% if building %}
+                            {{ building }}
+                        {% else %}
+                            Library
+                        {% endif %}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="listings-dropdown dropdown-menu">
+                        {% if building %}
+                            <li>
+                                <a href="?{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}">All Buildings</a><br/>
+                            </li>
+                        {% endif %}
+                        {% for b in buildings %}
+                            <li>
+                                <a href="?building={{ b|urlencode }}&amp;{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}" class="dropdown-item">{{ b }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
                 </div>
                 <div class="btn-group">
-                  <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default btn-textonly dropdown-toggle" type="button"{% if not floors %} disabled="disabled"{% endif %}>
-                    {% if floor %}
-                        {{ floor }}
-                    {% else %}
-                        Floor 
-                    {% endif %}
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="listings-dropdown dropdown-menu">
-                    {% if floor %}
-                       <li>
-                          <a href="?building={{ building|urlencode }}&amp;{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}">All Floors</a><br/>
-                       </li>
-                    {% endif %}
-                    {% for f in floors %}
-                      <li>
-                        <a href="?building={{ building|urlencode }}&amp;{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}floor={{ f|urlencode }}&amp;space_type={{ space_type|urlencode }}" class="dropdown-item">{{ f }}</a>
-                      </li>
-                    {% endfor %}
-                  </ul>
+                    <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default btn-textonly dropdown-toggle" type="button"{% if not floors %} disabled="disabled"{% endif %}>
+                        {% if floor %}
+                            {{ floor }}
+                        {% else %}
+                            Floor
+                        {% endif %}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="listings-dropdown dropdown-menu">
+                        {% if floor %}
+                            <li>
+                                <a href="?building={{ building|urlencode }}&amp;{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}">All Floors</a><br/>
+                            </li>
+                        {% endif %}
+                        {% for f in floors %}
+                            <li>
+                                <a href="?building={{ building|urlencode }}&amp;{% if feature %}feature={{ feature|urlencode }}&amp;{% endif %}floor={{ f|urlencode }}&amp;space_type={{ space_type|urlencode }}" class="dropdown-item">{{ f }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
                 </div>
 
                 <div class="btn-group">
-                  <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default btn-textonly dropdown-toggle" type="button">
-                    {% if feature %}
-                        {{ feature_label }}
-                    {% else %}
-                        Feature
-                    {% endif %}
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="listings-dropdown dropdown-menu">
-                    {% if feature %}
-                      <li>
-                        <a href="?{% if building %}building={{ building|urlencode }}&amp;{% endif %}{% if floor %}floor={{ floor|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}">All Features</a>
-                      </li>
-                    {% endif %}
-                    {% for f in features %}
-                      <li>
-                        <a href="?{% if building %}building={{ building|urlencode }}&amp;{% endif %}{% if floor %}floor={{ floor|urlencode }}&amp;{% endif %}feature={{ f.0|urlencode }}&amp;space_type={{ space_type|urlencode }}" class="dropdown-item">{{ f.1 }}</a>
-                      </li>
-                    {% endfor %}
-                  </ul>
-                </div>          
+                    <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default btn-textonly dropdown-toggle" type="button">
+                        {% if feature %}
+                            {{ feature_label }}
+                        {% else %}
+                            Feature
+                        {% endif %}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="listings-dropdown dropdown-menu">
+                        {% if feature %}
+                            <li>
+                                <a href="?{% if building %}building={{ building|urlencode }}&amp;{% endif %}{% if floor %}floor={{ floor|urlencode }}&amp;{% endif %}space_type={{ space_type|urlencode }}">All Features</a>
+                            </li>
+                        {% endif %}
+                        {% for f in features %}
+                            <li>
+                                <a href="?{% if building %}building={{ building|urlencode }}&amp;{% endif %}{% if floor %}floor={{ floor|urlencode }}&amp;{% endif %}feature={{ f.0|urlencode }}&amp;space_type={{ space_type|urlencode }}" class="dropdown-item">{{ f.1 }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="row sdir spacelist">
@@ -95,7 +95,7 @@
                 {% elif space_type == 'is_special_use' %}All Special Use Spaces
                 {% else %}Browse Spaces{% endif %}
             </h2>
-            {% for space in spaces %}                
+            {% for space in spaces %}
                 <article>
                     <div>
                         <h3><a href="{{ space.url }}">{{ space.title }}</a></h3>
@@ -115,8 +115,8 @@
                     </div>
                     <div>
                         {% autoescape off %}
-                        <h3 class="visually-hidden">features of {{ space.title }}</h3>
-                            {{space.features_html}} 
+                            <h3 class="visually-hidden">features of {{ space.title }}</h3>
+                            {{space.features_html}}
                         {% endautoescape %}
                     </div>
                     <div>
@@ -127,13 +127,14 @@
                         {% if space.location_photo %}
                             {% image space.location_photo width-100 %}
                         {% else %}
-                            {% image default_image width-100 %}
+                            {% image default_image width-100 alt="" %}
                         {% endif %}
                     </div>
                 </article>
-                {% empty %}
-                    <p class="empty-state">
-                      <span class="nothing">Sorry, no spaces available with these features</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
-                    </p>
+            {% empty %}
+                <p class="empty-state">
+                    <span class="nothing">Sorry, no spaces available with these features</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.</p>
             {% endfor %}
+        </div>
+    </article>
 {% endblock %}

--- a/public/templates/public/staff_public_page.html
+++ b/public/templates/public/staff_public_page.html
@@ -8,80 +8,80 @@
 
 {% block under_h1 %}
     {% if staff_page.pronouns %}
-      <span class="pronouns">{{ staff_page.pronouns }}</span>
+        <span class="pronouns">{{ staff_page.pronouns }}</span>
     {% endif %}
     <h2 class="position-title">{{ positiontitle }}</h2>
 {% endblock %}
 
 {% block content %}
-  <div class="col-xs-12 col-sm-3">
-    {% if profile_picture %}
-        {% image profile_picture width-200 class="img-responsive" %}
-    {% else %}
-        {% image default_image width-200 class="img-responsive" %}
-    {% endif %}
-  </div>
+    <div class="col-xs-12 col-sm-3">
+        {% if profile_picture %}
+            {% image profile_picture width-200 class="img-responsive" %}
+        {% else %}
+            {% image default_image width-200 class="img-responsive" alt="" %}
+        {% endif %}
+    </div>
 
-  <div class="col-xs-12 col-sm-9">
-    {{bio}}
-    {% if orcid %}
-        <h3>Publications</h3>
-        <p><a href="http://orcid.org/{{ orcid }}">View Works List On ORCID</a></p>
-    {% endif %}
+    <div class="col-xs-12 col-sm-9">
+        {{bio}}
+        {% if orcid %}
+            <h3>Publications</h3>
+            <p><a href="http://orcid.org/{{ orcid }}">View Works List On ORCID</a></p>
+        {% endif %}
 
-    {% if cv %}
-        <a role="button" class="btn btn-primary" href="{{ cv }}">View CV</a>
-    {% endif %}
-  </div>
+        {% if cv %}
+            <a role="button" class="btn btn-primary" href="{{ cv }}">View CV</a>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% block right_sidebar %}
-  <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-    <h4>Contact</h4>
-    <p>
-      {% if email %}
-        <a href="mailto:{{ email|urlencode }}">{{ email }}</a><br>
-	{% endif %}
-	{% staff_faculty_exchanges_phone_numbers staff_page %}
-	{% libcal_button staff_page email %}
-    </p>
-  </div>
-
-  <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-    <h4>Department</h4>
-      {% if parent_units %}
-        {% for unit, link in parent_units.items %}
-          <a href="/about/directory/?view=staff&amp;department={{ link }}">{{ unit }}</a><br>
-        {% endfor %}
-      {% endif %}
-  </div>
-
-  {% if subjects or libguide_url %}
     <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h4>Subject Specialties</h4>
-      <p style="line-height: 1.7em;">
-        {% if subjects %}
-            {% autoescape off %}
-                {{subjects}}
-            {% endautoescape %}
-        {% endif %}
-      </p>
-      {% if libguide_url %}
+        <h4>Contact</h4>
         <p>
-          <a role="button" class="btn btn-morelink" href="{{ libguide_url }}">View Research Guides </a>
+            {% if email %}
+                <a href="mailto:{{ email|urlencode }}">{{ email }}</a><br>
+            {% endif %}
+            {% staff_faculty_exchanges_phone_numbers staff_page %}
+            {% libcal_button staff_page email %}
         </p>
-      {% endif %}
     </div>
-  {% endif %}
 
-  {% if expertises %}
     <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-      <h4>Expertise</h4>
-      <p style="line-height: 1.7em;">
-        {% for expertise in expertises %}
-          {{ expertise }}<br/>
-        {% endfor %}
-      </p>
+        <h4>Department</h4>
+        {% if parent_units %}
+            {% for unit, link in parent_units.items %}
+                <a href="/about/directory/?view=staff&amp;department={{ link }}">{{ unit }}</a><br>
+            {% endfor %}
+        {% endif %}
     </div>
-  {% endif %}
+
+    {% if subjects or libguide_url %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h4>Subject Specialties</h4>
+            <p style="line-height: 1.7em;">
+                {% if subjects %}
+                    {% autoescape off %}
+                        {{subjects}}
+                    {% endautoescape %}
+                {% endif %}
+            </p>
+            {% if libguide_url %}
+                <p>
+                    <a role="button" class="btn btn-morelink" href="{{ libguide_url }}">View Research Guides </a>
+                </p>
+            {% endif %}
+        </div>
+    {% endif %}
+
+    {% if expertises %}
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h4>Expertise</h4>
+            <p style="line-height: 1.7em;">
+                {% for expertise in expertises %}
+                    {{ expertise }}<br/>
+                {% endfor %}
+            </p>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/staff/templates/staff/staff_directory_listing.html
+++ b/staff/templates/staff/staff_directory_listing.html
@@ -3,41 +3,40 @@
 {% load wagtailimages_tags %}
 
 {% cache 86400 staff_directory_listing staff_page.cnetid %}
-  <article>
-      <h3 class="visually-hidden">{{ staff_page.display_name }}</h3>
-    <div>
-      <h4 class="staff-name"><span class="visually-hidden">About </span>{% staff_public_page_link staff_page %}</h3>
-      {% if staff_page.pronouns %}
-        <span class="pronouns-listing">{{ staff_page.pronouns }}</span>
-      {% endif %}
-      <p>
-        {{ staff_page.position_title }}<br/>
-        <a href=".?view=staff&amp;department={{ staff_page.staff_page_units.first.library_unit.get_full_name|urlencode }}">{{ staff_page.staff_page_units.first.library_unit.title }}</a><br/>
-      </p>
-    </div>
-    <div>
-      <h4>Contact<span class="visually-hidden"> {{ staff_page.first_name }}</span></h4>
-      {% staff_email_addresses staff_page %}
-      {% staff_faculty_exchanges_phone_numbers staff_page %}
-      {% staff_libcal_schedules staff_page %}
-    </div>
-    <div>
-      {% if staff_page.staff_subject_placements.all %}
-      <h4><span class="visually-hidden">{{ staff_page.first_name }}'s </span>Specialties</h4>
-      <ul>
-        {% staff_subjects staff_page %}
-      </ul>
-      {% endif %}
-      {% if staff_page.libguide_url %}
-          <a href="{{ staff_page.libguide_url }}" class="guide-link"><span class="visually-hidden">{{ staff_page.first_name }}'s </span>Subject Guides</a>
-      {% endif %}
-    </div>
-    <div class="profile-image">
-      {% if staff_page.profile_picture %}
-          {% image staff_page.profile_picture fill-100x100 %}
-      {% else %}
-          {% image default_image fill-100x100 %}
-      {% endif %}
-    </div>
-  </article>
+    <article>
+        <div>
+            <h3 class="staff-name"><span class="visually-hidden">About </span>{% staff_public_page_link staff_page %}</h3>
+            {% if staff_page.pronouns %}
+                <span class="pronouns-listing">{{ staff_page.pronouns }}</span>
+            {% endif %}
+            <p>
+                {{ staff_page.position_title }}<br/>
+                <a href=".?view=staff&amp;department={{ staff_page.staff_page_units.first.library_unit.get_full_name|urlencode }}">{{ staff_page.staff_page_units.first.library_unit.title }}</a><br/>
+            </p>
+        </div>
+        <div>
+            <h4>Contact<span class="visually-hidden"> {{ staff_page.first_name }}</span></h4>
+            {% staff_email_addresses staff_page %}
+            {% staff_faculty_exchanges_phone_numbers staff_page %}
+            {% staff_libcal_schedules staff_page %}
+        </div>
+        <div>
+            {% if staff_page.staff_subject_placements.all %}
+                <h4><span class="visually-hidden">{{ staff_page.first_name }}'s </span>Specialties</h4>
+                <ul>
+                    {% staff_subjects staff_page %}
+                </ul>
+            {% endif %}
+            {% if staff_page.libguide_url %}
+                <a href="{{ staff_page.libguide_url }}" class="guide-link"><span class="visually-hidden">{{ staff_page.first_name }}'s </span>Subject Guides</a>
+            {% endif %}
+        </div>
+        <div class="profile-image">
+            {% if staff_page.profile_picture %}
+                {% image staff_page.profile_picture fill-100x100 %}
+            {% else %}
+                {% image default_image fill-100x100 alt="" %}
+            {% endif %}
+        </div>
+    </article>
 {% endcache %}

--- a/units/templates/units/unit_index_page.html
+++ b/units/templates/units/unit_index_page.html
@@ -7,112 +7,112 @@
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 
 {% block content %}
-  <div class="col-xs-12 col-md-9 centermain">
-    <div class="row">
+    <div class="col-xs-12 col-md-9 centermain">
+        <div class="row">
 
-      <div class="col-xs-12">
-        <form action="." class="searchbox" method="GET">
-	        <input name="query" placeholder="Search by name or department" required="required" type="search" aria-label="search by department or staff name" class="searchbox-input" value="{% if query %}{{ query }}{% endif %}"/>
-          <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
-            <input type="submit" class="searchbox-submit" role="button" aria-label="submit search" style="background-color: transparent; color: transparent;">
-          </span>
-        </form>
-      </div>
- 
-      <div class="col-xs-12">
-        <div class="btn-group spaces-toggle">
-          <a {% if view == 'staff' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'staff' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=staff">Staff</a>
-          <a {% if view == 'department' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'department' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=department">Departments</a>
-          <a {% if view == 'org' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'org' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=org">Org Chart</a>
-        </div><!-- /btn-group-->
-      </div>
+            <div class="col-xs-12">
+                <form action="." class="searchbox" method="GET">
+                    <input name="query" placeholder="Search by name or department" required="required" type="search" aria-label="search by department or staff name" class="searchbox-input" value="{% if query %}{{ query }}{% endif %}"/>
+                    <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
+                        <input type="submit" class="searchbox-submit" role="button" aria-label="submit search" style="background-color: transparent; color: transparent;">
+                    </span>
+                </form>
+            </div>
 
-      {% if view == 'staff' %} 
-        {% include "units/browse_by_pulldowns.html" %}
-      {% endif %}
+            <div class="col-xs-12">
+                <div class="btn-group spaces-toggle">
+                    <a {% if view == 'staff' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'staff' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=staff">Staff</a>
+                    <a {% if view == 'department' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'department' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=department">Departments</a>
+                    <a {% if view == 'org' %}aria-current="page"{% endif %} class="btn btn-list-toggle{% if view == 'org' %} active{% endif %}" style="padding: 5px 15px;" href=".?view=org">Org Chart</a>
+                </div><!-- /btn-group-->
+            </div>
 
-    </div><!-- / row -->
-
-    <section>
-      {% if query %}
-        <div class="row sdir" style="padding-top: 0; margin-top: 0">
-          <h2>Matching Departments</h2>
-            {% for department in departments %}
-              {% include "units/unit_directory_listing.html" %}
-            {% empty %}
-              <p class="empty-state"><span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.</p>
-              <span><a class="viewall" href=".?view=department">View all departments</a></span>
-            {% endfor %}
-        </div>
-
-        <div class="row sdir">
-          <h2>Matching Staff</h2>
-            {% for staff_page in staff_pages %}
-              {% include "staff/staff_directory_listing.html" %}
-            {% empty %}
-            <p class="empty-state">
-              <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
-            </p>
-            {% endfor %}
-        </div>
-
-      {% elif view == 'staff' %} 
-        <div class="row sdir">
-          <h2>
-            {% if subject and library %}
-                {{ library }} {{ subject }} Staff
-            {% elif subject and not library %}
-                {{ subject }} Staff
-            {% elif not subject and library %}
-                {{ library }} Staff
-            {% elif department %}
-                {{ department }} Staff
-            {% else %}
-                All Staff
+            {% if view == 'staff' %}
+                {% include "units/browse_by_pulldowns.html" %}
             {% endif %}
-          </h2>
-            {% for staff_page in staff_pages %}
-              {% include "staff/staff_directory_listing.html" %}
-            {% empty %}
-              <p class="empty-state">
-                <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
-              </p>
-            {% endfor %}
-          </div>
-      {% elif view == 'department' %}
-        {% cache 86400 department_directory_list %}
-          {% include "units/unit_division_listing.html" %}
-        {% endcache %}
-      {% elif view == 'org' %}
-        <div style="padding: 2em 0;">
-          {% if org_chart_image %}
-            {% image org_chart_image original class="img-responsive" %}
-          {% endif %}
-        </div>
-      {% endif %}
-    </section>
-  </div><!--/centermain-->
+
+        </div><!-- / row -->
+
+        <section>
+            {% if query %}
+                <div class="row sdir" style="padding-top: 0; margin-top: 0">
+                    <h2>Matching Departments</h2>
+                    {% for department in departments %}
+                        {% include "units/unit_directory_listing.html" %}
+                    {% empty %}
+                        <p class="empty-state"><span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.</p>
+                        <span><a class="viewall" href=".?view=department">View all departments</a></span>
+                    {% endfor %}
+                </div>
+
+                <div class="row sdir">
+                    <h2>Matching Staff</h2>
+                    {% for staff_page in staff_pages %}
+                        {% include "staff/staff_directory_listing.html" %}
+                    {% empty %}
+                        <p class="empty-state">
+                            <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
+                        </p>
+                    {% endfor %}
+                </div>
+
+            {% elif view == 'staff' %}
+                <div class="row sdir">
+                    <h2>
+                        {% if subject and library %}
+                            {{ library }} {{ subject }} Staff
+                        {% elif subject and not library %}
+                            {{ subject }} Staff
+                        {% elif not subject and library %}
+                            {{ library }} Staff
+                        {% elif department %}
+                            {{ department }} Staff
+                        {% else %}
+                            All Staff
+                        {% endif %}
+                    </h2>
+                    {% for staff_page in staff_pages %}
+                        {% include "staff/staff_directory_listing.html" %}
+                    {% empty %}
+                        <p class="empty-state">
+                            <span class="nothing">Sorry, no matches found</span>Need assistance? <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/">Ask a Librarian</a>.
+                        </p>
+                    {% endfor %}
+                </div>
+            {% elif view == 'department' %}
+                {% cache 86400 department_directory_list %}
+                    {% include "units/unit_division_listing.html" %}
+                {% endcache %}
+            {% elif view == 'org' %}
+                <div style="padding: 2em 0;">
+                    {% if org_chart_image %}
+                        {% image org_chart_image original class="img-responsive" %}
+                    {% endif %}
+                </div>
+            {% endif %}
+        </section>
+    </div><!--/centermain-->
 
     <div class="col-xs-12 col-md-3 rightside" role="complementary"><!-- Right Sidebar Content -->
-      <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-        <h2>Quick Numbers</h2>
-        <ul>
-          {% autoescape off %}
-            {{quick_nums}}
-          {% endautoescape %}
-        </ul>
-      </div>
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h2>Quick Numbers</h2>
+            <ul>
+                {% autoescape off %}
+                    {{quick_nums}}
+                {% endautoescape %}
+            </ul>
+        </div>
 
-      <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
-        <h2>Ask A Librarian</h2>
-        <ul>
-          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/"><i class="fa fa-comments-o fa-1x ask-icons" aria-hidden="true"></i> Chat <span class="visually-hidden">with a Librarian</span></a></li>
-          <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/ask-contact/"><span class="material-icons ask-icons" aria-hidden="true">mail_outline</span> Email <span class="visually-hidden">a Librarian for help</span></a></li>
-<!--           <li style="margin-bottom: 0.5em;"><a href="tel:773-702-4685"><span class="material-icons ask-icon" aria-hidden="true">phone</span>773-702-4685</a></li> -->          
-          <li><a href="sms:773-825-6777"><span class="material-icons ask-icons" aria-hidden="true">textsms</span> <span class="visually-hidden">Send a text for Library help to: </span>773-825-6777 (text)</a></li>
-          <li><a href="https://www.lib.uchicago.edu/libraries/libraries-hours/"><span class="material-icons ask-icons" aria-hidden="true">location_on</span> Visit <span class="visually-hidden">our locations</span></a></li>
-        </ul>
-      </div>
+        <div class="rightside-mod col-xs-12 col-sm-6 col-md-12">
+            <h2>Ask A Librarian</h2>
+            <ul>
+                <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/"><i class="fa fa-comments-o fa-1x ask-icons" aria-hidden="true"></i> Chat <span class="visually-hidden">with a Librarian</span></a></li>
+                <li><a href="https://www.lib.uchicago.edu/research/help/ask-librarian/ask-contact/"><span class="material-icons ask-icons" aria-hidden="true">mail_outline</span> Email <span class="visually-hidden">a Librarian for help</span></a></li>
+                <!--           <li style="margin-bottom: 0.5em;"><a href="tel:773-702-4685"><span class="material-icons ask-icon" aria-hidden="true">phone</span>773-702-4685</a></li> -->
+                <li><a href="sms:773-825-6777"><span class="material-icons ask-icons" aria-hidden="true">textsms</span> <span class="visually-hidden">Send a text for Library help to: </span>773-825-6777 (text)</a></li>
+                <li><a href="https://www.lib.uchicago.edu/libraries/libraries-hours/" aria-label="Visit our locations"><span class="material-icons ask-icons" aria-hidden="true">location_on</span> Visit</a></li>
+            </ul>
+        </div>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
Fixes #671 

**Changes in this request**
- Removed redundant headings in staff listing in directory and changed the heading structure here.
- SCSS changes related to the above.
- Removed alt text on _placeholder_ images in the staff directory.
- Removed alt text on other placeholder images throughout the site.
- Made "visit our locations" text in sidebar more accessible by moving it to an aria label.
- Linted all related templates and fixed invalid HTML errors.

To view changes without linting whitespace differences, run this command when on the working branch:
```
git diff -w master
```
Make sure the updated CSS displays:
1. Run `./manage.py compress`
2. Restart the Django dev server.
3. Empty cache in the admin and from the shell both. 