### PR TITLE
Page not found should return 404

### DIFF
--- a/lib_news/tests.py
+++ b/lib_news/tests.py
@@ -136,4 +136,4 @@ class test_lib_news_pages_and_categories(TestCase):
     def test_404_response(self):
         url = '/starfleet-news/adsfasdf/'
         response = self.client.get(url)
-        self.assertContains(response, '<h2>We think we can help you</h2>')
+        self.assertEqual(response.status_code, 404)

--- a/library_website/views.py
+++ b/library_website/views.py
@@ -45,4 +45,4 @@ def library_404_view(request, exception=Http404):
 
     context = context_404(is_default)
 
-    return render(request, '404.html', context)
+    return render(request, '404.html', context, status=404)


### PR DESCRIPTION
Fixes #692

**Changes in this request**
- Make the page not found throw a 404 instead of a 200.