### PR TITLE
GroupReportsPages fail after adding a report without a link

### DIFF
--- a/base/templates/base/minutes_and_reports_inner_table.html
+++ b/base/templates/base/minutes_and_reports_inner_table.html
@@ -1,10 +1,14 @@
-              <dl>
-                {% for date, items in table.items %}
-                  <dt>{{date}}</dt>
-                  {% for item in items %}
-                    <dd>
-                      <a href="{{item.url}}">{{item.summary}}</a>
-                    </dd>
-                  {% endfor %}
-                {% endfor %}
-              </dl>
+<dl>
+    {% for date, items in table.items %}
+        <dt>{{date}}</dt>
+        {% for item in items %}
+            <dd>
+                {% if item.url %}
+                    <a href="{{item.url}}">{{item.summary}}</a>
+                {% else %}
+                    {{item.summary}}
+                {% endif %}
+            </dd>
+        {% endfor %}
+    {% endfor %}
+</dl>

--- a/group/templates/group/group_reports_page.html
+++ b/group/templates/group/group_reports_page.html
@@ -4,19 +4,23 @@
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 
 {% block content %}
-	<article>
+    <article>
         <h1>{{ self.title }}</h1>
         {% with table=self.get_reports_grouped_by_date %}
             <dl>
                 {% for date, items in table.items %}
-                  <dt>{{date}}</dt>
-                  {% for item in items %}
-                    <dd>
-                      <a href="{{item.url}}">{{item.summary}}</a>
-                    </dd>
-                  {% endfor %}
+                    <dt>{{date}}</dt>
+                    {% for item in items %}
+                        <dd>
+                            {% if item.url %}
+                                <a href="{{item.url}}">{{item.summary}}</a>
+                            {% else %}
+                                {{item.summary}}
+                            {% endif %}
+                        </dd>
+                    {% endfor %}
                 {% endfor %}
             </dl>
         {% endwith %}
-	</article>
+    </article>
 {% endblock %}


### PR DESCRIPTION
Fixes #694

**Changes in this request**
- Graceful handling for reports pages when a report doesn't have a link.
- Linting

**Test**
- [Add a report to a GroupReportsPage in dev](http://loopdev:8000/groups/borg-victims-recovery/reports/) without assigning a link to the report.
- Go to the [GroupReportsPage ](http://loopdev:8000/groups/borg-victims-recovery/reports/2016/) and the [GroupReportsIndexPage](http://loopdev:8000/groups/borg-victims-recovery/reports/) in the browser. The summary will be displayed as plain text and the pages will function normally.