### PR TITLE
Staff Listing Streamfield Does Not Display Images

### DIFF
--- a/base/templates/base/blocks/staff_listing.html
+++ b/base/templates/base/blocks/staff_listing.html
@@ -15,7 +15,7 @@
             {% if value.show_photos %}
               <td>
                 {% if staff.specific.profile_picture %}
-                  {% image staff_page.profile_picture fill-100x100 %}
+                  {% image staff.specific.profile_picture fill-100x100 %}
                 {% else %}
                   <img width="100" height="100" src="/media/images/default-photo.2e16d0ba.fill-100x100.jpg" alt="Default Placeholder Photo">
                 {% endif %}


### PR DESCRIPTION
Fixes #721

**Changes in this request**
- Fixed bad image tag that was preventing thumbnails from displaying on the Staff Listing streamfield block.