### PR TITLE
Remove Forms Link from Loop Main Navigation

### DIFF
--- a/base/templates/base/intranet_base.html
+++ b/base/templates/base/intranet_base.html
@@ -83,7 +83,6 @@
           <li><a href="/departments/">Departments</a></li>
           <li><a href="/groups/">Committees &amp; Groups</a></li>
           <li><a href="/documentation/">Doc<span class="hidden-sm">ument</span>s &amp; Policies</a></li>       
-          <li><a href="/forms/">Forms</a></li>
           <li><a href="/technical-support/">Tech<span class="hidden-sm">nical</span> Support</a></li>
         </ul>
       </div> <!-- / Main Navigation -->


### PR DESCRIPTION
Fixes #815

Summary

Removed the Forms link from the Loop main navigation as requested.
- Removed the HTML list item containing the link to /forms/ from the main navigation in intranet_base.html

Testing:
Navigate to the Loop intranet site and verify that the Forms link no longer appears in the main navigation bar.