### PR TITLE
Move page button is invisible

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1,1 +1,5 @@
 /* Add styles for overriding things in the admin. */
+
+.chooser__actions {
+    opacity: 100;
+}


### PR DESCRIPTION
Fixes #676 

**Changes in this request**
- Added admin css to override the bad rule.

`./manage.py compress` and restart dev server to test.