### PR TITLE
remove uborrow

### DIFF
--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -88,7 +88,6 @@
                             <ul class="list-unstyled" aria-labelledby="search_catalogs">
                                 <li role="separator" class="divider visible-xs" role="presentation"></li>
                                 <li><a href="/h/3" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Library Catalog">Library Catalog</a></li>
-                                <li><a href="/h/ub" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; UBorrow">UBorrow</a></li>
                                 <li><a href="/h/borrowdirect" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; BorrowDirect">BorrowDirect</a></li>
                                 <li><a href="http://proxy.uchicago.edu/login?qurl={{'http://lib.uchicago.edu/h/worldcat'|urlencode:''}}" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; WorldCat">WorldCat</a></li>
                                 <li><a href="/search/catalogs/other" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Other Catalogs">Other Catalogs</a> <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:1em"></p></li>

--- a/base/templates/base/includes/header.html
+++ b/base/templates/base/includes/header.html
@@ -88,6 +88,7 @@
                             <ul class="list-unstyled" aria-labelledby="search_catalogs">
                                 <li role="separator" class="divider visible-xs" role="presentation"></li>
                                 <li><a href="/h/3" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Library Catalog">Library Catalog</a></li>
+                                <li><a href="/h/ub" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; UBorrow">UBorrow</a></li>
                                 <li><a href="/h/borrowdirect" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; BorrowDirect">BorrowDirect</a></li>
                                 <li><a href="http://proxy.uchicago.edu/login?qurl={{'http://lib.uchicago.edu/h/worldcat'|urlencode:''}}" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; WorldCat">WorldCat</a></li>
                                 <li><a href="/search/catalogs/other" data-ga-category="main-nav-links" data-ga-action="click" data-ga-label="Search &gt; Other Catalogs">Other Catalogs</a> <!-- Padding for lengthening column divider --> <p class="hidden-xs" style="padding-bottom:1em"></p></li>


### PR DESCRIPTION
Removes UBorrow link from header as the interface has been abandoned and the same service is now provided through Inter Library Loan.