### PR TITLE
753 inconsistet fonts and spacing on loop

### DIFF
--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -129,8 +129,7 @@ h1 + h2, h2 + h3, h3 + h4, h4 + h5, h5 + h6 {
  */
 p {
   font-size: 1.1em;
-  line-height: 1.7em;
-  max-width: 46em;
+  line-height: 1.7em;  
   margin-bottom: 0.5em; }
 
 .template-news-page .rich-text {
@@ -268,6 +267,20 @@ figure.center-block {
  *  Content
  * --------------------------------------------------
  */
+
+.block-paragraph {
+  max-width: 46em;
+}
+.block-paragraph p,
+.block-paragraph a,
+.block-paragraph li {
+  font-size: 16px;
+  line-height: 22px;
+}
+.block-paragraph a{
+  overflow-wrap: break-word;
+}
+
 .sw-toc {
   display: flex;
   flex-wrap: wrap;

--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -267,17 +267,16 @@ figure.center-block {
  *  Content
  * --------------------------------------------------
  */
-
-.block-paragraph {
+    
+.block-paragraph,
+.media-body{
   max-width: 46em;
 }
-.block-paragraph p,
-.block-paragraph a,
-.block-paragraph li {
-  font-size: 16px;
+[data-block-key]{
+  font-size: 15px;
   line-height: 22px;
 }
-.block-paragraph a{
+[data-block-key] a{
   overflow-wrap: break-word;
 }
 

--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -267,12 +267,15 @@ figure.center-block {
  *  Content
  * --------------------------------------------------
  */
-    
+
 .block-paragraph,
 .media-body{
   max-width: 46em;
 }
-[data-block-key]{
+.block-paragraph p,
+.block-paragraph li,
+.media-body p,
+.media-body li{
   font-size: 15px;
   line-height: 22px;
 }

--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -139,7 +139,6 @@ h1+h2, h2+h3, h3+h4, h4+h5, h5+h6 {
 p {
   font-size: 1.1em;
   line-height: 1.7em;
-  max-width: 46em;
   margin-bottom: 0.5em;
 }
 
@@ -315,6 +314,10 @@ figure {
  *  Content
  * --------------------------------------------------
  */
+
+.block-paragraph {
+    max-width: 46em;
+}
 
 .sw-toc {
     display: flex;

--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -315,8 +315,18 @@ figure {
  * --------------------------------------------------
  */
 
+
 .block-paragraph {
-    max-width: 46em;
+  max-width: 46em;
+  p,
+  a,
+  li {
+    font-size: 16px;
+    line-height: 22px;
+  }
+  a{
+    overflow-wrap: break-word;
+  }
 }
 
 .sw-toc {

--- a/base/static/base/css/sidebars.scss
+++ b/base/static/base/css/sidebars.scss
@@ -20,7 +20,6 @@ Right Sidebar: Widget Items
  * Off Canvas (Sidebar Mobile Toggle)
  * --------------------------------------------------
  */
-
 @media screen and (max-width: 986px) { // Keep as @media (instead of @include) for stability
  .row-offcanvas {
     position: relative;
@@ -44,6 +43,7 @@ Right Sidebar: Widget Items
     min-height: 900px; // fix to sidebar overlapping footer in mobile.
       .sidebar-offcanvas {
         left: -50%; /* 6 columns */
+        z-index: 1;
     }
     &.active {
         left: 50%; /* 6 columns */

--- a/base/templates/base/intranet_base.html
+++ b/base/templates/base/intranet_base.html
@@ -155,10 +155,9 @@
 {% endif %}
     </div><!-- /.row-fluid -->
   </div> <!-- /main container -->
-
   <!-- Footer Section -->
   <footer class="container-fluid footer" role="contentinfo"> 
-    <span class="footer-brand"><a href="https://www.lib.uchicago.edu/"><img src="/static/base/images/color-logo.png" alt="Loop logo"></a></span>
+    <span class="footer-brand"><a href="https://www.lib.uchicago.edu/"><img src="https://www.lib.uchicago.edu/web-resources/img/white-logo.png" alt="Loop logo"></a></span>
       <ul>
         <li><a href="/mailaliases/"><span class="hidden-xs">Library </span>Email Aliases</a></li>
         <li><a href="/staff/"><span class="hidden-xs">Library Staff</span> Directory</a></li>


### PR DESCRIPTION
Fixes #753.
Fixes #754.

**Changes in this request**
- create consistency in the content block width by changing the limit from the `p` rule to the general `.block-paragraph`.
- add `z-index` to the left sidebar so that its content doesn't get visually mixed with the footer.
- new logo's maroon has low contrast with loop's green so it was changed to the all-white logo.