### PR TITLE
Enable Libcal integration from other views of Staff

### DIFF
--- a/base/templates/base/blocks/staff_listing.html
+++ b/base/templates/base/blocks/staff_listing.html
@@ -35,6 +35,7 @@
                 <br/>
                 {% staff_email_addresses staff.specific %}
                 {% staff_faculty_exchanges_phone_numbers staff.specific %}
+                {% staff_libcal_schedules staff.specific %}
               </td>
             {% endif %}
             {% if value.show_subject_specialties %}


### PR DESCRIPTION
Fixes #758

**Changes in this request**
- Adds Libcal appointment scheduling button to the staff listing widget template.

Can be previewed here:
https://liblet.lib.uchicago.edu/research/scholar/about-us/