### PR TITLE
817 fix finding aids crash when logged in

### DIFF
--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -220,11 +220,7 @@ class FindingAidsPage(PublicBasePage):
         topiclist = []
         thistopiclist = []
 
-        if view == 'all':
-            pass
-        elif view == 'title':
-            pass
-        elif view == 'digitized':
+        if view == 'digitized':
             digitizedlist = get_digitized_content()
         elif view == 'topics':
             topiclist = get_topic_list(all_topics)

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -26,23 +26,23 @@ class FindingAidsPage(PublicBasePage):
         def get_marklogic_xml(route):
             try:
                 r = urllib.request.urlopen(marklogic_url(route))
-                xml_string = r.read().decode("utf-8")
+                xml_string = r.read().decode('utf-8')
                 return xml_string
             except urllib.error.URLError:
-                return ""
+                return ''
 
         def get_browses():
             browses = []
 
             route = (
-                "/admin/gimme.xqy" "?collection=institution%2FUniversity%20of%20Chicago"
+                '/admin/gimme.xqy" "?collection=institution%2FUniversity%20of%20Chicago'
             )
 
             xml_string = get_marklogic_xml(route)
 
             try:
                 e = ElementTree.fromstring(xml_string)
-                for div in e.find("body").findall("div"):
+                for div in e.find('body').findall('div'):
                     span = div.findall("span")
                     if span[0].text and span[1].text:
                         browses.append([span[0].text, span[1].text])
@@ -66,19 +66,19 @@ class FindingAidsPage(PublicBasePage):
 
             digitized = []
 
-            route = "/admin/gimmeDigitalEADIDs.xqy"
+            route = '/admin/gimmeDigitalEADIDs.xqy'
 
             xml_string = get_marklogic_xml(route)
 
             try:
                 e = ElementTree.fromstring(xml_string)
-                for div in e.find("body").findall("div"):
-                    span = div.findall("span")
+                for div in e.find('body').findall('div'):
+                    span = div.findall('span')
                     digitized.append(
                         [
-                            span[0].find("eadid").text,
+                            span[0].find('eadid').text,
                             span[1].text,
-                            span[2].find("abstract").text,
+                            span[2].find('abstract').text,
                         ]
                     )
             except ElementTree.ParseError:
@@ -101,14 +101,14 @@ class FindingAidsPage(PublicBasePage):
             if exactphrase:
                 route = "/request.xqy?" + urllib.parse.urlencode(
                     {
-                        "action": "search",
-                        "collection": "project/SCRC",
-                        "q": '"' + searchq + '"',
+                        'action': 'search',
+                        'collection': 'project/SCRC',
+                        'q': '"' + searchq + '"',
                     }
                 )
             else:
                 route = "/request.xqy?" + urllib.parse.urlencode(
-                    {"action": "search", "collection": "project/SCRC", "q": searchq}
+                    {'action': 'search', 'collection': 'project/SCRC', 'q': searchq}
                 )
 
             xml_string = get_marklogic_xml(route)
@@ -120,9 +120,9 @@ class FindingAidsPage(PublicBasePage):
                 ):
                     searchresults.append(
                         {
-                            "eadid": div.find("div[@class='eadid']").text,
-                            "title": div.find("div[@class='project']").text,
-                            "abstract": div.find("div[@class='abstract']").text,
+                            'eadid': div.find("div[@class='eadid']").text,
+                            'title': div.find("div[@class='project']").text,
+                            'abstract': div.find("div[@class='abstract']").text,
                         }
                     )
             except (AttributeError, ElementTree.ParseError):
@@ -139,8 +139,8 @@ class FindingAidsPage(PublicBasePage):
 
             try:
                 e = ElementTree.fromstring(xml_string)
-                for div in e.findall("div"):
-                    subject = div.find("subject").text
+                for div in e.findall('div'):
+                    subject = div.find('subject').text
 
                     if subject is None:
                         continue
@@ -149,24 +149,24 @@ class FindingAidsPage(PublicBasePage):
                         topics[subject] = []
 
                     topic_data = {}
-                    for f in ["eadid", "title"]:
+                    for f in ['eadid', 'title']:
                         try:
                             topic_data[f] = div.find(f).text
                         except AttributeError:
-                            topic_data[f] = ""
+                            topic_data[f] = ''
 
                     try:
-                        topic_data["abstract"] = (
-                            div.find("abstract").find("abstract").text
+                        topic_data['abstract'] = (
+                            div.find('abstract').find('abstract').text
                         )
                     except AttributeError:
-                        topic_data["abstract"] = ""
+                        topic_data['abstract'] = ''
 
                     topics[subject].append(
                         [
-                            topic_data["eadid"],
-                            topic_data["title"],
-                            topic_data["abstract"],
+                            topic_data['eadid'],
+                            topic_data['title'],
+                            topic_data['abstract'],
                         ]
                     )
             except ElementTree.ParseError:
@@ -182,14 +182,14 @@ class FindingAidsPage(PublicBasePage):
 
         context = super(FindingAidsPage, self).get_context(request)
 
-        browse = request.GET.get("browse", "all")
-        digitized = request.GET.get("digitized", None)
-        searchq = request.GET.get("searchq", None)
-        topic = request.GET.get("topic", None)
-        topics = request.GET.get("topics", None)
-        if topics and not topics == "all":
+        browse = request.GET.get('browse', 'all')
+        digitized = request.GET.get('digitized', None)
+        searchq = request.GET.get('searchq', None)
+        topic = request.GET.get('topic', None)
+        topics = request.GET.get('topics', None)
+        if topics and not topics == 'all':
             topics = None
-        view = request.GET.get("view", "title")
+        view = request.GET.get('view', 'title')
 
         # search
         searchresults = []
@@ -211,7 +211,7 @@ class FindingAidsPage(PublicBasePage):
         page_obj = paginator.get_page(page_number)
         num_pages = paginator.num_pages
 
-        if browse != "all":
+        if browse != 'all':
             browses = get_browse_list(all_browses, browse)
             browselinks = get_browse_links(all_browses)
         else:
@@ -224,9 +224,9 @@ class FindingAidsPage(PublicBasePage):
         topiclist = []
         thistopiclist = []
 
-        if view == "digitized":
+        if view == 'digitized':
             digitizedlist = get_digitized_content()
-        elif view == "topics":
+        elif view == 'topics':
             topiclist = get_topic_list(all_topics)
             if topic:
                 try:
@@ -234,21 +234,21 @@ class FindingAidsPage(PublicBasePage):
                 except KeyError:
                     thistopiclist = []
 
-        context["page_obj"] = page_obj
-        context["num_pages"] = num_pages
-        context["browse"] = browse
-        context["browselinks"] = browselinks
-        context["browses"] = browses
-        context["digitized"] = digitized
-        context["digitizedlist"] = digitizedlist
-        context["searchq"] = searchq
-        context["searchresultcount"] = searchresultcount
-        context["searchresults"] = searchresults
-        context["topiclist"] = topiclist
-        context["thistopiclist"] = thistopiclist
-        context["topics"] = topics
-        context["topic"] = topic
-        context["view"] = view
-        context["e_url"] = E_FINDING_AIDS
+        context['page_obj'] = page_obj
+        context['num_pages'] = num_pages
+        context['browse'] = browse
+        context['browselinks'] = browselinks
+        context['browses'] = browses
+        context['digitized'] = digitized
+        context['digitizedlist'] = digitizedlist
+        context['searchq'] = searchq
+        context['searchresultcount'] = searchresultcount
+        context['searchresults'] = searchresults
+        context['topiclist'] = topiclist
+        context['thistopiclist'] = thistopiclist
+        context['topics'] = topics
+        context['topic'] = topic
+        context['view'] = view
+        context['e_url'] = E_FINDING_AIDS
 
         return context

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -188,6 +188,13 @@ class FindingAidsPage(PublicBasePage):
             topics = None
         view = request.GET.get('view', 'all')
 
+        # search
+        searchresults = []
+        searchresultcount = 0
+        if searchq:
+            searchresults = get_search_results(searchq)
+            searchresultcount = len(searchresults)
+
         all_browses = get_browses()
         paginator = Paginator(all_browses, 100)
         page_number = request.GET.get("page")
@@ -209,32 +216,20 @@ class FindingAidsPage(PublicBasePage):
         # def random_list():
         #     return [ [ random_string(), random_string() ] for _ in range (0, 1744) ]
 
-        # digitized
         digitizedlist = []
+        topiclist = []
+        thistopiclist = []
+
         if view == 'digitized':
             digitizedlist = get_digitized_content()
-
-        # search
-        searchresults = []
-        searchresultcount = 0
-        if searchq:
-            searchresults = get_search_results(searchq)
-            searchresultcount = len(searchresults)
-
-        # topics
-        topiclist = []
-        if view == 'topics':
+        elif view == 'topics':
             topiclist = get_topic_list(all_topics)
-
-        # topic
-        thistopiclist = []
-        if topic:
-            try:
-                thistopiclist = list(
-                    sorted(all_topics[topic], key=lambda t: t[1]))
-            except KeyError:
-                thistopiclist = []
-
+            if topic:
+                try:
+                    thistopiclist = list(
+                        sorted(all_topics[topic], key=lambda t: t[1]))
+                except KeyError:
+                    thistopiclist = []
 
         context["page_obj"] = page_obj
         context["num_pages"] = num_pages

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -35,7 +35,8 @@ class FindingAidsPage(PublicBasePage):
             browses = []
 
             route = (
-                '/admin/gimme.xqy" "?collection=institution%2FUniversity%20of%20Chicago'
+                '/admin/gimme.xqy'
+                '?collection=institution%2FUniversity%20of%20Chicago'
             )
 
             xml_string = get_marklogic_xml(route)

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -3,9 +3,11 @@ from library_website.settings import MARKLOGIC_LDR_BASE, MARKLOGIC_FINDINGAIDS_P
 from wagtail.models import Page
 from xml.etree import ElementTree
 from django.core.paginator import Paginator
+from django.core.cache import cache
 
 import re
 import urllib
+import json
 # import random
 # import string
 
@@ -195,7 +197,14 @@ class FindingAidsPage(PublicBasePage):
             searchresults = get_search_results(searchq)
             searchresultcount = len(searchresults)
 
-        all_browses = get_browses()
+        cached_browses = cache.get("finding_aids_all_browses")
+
+        if cached_browses:
+            all_browses = json.loads(cached_browses)
+        else:
+            all_browses = get_browses()
+            cache.set("finding_aids_all_browses", json.dumps(all_browses))
+        
         paginator = Paginator(all_browses, 100)
         page_number = request.GET.get("page")
         page_obj = paginator.get_page(page_number)

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -179,14 +179,14 @@ class FindingAidsPage(PublicBasePage):
 
         context = super(FindingAidsPage, self).get_context(request)
 
-        browse = request.GET.get('browse', None)
+        browse = request.GET.get('browse', 'all')
         digitized = request.GET.get('digitized', None)
         searchq = request.GET.get('searchq', None)
         topic = request.GET.get('topic', None)
         topics = request.GET.get('topics', None)
         if topics and not topics == 'all':
             topics = None
-        view = request.GET.get('view', 'all')
+        view = request.GET.get('view', 'title')
 
         # search
         searchresults = []
@@ -201,7 +201,7 @@ class FindingAidsPage(PublicBasePage):
         page_obj = paginator.get_page(page_number)
         num_pages = paginator.num_pages
 
-        if browse:
+        if browse != 'all':
             browses = get_browse_list(all_browses, browse)
             browselinks = get_browse_links(all_browses)
         else:
@@ -220,7 +220,11 @@ class FindingAidsPage(PublicBasePage):
         topiclist = []
         thistopiclist = []
 
-        if view == 'digitized':
+        if view == 'all':
+            pass
+        elif view == 'title':
+            pass
+        elif view == 'digitized':
             digitizedlist = get_digitized_content()
         elif view == 'topics':
             topiclist = get_topic_list(all_topics)

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -2,9 +2,12 @@ from base.models import PublicBasePage
 from library_website.settings import MARKLOGIC_LDR_BASE, MARKLOGIC_FINDINGAIDS_PORT
 from wagtail.models import Page
 from xml.etree import ElementTree
+from django.core.paginator import Paginator
 
 import re
 import urllib
+# import random
+# import string
 
 
 class FindingAidsPage(PublicBasePage):
@@ -183,17 +186,28 @@ class FindingAidsPage(PublicBasePage):
         topics = request.GET.get('topics', None)
         if topics and not topics == 'all':
             topics = None
-        view = request.GET.get('view', None)
-        if not view:
-            view = 'title'
+        view = request.GET.get('view', 'all')
 
-        # browse
-        browses = get_browses()
-        browselinks = get_browse_links(browses)
+        all_browses = get_browses()
+        paginator = Paginator(all_browses, 100)
+        page_number = request.GET.get("page")
+        page_obj = paginator.get_page(page_number)
+        num_pages = paginator.num_pages
+
         if browse:
-            browses = get_browse_list(browses, browse)
+            browses = get_browse_list(all_browses, browse)
+            browselinks = get_browse_links(all_browses)
+        else:
+            browses = None
+            browselinks = get_browse_links(all_browses)
 
         all_topics = get_topics()
+
+        # def random_string():
+        #     return "".join(random.choice(string.ascii_uppercase) for _ in range (0,28))
+
+        # def random_list():
+        #     return [ [ random_string(), random_string() ] for _ in range (0, 1744) ]
 
         # digitized
         digitizedlist = []
@@ -221,6 +235,9 @@ class FindingAidsPage(PublicBasePage):
             except KeyError:
                 thistopiclist = []
 
+
+        context["page_obj"] = page_obj
+        context["num_pages"] = num_pages
         context['browse'] = browse
         context['browselinks'] = browselinks
         context['browses'] = browses

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 from base.models import PublicBasePage
 from django.core.cache import cache
 from django.core.paginator import Paginator
-from library_website.settings import MARKLOGIC_FINDINGAIDS_PORT, MARKLOGIC_LDR_BASE
+from library_website.settings import MARKLOGIC_FINDINGAIDS_PORT, MARKLOGIC_LDR_BASE, E_FINDING_AIDS
 from wagtail.models import Page
 
 
@@ -249,5 +249,6 @@ class FindingAidsPage(PublicBasePage):
         context["topics"] = topics
         context["topic"] = topic
         context["view"] = view
+        context["e_url"] = E_FINDING_AIDS
 
         return context

--- a/findingaids/models.py
+++ b/findingaids/models.py
@@ -8,9 +8,6 @@ from django.core.cache import cache
 import re
 import urllib
 import json
-# import random
-# import string
-
 
 class FindingAidsPage(PublicBasePage):
     content_panels = Page.content_panels + PublicBasePage.content_panels
@@ -218,12 +215,6 @@ class FindingAidsPage(PublicBasePage):
             browselinks = get_browse_links(all_browses)
 
         all_topics = get_topics()
-
-        # def random_string():
-        #     return "".join(random.choice(string.ascii_uppercase) for _ in range (0,28))
-
-        # def random_list():
-        #     return [ [ random_string(), random_string() ] for _ in range (0, 1744) ]
 
         digitizedlist = []
         topiclist = []

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -23,6 +23,10 @@
 		</span>
             </form>
 	</div>
+	<div class="col-md-12">
+	    <!-- just padding -->
+	    <p/>
+	</div>
 
 	<!-- case 1: user has just entered a search term -->
 	{% if searchq %}
@@ -111,226 +115,120 @@
 	    </tbody>
 	</table>
 
-	<!-- case 3: user is looking at alphabetical browses -->
+	<!-- case 3: user is looking at browses by title -->
 	{% elif view == 'title' %}
-	<div class="col-xs-12 btn-alpha">
-            <div class="btn-group btn-group-sm">
+	<center>
+	    <ul class="pagination justify-content-center">
 		{% for b in browselinks %}
-		{% if browse and b == browse %}
-		{{ b }}
+		{% if browse == b %}
+		<li class="active">
+		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		</li>
 		{% else %}
-		<a href=".?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		<li>
+		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		</li>
 		{% endif %}
 		{% endfor %}
-            </div>
+	    </ul>
+	</center>
+	<div class="col-md-12">
+	    <!-- just padding -->
+	    <p/>
 	</div>
+	<!-- wait till user has clicked on a link before displaying browses -->
+	{% if browse %}
+	<table class="table table-striped scrc-list">
+	    <thead>
+		<tr class="etable-header">
+		    <th colspan="1">
+			All Finding Aids beginning with "{{ browse }}"
+		    </th>
+		</tr>
+	    </thead>
+	    <tbody>
+		{% for b in browses %}
+		<tr>
+		    <td>
+			<strong>
+			    <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
+			</strong>
+		    </td>
+		</tr>
+		{% endfor %}
+	    </tbody>
+	</table>
 	{% endif %}
 
-	<hr>
-	<hr>
-	<hr>
-
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="btn-group spaces-toggle">
-          <a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title">By Title</a>
-          <a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics">By Topic</a>
-          <a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized">With Digital Content</a>
-        </div>
-      </div>
-
-      <div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search">
-        <form action="." class="searchbox" method="get">
-          <input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
-          <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
-            <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
-          </span>
-        </form>
-      </div>
-
-      <div class="col-xs-12 btn-alpha">
-        <div class="btn-group btn-group-sm">
-          {% for b in browselinks %}
-            {% if browse and b == browse %}
-              {{ b }}
-            {% else %}
-              <a href=".?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-            {% endif %}
-          {% endfor %}
-        </div>
-      </div>
-    </div>
-
-    {% if view == 'title' %}
-
-      {% if searchq %}
-
-        {% if searchresults %}
-
-          <table class="table table-striped scrc-list">
+	<!-- case 4: user is looking at browses by topic -->
+	{% elif view == 'topics' %}
+	{% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
+	<table class="table table-striped scrc-list">
             <thead>
-              <tr class="etable-header">
-                <th colspan="1">
-                  {{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
-                </th>
-              </tr>
+		<tr class="etable-header">
+		    <th colspan="1">
+			{{ topic }}
+		    </th>
+		</tr>
             </thead>
             <tbody>
-              {% for r in searchresults %}
-                <tr>
-                  <td colspan="1">
-                    <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
-                    <p>{{ r.abstract }}</p>
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-  
-        {% else %}
-  
-          <table class="table table-striped scrc-list">
-            <thead>
-              <tr class="etable-header">
-                <th colspan="1">
-                  There were no results for your search.
-                </th>
-              </tr>
-            </thead>
-          </table>
-
-        {% endif %}
-  
-      {% else %}
-
-	  {% if page_obj %}
-	    {% if not browse %}
-	      <ul class="pagination">
-
-		  {% if page_obj.has_previous %}
-		      <li><a href="{{ root_link }}?page={{ previous_page_number }}">&laquo;</a></li>
-		  {% else %}
-		      <li class="disabled"><span>&laquo;</span></li>
-		  {% endif %}
-
-		  {% for i in page_obj.paginator.page_range %}
-		      {% if page_obj.number == i %}
-			  <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-		      {% else %}
-			  <li><a href="{{ root_link }}?page={{ i }}">{{ i }}</a></li>
-		      {% endif %}
-		  {% endfor %}
-
-		  {% if page_obj.has_next %}
-		      <li><a href="{{ root_link }}?page={{ page_obj.next_page_number }}">&raquo;</a></li>
-		  {% else %}
-		      <li class="disabled"><span>&raquo;</span></li>
-		  {% endif %}
-	      </ul>
-	    {% endif%}
-	    <table class="table table-striped scrc-list">
-	      <thead>
-		<tr class="etable-header">
-		  <th colspan="1">
-		    {% if browse %}
-		      All Finding Aids beginning with "{{ browse }}"
-		      
-		    {% else %}
-		      All Finding Aids
-		    {% endif %}
-		  </th>
+		{% for t in thistopiclist %}
+		<tr>
+                    <td>
+			<h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t.0|urlencode }}">{{ t.1 }}</a></h3>
+			<p>{{ t.2 }}</p>
+                    </td>
 		</tr>
-	      </thead>
-	      <tbody>
-		{% for b in page_obj %}
-		  <tr>
-		    <td><strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a></strong></td>
-		  </tr>
 		{% endfor %}
-	      </tbody>
-	    </table>
-	  {% else %}
-	    {% include "findingaids/marklogic_error.html" %}
-	  {% endif %}
-    
-      {% endif %}
-
-    {% elif view == 'topics' %}
-
-      {% if topic and thistopiclist %}
-
-        <table class="table table-striped scrc-list">
-          <thead>
-            <tr class="etable-header">
-              <th colspan="1">
-                {{ topic }}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for t in thistopiclist %}
-              <tr>
-                <td>
-                  <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t.0|urlencode }}">{{ t.1 }}</a></h3>
-                  <p>{{ t.2 }}</p>
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
+            </tbody>
         </table>
-
-      {% elif topiclist %}
-
-        <table class="table table-striped scrc-list">
-          <thead>
-            <tr class="etable-header">
-              <th colspan="1">
-                Browse Finding Aids by Topic
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for t in topiclist %}
-              <tr>
-                <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
-              </tr>
-            {% endfor %}
-          </tbody>
+	{% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
+	<table class="table table-striped scrc-list">
+            <thead>
+		<tr class="etable-header">
+		    <th colspan="1">
+			Browse Finding Aids by Topic
+		    </th>
+		</tr>
+            </thead>
+            <tbody>
+		{% for t in topiclist %}
+		<tr>
+                    <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
+		</tr>
+		{% endfor %}
+            </tbody>
         </table>
+	{% endif %}
+	
+	<!-- TODO case 5: user is looking at digital content -->
+	{% elif view == 'digitized' and digitizedlist %}
+	<table class="table table-striped scrc-list">
+            <thead>
+		<tr class="etable-header">
+		    <th colspan="1">
+			Browse Finding Aids with Digitized Content
+		    </th>
+		</tr>
+            </thead>
+            <tbody>
+		{% for d in digitizedlist %}
+		<tr>
+		    <td>
+			<strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ d.0|urlencode }}">{{ d.1 }}</a></strong><br/>
+			{{ d.2 }}
+		    </td>
+		</tr>
+		{% endfor %}
+            </tbody>
+	</table>
 
-      {% else %}
-	{% include "findingaids/marklogic_error.html" %}
-      {% endif %}
-
-    {% elif view == 'digitized' %}
-
-      {% if digitizedlist %}
-      <table class="table table-striped scrc-list">
-        <thead>
-          <tr class="etable-header">
-            <th colspan="1">
-              Browse Finding Aids with Digitized Content
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for d in digitizedlist %}
-            <tr>
-              <td>
-                <strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ d.0|urlencode }}">{{ d.1 }}</a></strong><br/>
-                {{ d.2 }}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      {% else %}
+	<!-- case 6: there's a problem grabbing the Mark Logic data -->
+	{% else %}
         {% include "findingaids/marklogic_error.html" %}
-      {% endif %}
 
-    {% else %}
+	<!-- end of cases 1-6 if/elif/else -->
+	{% endif %}
 
-
-    {% endif %}
-  </article>
+</article>
 {% endblock %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -3,266 +3,266 @@
 
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 {% block content %}
-<article>
+    <article>
 
-    <div class="row">
-	<div class="col-xs-12">
-            <div class="btn-group spaces-toggle">
-		<a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all">By Title</a>
-		<a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics">By Topic</a>
-		<a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized">With Digital Content</a>
+        <div class="row">
+            <div class="col-xs-12">
+                <div class="btn-group spaces-toggle">
+                    <a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all">By Title</a>
+                    <a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics">By Topic</a>
+                    <a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized">With Digital Content</a>
+                </div>
             </div>
-	</div>
 
-	<div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search">
-            <form action="." class="searchbox" method="get">
-		<input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
-		<span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
-		    <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
-		</span>
-            </form>
-	</div>
-	<div class="col-md-12">
-	    <!-- just padding -->
-	    <p/>
-	</div>
+            <div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search">
+                <form action="." class="searchbox" method="get">
+                    <input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
+                    <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
+                        <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
+                    </span>
+                </form>
+            </div>
+            <div class="col-md-12">
+                <!-- just padding -->
+                <p/>
+            </div>
 
-	<!-- case 1: user has just entered a search term -->
-	{% if searchq %}
-        {% if searchresults %}
-	<div class="col-md-12">
-	    <!-- just padding -->
-	    <p/>
-	</div>
-        <table class="table table-striped scrc-list">
-            <thead>
-		<tr class="etable-header">
-                    <th colspan="1">
-			{{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
-                    </th>
-		</tr>
-            </thead>
-            <tbody>
-		{% for r in searchresults %}
-                <tr>
-                    <td colspan="1">
-			<h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
-			<p>{{ r.abstract }}</p>
-                    </td>
-                </tr>
-		{% endfor %}
-            </tbody>
-        </table>
-        {% else %}
-        <table class="table table-striped scrc-list">
-            <thead>
-		<tr class="etable-header">
-                    <th colspan="1">
-			There were no results for your search.
-                    </th>
-		</tr>
-            </thead>
-        </table>
-	{% endif %}
+            <!-- case 1: user has just entered a search term -->
+            {% if searchq %}
+                {% if searchresults %}
+                    <div class="col-md-12">
+                        <!-- just padding -->
+                        <p/>
+                    </div>
+                    <table class="table table-striped scrc-list">
+                        <thead>
+                            <tr class="etable-header">
+                                <th colspan="1">
+                                    {{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for r in searchresults %}
+                                <tr>
+                                    <td colspan="1">
+                                        <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
+                                        <p>{{ r.abstract }}</p>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <table class="table table-striped scrc-list">
+                        <thead>
+                            <tr class="etable-header">
+                                <th colspan="1">
+                                    There were no results for your search.
+                                </th>
+                            </tr>
+                        </thead>
+                    </table>
+                {% endif %}
 
-	<!-- case 2: user is browsing all finding aids w/ pagination -->
-	{% elif page_obj and view == 'title' and browse == 'all' %}
-	<center>
-	    <ul class="pagination justify-content-center">
-		{% if browse == 'all' %}
-		<li class="active">
-		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-		</li>
-		{% else %}
-		<li>
-		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-		</li>
-		{% endif %}
-		{% for b in browselinks %}
-		{% if browse == b %}
-		<li class="active">
-		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-		</li>
-		{% else %}
-		<li>
-		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-		</li>
-		{% endif %}
-		{% endfor %}
-	    </ul>
-	</center>
-	<table class="table table-striped scrc-list">
-	    <thead>
-		<tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
-	    </thead>
-	    <tbody>
-		{% for b in page_obj %}
-		<tr>
-		    <td>
-			<strong>
-			    <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
-			</strong>
-		    </td>
-		</tr>
-		{% endfor %}
-	    </tbody>
-	</table>
-	<center>
-	    <ul class="pagination justify-content-center">
-		{% if page_obj.has_previous %}
-		<li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
-		{% else %}
-		<li class="disabled"><span>&laquo;</span></li>
-		{% endif %}
+                <!-- case 2: user is browsing all finding aids w/ pagination -->
+            {% elif page_obj and view == 'title' and browse == 'all' %}
+                <center>
+                    <ul class="pagination justify-content-center">
+                        {% if browse == 'all' %}
+                            <li class="active">
+                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                            </li>
+                        {% else %}
+                            <li>
+                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                            </li>
+                        {% endif %}
+                        {% for b in browselinks %}
+                            {% if browse == b %}
+                                <li class="active">
+                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                                </li>
+                            {% else %}
+                                <li>
+                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </center>
+                <table class="table table-striped scrc-list">
+                    <thead>
+                        <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
+                    </thead>
+                    <tbody>
+                        {% for b in page_obj %}
+                            <tr>
+                                <td>
+                                    <strong>
+                                        <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
+                                    </strong>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <center>
+                    <ul class="pagination justify-content-center">
+                        {% if page_obj.has_previous %}
+                            <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
+                        {% else %}
+                            <li class="disabled"><span>&laquo;</span></li>
+                        {% endif %}
 
-		{% for i in page_obj.paginator.page_range %}
-		{% if page_obj.number == i %}
-		<li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-		{% else %}
-		<li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
-		{% endif %}
-		{% endfor %}
+                        {% for i in page_obj.paginator.page_range %}
+                            {% if page_obj.number == i %}
+                                <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                            {% else %}
+                                <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
+                            {% endif %}
+                        {% endfor %}
 
-		{% if page_obj.has_next %}
-		<li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
-		{% else %}
-		<li class="disabled"><span>&raquo;</span></li>
-		{% endif %}
-	    </ul>
-	    <div class="text-primary col-md-12">
-		page {{ page_obj.number }} of {{ num_pages }}
-		<div class="col-md-12">
-		    <!-- more padding -->
-		    <p/>
-		</div>
-	    </div>
-	</center>
+                        {% if page_obj.has_next %}
+                            <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+                        {% else %}
+                            <li class="disabled"><span>&raquo;</span></li>
+                        {% endif %}
+                    </ul>
+                    <div class="text-primary col-md-12">
+                        page {{ page_obj.number }} of {{ num_pages }}
+                        <div class="col-md-12">
+                            <!-- more padding -->
+                            <p/>
+                        </div>
+                    </div>
+                </center>
 
-	<!-- case 3: user is looking at browses by title -->
-	{% elif view == 'title' %}
-	<center>
-	    <ul class="pagination justify-content-center">
-		{% if browse == 'all' %}
-		<li class="active">
-		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-		</li>
-		{% else %}
-		<li>
-		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-		</li>
-		{% endif %}
-		{% for b in browselinks %}
-		{% if browse == b %}
-		<li class="active">
-		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-		</li>
-		{% else %}
-		<li>
-		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-		</li>
-		{% endif %}
-		{% endfor %}
-	    </ul>
-	</center>
-	<div class="col-md-12">
-	    <!-- just padding -->
-	    <p/>
-	</div>
-	<!-- wait till user has clicked on a link before displaying browses -->
-	{% if browse != 'all' %}
-	<table class="table table-striped scrc-list">
-	    <thead>
-		<tr class="etable-header">
-		    <th colspan="1">
-			All Finding Aids beginning with "{{ browse }}"
-		    </th>
-		</tr>
-	    </thead>
-	    <tbody>
-		{% for b in browses %}
-		<tr>
-		    <td>
-			<strong>
-			    <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
-			</strong>
-		    </td>
-		</tr>
-		{% endfor %}
-	    </tbody>
-	</table>
-	{% endif %}
+                <!-- case 3: user is looking at browses by title -->
+            {% elif view == 'title' %}
+                <center>
+                    <ul class="pagination justify-content-center">
+                        {% if browse == 'all' %}
+                            <li class="active">
+                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                            </li>
+                        {% else %}
+                            <li>
+                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                            </li>
+                        {% endif %}
+                        {% for b in browselinks %}
+                            {% if browse == b %}
+                                <li class="active">
+                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                                </li>
+                            {% else %}
+                                <li>
+                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </center>
+                <div class="col-md-12">
+                    <!-- just padding -->
+                    <p/>
+                </div>
+                <!-- wait till user has clicked on a link before displaying browses -->
+                {% if browse != 'all' %}
+                    <table class="table table-striped scrc-list">
+                        <thead>
+                            <tr class="etable-header">
+                                <th colspan="1">
+                                    All Finding Aids beginning with "{{ browse }}"
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for b in browses %}
+                                <tr>
+                                    <td>
+                                        <strong>
+                                            <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
+                                        </strong>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
 
-	<!-- case 4: user is looking at browses by topic -->
-	{% elif view == 'topics' %}
-	{% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
-	<table class="table table-striped scrc-list">
-            <thead>
-		<tr class="etable-header">
-		    <th colspan="1">
-			{{ topic }}
-		    </th>
-		</tr>
-            </thead>
-            <tbody>
-		{% for t in thistopiclist %}
-		<tr>
-                    <td>
-			<h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t.0|urlencode }}">{{ t.1 }}</a></h3>
-			<p>{{ t.2 }}</p>
-                    </td>
-		</tr>
-		{% endfor %}
-            </tbody>
-        </table>
-	{% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
-	<table class="table table-striped scrc-list">
-            <thead>
-		<tr class="etable-header">
-		    <th colspan="1">
-			Browse Finding Aids by Topic
-		    </th>
-		</tr>
-            </thead>
-            <tbody>
-		{% for t in topiclist %}
-		<tr>
-                    <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
-		</tr>
-		{% endfor %}
-            </tbody>
-        </table>
-	{% endif %}
-	
-	<!-- TODO case 5: user is looking at digital content -->
-	{% elif view == 'digitized' and digitizedlist %}
-	<table class="table table-striped scrc-list">
-            <thead>
-		<tr class="etable-header">
-		    <th colspan="1">
-			Browse Finding Aids with Digitized Content
-		    </th>
-		</tr>
-            </thead>
-            <tbody>
-		{% for d in digitizedlist %}
-		<tr>
-		    <td>
-			<strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ d.0|urlencode }}">{{ d.1 }}</a></strong><br/>
-			{{ d.2 }}
-		    </td>
-		</tr>
-		{% endfor %}
-            </tbody>
-	</table>
+                <!-- case 4: user is looking at browses by topic -->
+            {% elif view == 'topics' %}
+                {% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
+                    <table class="table table-striped scrc-list">
+                        <thead>
+                            <tr class="etable-header">
+                                <th colspan="1">
+                                    {{ topic }}
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for t in thistopiclist %}
+                                <tr>
+                                    <td>
+                                        <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t.0|urlencode }}">{{ t.1 }}</a></h3>
+                                        <p>{{ t.2 }}</p>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
+                    <table class="table table-striped scrc-list">
+                        <thead>
+                            <tr class="etable-header">
+                                <th colspan="1">
+                                    Browse Finding Aids by Topic
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for t in topiclist %}
+                                <tr>
+                                    <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
 
-	<!-- case 6: there's a problem grabbing the Mark Logic data -->
-	{% else %}
-	<div class="col-md-12">
-            {% include "findingaids/marklogic_error.html" %}
-	</div>
+                <!-- TODO case 5: user is looking at digital content -->
+            {% elif view == 'digitized' and digitizedlist %}
+                <table class="table table-striped scrc-list">
+                    <thead>
+                        <tr class="etable-header">
+                            <th colspan="1">
+                                Browse Finding Aids with Digitized Content
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for d in digitizedlist %}
+                            <tr>
+                                <td>
+                                    <strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ d.0|urlencode }}">{{ d.1 }}</a></strong><br/>
+                                    {{ d.2 }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
 
-	<!-- end of cases 1-6 if/elif/else -->
-	{% endif %}
+                <!-- case 6: there's a problem grabbing the Mark Logic data -->
+            {% else %}
+                <div class="col-md-12">
+                    {% include "findingaids/marklogic_error.html" %}
+                </div>
 
-</article>
+                <!-- end of cases 1-6 if/elif/else -->
+            {% endif %}
+
+        </article>
 {% endblock %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -64,23 +64,23 @@
     {% elif page_obj and view == 'title' %}
         <ul class="text-center pagination" style="display:flex;flex-wrap:wrap;justify-content:center;">
             {% if browse == 'all' %}
-	    <li class="active">
-		{% else %}
-		<li>
-		    {% endif %}
-                    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-		</li>
-            {% for b in browselinks %}
-                {% if browse == b %}
-                    <li class="active">
-                        <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                    </li>
-                {% else %}
-                    <li>
-                        <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                    </li>
-                {% endif %}
-            {% endfor %}
+                <li class="active">
+            {% else %}
+                <li>
+            {% endif %}
+            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+        </li>
+        {% for b in browselinks %}
+            {% if browse == b %}
+                <li class="active">
+                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                </li>
+            {% else %}
+                <li>
+                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
         </ul>
         <table class="table table-striped scrc-list">
             <thead>

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -62,10 +62,14 @@
 
         <!-- case 2: user is browsing by title -->
     {% elif page_obj and view == 'title' %}
-        <ul class="text-center pagination justify-content-center">
-            <li class="active">
-                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-            </li>
+        <ul class="text-center pagination" style="display:flex;flex-wrap:wrap;justify-content:center;">
+            {% if browse=='all' %}
+	    <li class="active">
+		{% else %}
+		<li>
+		    {% endif %}
+                    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+		</li>
             {% for b in browselinks %}
                 {% if browse == b %}
                     <li class="active">
@@ -100,7 +104,7 @@
         </table>
         <!-- show pagination only when 'all' is selected -->
         {% if browse == 'all' %}
-            <ul class="text-center pagination justify-content-center">
+            <ul class="text-center pagination" style="display:flex;flex-wrap:wrap;justify-content:center;">
                 {% if page_obj.has_previous %}
                     <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
                 {% else %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -2,259 +2,259 @@
 {% load wagtailcore_tags %}
 
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
-{% block content %} 
-<div class="row">
-    <div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search" style="display: flex ; flex-direction: column;">
-        <form action="." class="searchbox" method="get">
-            <input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
-            <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
-                <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
-            </span>
-        </form>
-        <div class="btn-group spaces-toggle" style="display: flex; flex-wrap: wrap;">
-            <a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all" style="flex-grow: 1;margin-bottom:.5em;">By Title</a>
-            <a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics" style="flex-grow: 1;margin-bottom:.5em;">By Topic</a>
-            <a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized" style="flex-grow: 1;margin-bottom:.5em;">With Digital Content</a>
+{% block content %}
+    <div class="row">
+        <div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search" style="display: flex ; flex-direction: column;">
+            <form action="." class="searchbox" method="get">
+                <input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
+                <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
+                    <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
+                </span>
+            </form>
+            <div class="btn-group spaces-toggle" style="display: flex; flex-wrap: wrap;">
+                <a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all" style="flex-grow: 1;margin-bottom:.5em;">By Title</a>
+                <a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics" style="flex-grow: 1;margin-bottom:.5em;">By Topic</a>
+                <a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized" style="flex-grow: 1;margin-bottom:.5em;">With Digital Content</a>
+            </div>
         </div>
     </div>
-</div>
 
-<div class="col-md-12" style="padding-top:1em!important">
-    <!-- just padding -->
-</div>
+    <div class="col-md-12" style="padding-top:1em!important">
+        <!-- just padding -->
+    </div>
 
-<!-- case 1: user has just entered a search term -->
-{% if searchq %}
-{% if searchresults %}
-<div class="col-md-12" style="padding-top:1em!important">
-    <!-- just padding -->
-</div>
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header">
-            <th colspan="1">
-                {{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for r in searchresults %}
-        <tr>
-            <td colspan="1">
-		<h3><a target="_blank" href="{{ e_url }}{{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
-		<p>{{ r.abstract }}</p>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-{% else %}
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header">
-            <th colspan="1">
-                There were no results for your search.
-            </th>
-        </tr>
-    </thead>
-</table>
-{% endif %}
-
-<!-- case 2: user is browsing all finding aids w/ pagination -->
-{% elif page_obj and view == 'title' and browse == 'all' %}
-<center>
-    <ul class="pagination justify-content-center">
-        {% if browse == 'all' %}
-        <li class="active">
-            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-        </li>
+    <!-- case 1: user has just entered a search term -->
+    {% if searchq %}
+        {% if searchresults %}
+            <div class="col-md-12" style="padding-top:1em!important">
+                <!-- just padding -->
+            </div>
+            <table class="table table-striped scrc-list">
+                <thead>
+                    <tr class="etable-header">
+                        <th colspan="1">
+                            {{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in searchresults %}
+                        <tr>
+                            <td colspan="1">
+                                <h3><a target="_blank" href="{{ e_url }}{{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
+                                <p>{{ r.abstract }}</p>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         {% else %}
-        <li>
-            <a href="{{ root_url} google calend}?view=title&browse=all">ALL</a>
-        </li>
-        {% endif %}
-        {% for b in browselinks %}
-        {% if browse == b %}
-        <li class="active">
-            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-        </li>
-        {% else %}
-        <li>
-            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-    </ul>
-</center>
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
-    </thead>
-    <tbody>
-        {% for b0, b1 in page_obj %}
-        <tr>
-            <td>
-                <strong>
-		    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
-                </strong>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-<center>
-    <ul class="pagination justify-content-center">
-        {% if page_obj.has_previous %}
-        <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
-        {% else %}
-        <li class="disabled"><span>&laquo;</span></li>
+            <table class="table table-striped scrc-list">
+                <thead>
+                    <tr class="etable-header">
+                        <th colspan="1">
+                            There were no results for your search.
+                        </th>
+                    </tr>
+                </thead>
+            </table>
         {% endif %}
 
-        {% for i in page_obj.paginator.page_range %}
-        {% if page_obj.number == i %}
-        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-        {% else %}
-        <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
-        {% endif %}
-        {% endfor %}
+        <!-- case 2: user is browsing all finding aids w/ pagination -->
+    {% elif page_obj and view == 'title' and browse == 'all' %}
+        <center>
+            <ul class="pagination justify-content-center">
+                {% if browse == 'all' %}
+                    <li class="active">
+                        <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                    </li>
+                {% else %}
+                    <li>
+                        <a href="{{ root_url} google calend}?view=title&browse=all">ALL</a>
+                    </li>
+                {% endif %}
+                {% for b in browselinks %}
+                    {% if browse == b %}
+                        <li class="active">
+                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                        </li>
+                    {% else %}
+                        <li>
+                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        </center>
+        <table class="table table-striped scrc-list">
+            <thead>
+                <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
+            </thead>
+            <tbody>
+                {% for b0, b1 in page_obj %}
+                    <tr>
+                        <td>
+                            <strong>
+                                <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
+                            </strong>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <center>
+            <ul class="pagination justify-content-center">
+                {% if page_obj.has_previous %}
+                    <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
+                {% else %}
+                    <li class="disabled"><span>&laquo;</span></li>
+                {% endif %}
 
-        {% if page_obj.has_next %}
-        <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
-        {% else %}
-        <li class="disabled"><span>&raquo;</span></li>
+                {% for i in page_obj.paginator.page_range %}
+                    {% if page_obj.number == i %}
+                        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                    {% else %}
+                        <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
+                    {% endif %}
+                {% endfor %}
+
+                {% if page_obj.has_next %}
+                    <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+                {% else %}
+                    <li class="disabled"><span>&raquo;</span></li>
+                {% endif %}
+            </ul>
+            <div class="text-primary col-md-12">
+                page {{ page_obj.number }} of {{ num_pages }}
+                <div class="col-md-12">
+                    <!-- more padding -->
+                    <p/>
+                </div>
+            </div>
+        </center>
+
+        <!-- case 3: user is looking at browses by title -->
+    {% elif view == 'title' %}
+        <center>
+            <ul class="pagination justify-content-center">
+                {% if browse == 'all' %}
+                    <li class="active">
+                        <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                    </li>
+                {% else %}
+                    <li>
+                        <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                    </li>
+                {% endif %}
+                {% for b in browselinks %}
+                    {% if browse == b %}
+                        <li class="active">
+                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                        </li>
+                    {% else %}
+                        <li>
+                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        </center>
+        <div class="col-md-12" style="padding-top:1em!important">
+            <!-- just padding -->
+        </div>
+        <!-- wait till user has clicked on a link before displaying browses -->
+        {% if browse != 'all' %}
+            <table class="table table-striped scrc-list">
+                <thead>
+                    <tr class="etable-header">
+                        <th colspan="1">
+                            All Finding Aids beginning with "{{ browse }}"
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for b0, b1 in browses %}
+                        <tr>
+                            <td>
+                                <strong>
+                                    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
+                                </strong>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         {% endif %}
-    </ul>
-    <div class="text-primary col-md-12">
-        page {{ page_obj.number }} of {{ num_pages }}
+
+        <!-- case 4: user is looking at browses by topic -->
+    {% elif view == 'topics' %}
+        {% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
+            <table class="table table-striped scrc-list">
+                <thead>
+                    <tr class="etable-header">
+                        <th colspan="1">
+                            {{ topic }}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for t0, t1, t2 in thistopiclist %}
+                        <tr>
+                            <td>
+                                <h3><a target="_blank" href="{{ e_url }}{{ t0|urlencode }}">{{ t1 }}</a></h3>
+                                <p>{{ t2 }}</p>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
+            <table class="table table-striped scrc-list">
+                <thead>
+                    <tr class="etable-header">
+                        <th colspan="1">
+                            Browse Finding Aids by Topic
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for t in topiclist %}
+                        <tr>
+                            <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+
+        <!-- case 5: user is looking at digital content -->
+    {% elif view == 'digitized' and digitizedlist %}
+        <table class="table table-striped scrc-list">
+            <thead>
+                <tr class="etable-header">
+                    <th colspan="1">
+                        Browse Finding Aids with Digitized Content
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for d0, d1, d2 in digitizedlist %}
+                    <tr>
+                        <td>
+                            <strong><a target="_blank" href="{{ e_url }}{{ d0|urlencode }}">{{ d1 }}</a></strong><br/>
+                            {{ d2 }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <!-- case 6: there's a problem grabbing the Mark Logic data -->
+    {% else %}
         <div class="col-md-12">
-            <!-- more padding -->
-            <p/>
+            {% include "findingaids/marklogic_error.html" %}
         </div>
-    </div>
-</center>
 
-<!-- case 3: user is looking at browses by title -->
-{% elif view == 'title' %}
-<center>
-    <ul class="pagination justify-content-center">
-        {% if browse == 'all' %}
-        <li class="active">
-            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-        </li>
-        {% else %}
-        <li>
-            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-        </li>
-        {% endif %}
-        {% for b in browselinks %}
-        {% if browse == b %}
-        <li class="active">
-            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-        </li>
-        {% else %}
-        <li>
-            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-    </ul>
-</center>
-<div class="col-md-12" style="padding-top:1em!important">
-    <!-- just padding -->
-</div>
-<!-- wait till user has clicked on a link before displaying browses -->
-{% if browse != 'all' %}
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header">
-            <th colspan="1">
-                All Finding Aids beginning with "{{ browse }}"
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for b0, b1 in browses %}
-        <tr>
-            <td>
-                <strong>
-		    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
-                </strong>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-{% endif %}
-
-<!-- case 4: user is looking at browses by topic -->
-{% elif view == 'topics' %}
-{% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header">
-            <th colspan="1">
-                {{ topic }}
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for t0, t1, t2 in thistopiclist %}
-        <tr>
-            <td>
-		<h3><a target="_blank" href="{{ e_url }}{{ t0|urlencode }}">{{ t1 }}</a></h3>
-		<p>{{ t2 }}</p>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-{% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header">
-            <th colspan="1">
-                Browse Finding Aids by Topic
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for t in topiclist %}
-        <tr>
-            <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-{% endif %}
-
-<!-- case 5: user is looking at digital content -->
-{% elif view == 'digitized' and digitizedlist %}
-<table class="table table-striped scrc-list">
-    <thead>
-        <tr class="etable-header">
-            <th colspan="1">
-                Browse Finding Aids with Digitized Content
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for d0, d1, d2 in digitizedlist %}
-        <tr>
-            <td>
-		<strong><a target="_blank" href="{{ e_url }}{{ d0|urlencode }}">{{ d1 }}</a></strong><br/>
-                {{ d2 }}
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-
-<!-- case 6: there's a problem grabbing the Mark Logic data -->
-{% else %}
-<div class="col-md-12">
-    {% include "findingaids/marklogic_error.html" %}
-</div>
-
-<!-- end of cases 1-6 if/elif/else -->
-{% endif %}
+        <!-- end of cases 1-6 if/elif/else -->
+    {% endif %}
 {% endblock %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -8,8 +8,7 @@
     <div class="row">
 	<div class="col-xs-12">
             <div class="btn-group spaces-toggle">
-		<a class="btn btn-list-toggle{% if view == 'all' %} active{% endif %}" href="?view=all">All</a>
-		<a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title">By Title</a>
+		<a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all">By Title</a>
 		<a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics">By Topic</a>
 		<a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized">With Digital Content</a>
             </div>
@@ -67,36 +66,30 @@
 	{% endif %}
 
 	<!-- case 2: user is browsing all finding aids w/ pagination -->
-	{% elif page_obj and view == 'all' %}
+	{% elif page_obj and view == 'title' and browse == 'all' %}
 	<center>
 	    <ul class="pagination justify-content-center">
-		{% if page_obj.has_previous %}
-		<li><a href="{{ root_link }}?view=all&page={{ previous_page_number }}">&laquo;</a></li>
+		{% if browse == 'all' %}
+		<li class="active">
+		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+		</li>
 		{% else %}
-		<li class="disabled"><span>&laquo;</span></li>
+		<li>
+		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+		</li>
 		{% endif %}
-
-		{% for i in page_obj.paginator.page_range %}
-		{% if page_obj.number == i %}
-		<li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+		{% for b in browselinks %}
+		{% if browse == b %}
+		<li class="active">
+		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		</li>
 		{% else %}
-		<li><a href="{{ root_link }}?view=all&page={{ i }}">{{ i }}</a></li>
+		<li>
+		    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		</li>
 		{% endif %}
 		{% endfor %}
-
-		{% if page_obj.has_next %}
-		<li><a href="{{ root_link }}?view=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
-		{% else %}
-		<li class="disabled"><span>&raquo;</span></li>
-		{% endif %}
 	    </ul>
-	    <div class="text-primary col-md-12">
-		page {{ page_obj.number }} of {{ num_pages }}
-		<div class="col-md-12">
-		    <!-- more padding -->
-		    <p/>
-		</div>
-	    </div>
 	</center>
 	<table class="table table-striped scrc-list">
 	    <thead>
@@ -114,11 +107,50 @@
 		{% endfor %}
 	    </tbody>
 	</table>
+	<center>
+	    <ul class="pagination justify-content-center">
+		{% if page_obj.has_previous %}
+		<li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
+		{% else %}
+		<li class="disabled"><span>&laquo;</span></li>
+		{% endif %}
+
+		{% for i in page_obj.paginator.page_range %}
+		{% if page_obj.number == i %}
+		<li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+		{% else %}
+		<li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
+		{% endif %}
+		{% endfor %}
+
+		{% if page_obj.has_next %}
+		<li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+		{% else %}
+		<li class="disabled"><span>&raquo;</span></li>
+		{% endif %}
+	    </ul>
+	    <div class="text-primary col-md-12">
+		page {{ page_obj.number }} of {{ num_pages }}
+		<div class="col-md-12">
+		    <!-- more padding -->
+		    <p/>
+		</div>
+	    </div>
+	</center>
 
 	<!-- case 3: user is looking at browses by title -->
 	{% elif view == 'title' %}
 	<center>
 	    <ul class="pagination justify-content-center">
+		{% if browse == 'all' %}
+		<li class="active">
+		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+		</li>
+		{% else %}
+		<li>
+		    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+		</li>
+		{% endif %}
 		{% for b in browselinks %}
 		{% if browse == b %}
 		<li class="active">
@@ -137,7 +169,7 @@
 	    <p/>
 	</div>
 	<!-- wait till user has clicked on a link before displaying browses -->
-	{% if browse %}
+	{% if browse != 'all' %}
 	<table class="table table-striped scrc-list">
 	    <thead>
 		<tr class="etable-header">
@@ -225,7 +257,9 @@
 
 	<!-- case 6: there's a problem grabbing the Mark Logic data -->
 	{% else %}
-        {% include "findingaids/marklogic_error.html" %}
+	<div class="col-md-12">
+            {% include "findingaids/marklogic_error.html" %}
+	</div>
 
 	<!-- end of cases 1-6 if/elif/else -->
 	{% endif %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -44,8 +44,8 @@
                             {% for r in searchresults %}
                                 <tr>
                                     <td colspan="1">
-                                        <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
-                                        <p>{{ r.abstract }}</p>
+					<h3><a target="_blank" href="{{ e_url }}{{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
+					<p>{{ r.abstract }}</p>
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -98,7 +98,7 @@
                             <tr>
                                 <td>
                                     <strong>
-                                        <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b0|urlencode }}">{{ b1 }}</a>
+				        <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
                                     </strong>
                                 </td>
                             </tr>
@@ -180,7 +180,7 @@
                                 <tr>
                                     <td>
                                         <strong>
-                                            <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b0|urlencode }}">{{ b1 }}</a>
+					    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
                                         </strong>
                                     </td>
                                 </tr>
@@ -204,8 +204,8 @@
                             {% for t0, t1, t2 in thistopiclist %}
                                 <tr>
                                     <td>
-                                        <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t0|urlencode }}">{{ t1 }}</a></h3>
-                                        <p>{{ t2 }}</p>
+					<h3><a target="_blank" href="{{ e_url }}{{ t0|urlencode }}">{{ t1 }}</a></h3>
+					<p>{{ t2 }}</p>
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -230,7 +230,7 @@
                     </table>
                 {% endif %}
 
-                <!-- TODO case 5: user is looking at digital content -->
+            <!-- case 5: user is looking at digital content -->
             {% elif view == 'digitized' and digitizedlist %}
                 <table class="table table-striped scrc-list">
                     <thead>
@@ -241,11 +241,11 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for d in digitizedlist %}
+                        {% for d0, d1, d2 in digitizedlist %}
                             <tr>
                                 <td>
-                                    <strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ d.0|urlencode }}">{{ d.1 }}</a></strong><br/>
-                                    {{ d.2 }}
+				    <strong><a target="_blank" href="{{ e_url }}{{ d0|urlencode }}">{{ d1 }}</a></strong><br/>
+                                    {{ d2 }}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -63,7 +63,7 @@
         <!-- case 2: user is browsing by title -->
     {% elif page_obj and view == 'title' %}
         <ul class="text-center pagination" style="display:flex;flex-wrap:wrap;justify-content:center;">
-            {% if browse=='all' %}
+            {% if browse == 'all' %}
 	    <li class="active">
 		{% else %}
 		<li>

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -3,7 +3,132 @@
 
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
 {% block content %}
-  <article>
+<article>
+
+    <div class="row">
+	<div class="col-xs-12">
+            <div class="btn-group spaces-toggle">
+		<a class="btn btn-list-toggle{% if view == 'all' %} active{% endif %}" href="?view=all">All</a>
+		<a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title">By Title</a>
+		<a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics">By Topic</a>
+		<a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized">With Digital Content</a>
+            </div>
+	</div>
+
+	<div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search">
+            <form action="." class="searchbox" method="get">
+		<input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
+		<span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
+		    <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
+		</span>
+            </form>
+	</div>
+
+	<!-- case 1: user has just entered a search term -->
+	{% if searchq %}
+        {% if searchresults %}
+	<div class="col-md-12">
+	    <!-- just padding -->
+	    <p/>
+	</div>
+        <table class="table table-striped scrc-list">
+            <thead>
+		<tr class="etable-header">
+                    <th colspan="1">
+			{{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
+                    </th>
+		</tr>
+            </thead>
+            <tbody>
+		{% for r in searchresults %}
+                <tr>
+                    <td colspan="1">
+			<h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
+			<p>{{ r.abstract }}</p>
+                    </td>
+                </tr>
+		{% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <table class="table table-striped scrc-list">
+            <thead>
+		<tr class="etable-header">
+                    <th colspan="1">
+			There were no results for your search.
+                    </th>
+		</tr>
+            </thead>
+        </table>
+	{% endif %}
+
+	<!-- case 2: user is browsing all finding aids w/ pagination -->
+	{% elif page_obj and view == 'all' %}
+	<center>
+	    <ul class="pagination justify-content-center">
+		{% if page_obj.has_previous %}
+		<li><a href="{{ root_link }}?view=all&page={{ previous_page_number }}">&laquo;</a></li>
+		{% else %}
+		<li class="disabled"><span>&laquo;</span></li>
+		{% endif %}
+
+		{% for i in page_obj.paginator.page_range %}
+		{% if page_obj.number == i %}
+		<li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+		{% else %}
+		<li><a href="{{ root_link }}?view=all&page={{ i }}">{{ i }}</a></li>
+		{% endif %}
+		{% endfor %}
+
+		{% if page_obj.has_next %}
+		<li><a href="{{ root_link }}?view=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+		{% else %}
+		<li class="disabled"><span>&raquo;</span></li>
+		{% endif %}
+	    </ul>
+	    <div class="text-primary col-md-12">
+		page {{ page_obj.number }} of {{ num_pages }}
+		<div class="col-md-12">
+		    <!-- more padding -->
+		    <p/>
+		</div>
+	    </div>
+	</center>
+	<table class="table table-striped scrc-list">
+	    <thead>
+		<tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
+	    </thead>
+	    <tbody>
+		{% for b in page_obj %}
+		<tr>
+		    <td>
+			<strong>
+			    <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
+			</strong>
+		    </td>
+		</tr>
+		{% endfor %}
+	    </tbody>
+	</table>
+
+	<!-- case 3: user is looking at alphabetical browses -->
+	{% elif view == 'title' %}
+	<div class="col-xs-12 btn-alpha">
+            <div class="btn-group btn-group-sm">
+		{% for b in browselinks %}
+		{% if browse and b == browse %}
+		{{ b }}
+		{% else %}
+		<a href=".?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		{% endif %}
+		{% endfor %}
+            </div>
+	</div>
+	{% endif %}
+
+	<hr>
+	<hr>
+	<hr>
 
     <div class="row">
       <div class="col-xs-12">
@@ -21,11 +146,6 @@
             <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
           </span>
         </form>
-     
-        <!-- 
-          <span class="headline">Limit to</span> &nbsp;
-          <input type="checkbox" value="ebooks" id="checkboxebooks"> Digitized Content
-        -->
       </div>
 
       <div class="col-xs-12 btn-alpha">
@@ -83,13 +203,38 @@
   
       {% else %}
 
-	  {% if browses %}
+	  {% if page_obj %}
+	    {% if not browse %}
+	      <ul class="pagination">
+
+		  {% if page_obj.has_previous %}
+		      <li><a href="{{ root_link }}?page={{ previous_page_number }}">&laquo;</a></li>
+		  {% else %}
+		      <li class="disabled"><span>&laquo;</span></li>
+		  {% endif %}
+
+		  {% for i in page_obj.paginator.page_range %}
+		      {% if page_obj.number == i %}
+			  <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+		      {% else %}
+			  <li><a href="{{ root_link }}?page={{ i }}">{{ i }}</a></li>
+		      {% endif %}
+		  {% endfor %}
+
+		  {% if page_obj.has_next %}
+		      <li><a href="{{ root_link }}?page={{ page_obj.next_page_number }}">&raquo;</a></li>
+		  {% else %}
+		      <li class="disabled"><span>&raquo;</span></li>
+		  {% endif %}
+	      </ul>
+	    {% endif%}
 	    <table class="table table-striped scrc-list">
 	      <thead>
 		<tr class="etable-header">
 		  <th colspan="1">
 		    {% if browse %}
 		      All Finding Aids beginning with "{{ browse }}"
+		      
 		    {% else %}
 		      All Finding Aids
 		    {% endif %}
@@ -97,7 +242,7 @@
 		</tr>
 	      </thead>
 	      <tbody>
-		{% for b in browses %}
+		{% for b in page_obj %}
 		  <tr>
 		    <td><strong><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a></strong></td>
 		  </tr>

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -98,80 +98,39 @@
                 {% endfor %}
             </tbody>
         </table>
+	<!-- show pagination only when 'all' is selected -->
 	{% if browse == 'all' %}
-            <ul class="text-center pagination justify-content-center">
-                {% if page_obj.has_previous %}
-                    <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
-                {% else %}
-                    <li class="disabled"><span>&laquo;</span></li>
-                {% endif %}
+        <ul class="text-center pagination justify-content-center">
+            {% if page_obj.has_previous %}
+            <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
+            {% else %}
+            <li class="disabled"><span>&laquo;</span></li>
+            {% endif %}
 
-                {% for i in page_obj.paginator.page_range %}
-                    {% if page_obj.number == i %}
-                        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                    {% else %}
-                        <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
-                    {% endif %}
-                {% endfor %}
+            {% for i in page_obj.paginator.page_range %}
+            {% if page_obj.number == i %}
+            <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+            {% else %}
+            <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
+            {% endif %}
+            {% endfor %}
 
-                {% if page_obj.has_next %}
-                    <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
-                {% else %}
-                    <li class="disabled"><span>&raquo;</span></li>
-                {% endif %}
-            </ul>
-            <div class="text-primary col-md-12">
-                page {{ page_obj.number }} of {{ num_pages }}
-                <div class="col-md-12">
-                    <!-- more padding -->
-                    <p/>
-                </div>
+            {% if page_obj.has_next %}
+            <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+            {% else %}
+            <li class="disabled"><span>&raquo;</span></li>
+            {% endif %}
+        </ul>
+        <div class="text-primary col-md-12">
+            page {{ page_obj.number }} of {{ num_pages }}
+            <div class="col-md-12">
+                <!-- more padding -->
+                <p/>
             </div>
-	    {% endif %}
-
-    <!-- case 3: user is looking at browses by title -->
-    {% elif view == 'title' %}
-	<ul class="text-center pagination justify-content-center">
-	    {% for b in browselinks %}
-		{% if browse == b %}
-		    <li class="active">
-			<a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-		    </li>
-		{% else %}
-		    <li>
-			<a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-		    </li>
-		{% endif %}
-	    {% endfor %}
-	</ul>
-        <div class="col-md-12" style="padding-top:1em!important">
-            <!-- just padding -->
         </div>
-        <!-- wait till user has clicked on a link before displaying browses -->
-        {% if browse != 'all' %}
-            <table class="table table-striped scrc-list">
-                <thead>
-                    <tr class="etable-header">
-                        <th colspan="1">
-                            All Finding Aids beginning with "{{ browse }}"
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for b0, b1 in browses %}
-                        <tr>
-                            <td>
-                                <strong>
-                                    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
-                                </strong>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        {% endif %}
+	{% endif %}
 
-        <!-- case 4: user is looking at browses by topic -->
+    <!-- case 3: user is looking at browses by topic -->
     {% elif view == 'topics' %}
         {% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
             <table class="table table-striped scrc-list">
@@ -212,7 +171,7 @@
             </table>
         {% endif %}
 
-        <!-- case 5: user is looking at digital content -->
+    <!-- case 4: user is looking at digital content -->
     {% elif view == 'digitized' and digitizedlist %}
         <table class="table table-striped scrc-list">
             <thead>
@@ -234,12 +193,12 @@
             </tbody>
         </table>
 
-        <!-- case 6: there's a problem grabbing the Mark Logic data -->
+    <!-- case 5: there's a problem grabbing the Mark Logic data -->
     {% else %}
         <div class="col-md-12">
             {% include "findingaids/marklogic_error.html" %}
         </div>
 
-        <!-- end of cases 1-6 if/elif/else -->
+    <!-- end of cases 1-5 if/elif/else -->
     {% endif %}
 {% endblock %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -22,18 +22,16 @@
                     </span>
                 </form>
             </div>
-            <div class="col-md-12">
-                <!-- just padding -->
-                <p/>
-            </div>
-
-            <!-- case 1: user has just entered a search term -->
+	    <div class="col-md-12" style="padding-top:1em!important">
+	        <!-- just padding -->
+	    </div>
+            
+	    <!-- case 1: user has just entered a search term -->
             {% if searchq %}
                 {% if searchresults %}
-                    <div class="col-md-12">
-                        <!-- just padding -->
-                        <p/>
-                    </div>
+                    <div class="col-md-12" style="padding-top:1em!important">
+	                <!-- just padding -->
+	            </div>
                     <table class="table table-striped scrc-list">
                         <thead>
                             <tr class="etable-header">
@@ -96,11 +94,11 @@
                         <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
                     </thead>
                     <tbody>
-                        {% for b in page_obj %}
+                        {% for b0, b1 in page_obj %}
                             <tr>
                                 <td>
                                     <strong>
-                                        <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
+                                        <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b0|urlencode }}">{{ b1 }}</a>
                                     </strong>
                                 </td>
                             </tr>
@@ -164,10 +162,9 @@
                         {% endfor %}
                     </ul>
                 </center>
-                <div class="col-md-12">
-                    <!-- just padding -->
-                    <p/>
-                </div>
+                <div class="col-md-12" style="padding-top:1em!important">
+	            <!-- just padding -->
+	        </div>
                 <!-- wait till user has clicked on a link before displaying browses -->
                 {% if browse != 'all' %}
                     <table class="table table-striped scrc-list">
@@ -179,11 +176,11 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for b in browses %}
+                            {% for b0, b1 in browses %}
                                 <tr>
                                     <td>
                                         <strong>
-                                            <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b.0|urlencode }}">{{ b.1 }}</a>
+                                            <a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ b0|urlencode }}">{{ b1 }}</a>
                                         </strong>
                                     </td>
                                 </tr>
@@ -204,11 +201,11 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for t in thistopiclist %}
+                            {% for t0, t1, t2 in thistopiclist %}
                                 <tr>
                                     <td>
-                                        <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t.0|urlencode }}">{{ t.1 }}</a></h3>
-                                        <p>{{ t.2 }}</p>
+                                        <h3><a target="_blank" href="http://www.lib.uchicago.edu/e/scrc/findingaids/view.php?eadid={{ t0|urlencode }}">{{ t1 }}</a></h3>
+                                        <p>{{ t2 }}</p>
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -60,8 +60,8 @@
             </table>
         {% endif %}
 
-    <!-- case 2: user is browsing all finding aids w/ pagination -->
-    {% elif page_obj and view == 'title' and browse == 'all' %}
+    <!-- case 2: user is browsing by title -->
+    {% elif page_obj and view == 'title' %}
             <ul class="text-center pagination justify-content-center">
                 <li class="active">
                     <a href="{{ root_url }}?view=title&browse=all">ALL</a>
@@ -80,7 +80,11 @@
             </ul>
         <table class="table table-striped scrc-list">
             <thead>
+		{% if browse == 'all' %}
                 <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
+		{% else %}
+		<tr class="etable-header"> <th colspan="1"> All Finding Aids beginning with "{{ browse }}" </th> </tr>
+		{% endif %}
             </thead>
             <tbody>
                 {% for b0, b1 in page_obj %}
@@ -94,6 +98,7 @@
                 {% endfor %}
             </tbody>
         </table>
+	{% if browse == 'all' %}
             <ul class="text-center pagination justify-content-center">
                 {% if page_obj.has_previous %}
                     <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
@@ -122,31 +127,23 @@
                     <p/>
                 </div>
             </div>
+	    {% endif %}
 
     <!-- case 3: user is looking at browses by title -->
     {% elif view == 'title' %}
-            <ul class="text-center pagination justify-content-center">
-                {% if browse == 'all' %}
-                    <li class="active">
-                        <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                    </li>
-                {% else %}
-                    <li>
-                        <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                    </li>
-                {% endif %}
-                {% for b in browselinks %}
-                    {% if browse == b %}
-                        <li class="active">
-                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                        </li>
-                    {% else %}
-                        <li>
-                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
+	<ul class="text-center pagination justify-content-center">
+	    {% for b in browselinks %}
+		{% if browse == b %}
+		    <li class="active">
+			<a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		    </li>
+		{% else %}
+		    <li>
+			<a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+		    </li>
+		{% endif %}
+	    {% endfor %}
+	</ul>
         <div class="col-md-12" style="padding-top:1em!important">
             <!-- just padding -->
         </div>

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -2,264 +2,259 @@
 {% load wagtailcore_tags %}
 
 {% block body_class %}template-{{ self.get_verbose_name|slugify }}{% endblock %}
-{% block content %}
-    <article>
+{% block content %} 
+<div class="row">
+    <div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search" style="display: flex ; flex-direction: column;">
+        <form action="." class="searchbox" method="get">
+            <input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
+            <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
+                <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
+            </span>
+        </form>
+        <div class="btn-group spaces-toggle" style="display: flex; flex-wrap: wrap;">
+            <a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all" style="flex-grow: 1;margin-bottom:.5em;">By Title</a>
+            <a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics" style="flex-grow: 1;margin-bottom:.5em;">By Topic</a>
+            <a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized" style="flex-grow: 1;margin-bottom:.5em;">With Digital Content</a>
+        </div>
+    </div>
+</div>
 
-        <div class="row">
-            <div class="col-xs-12">
-                <div class="btn-group spaces-toggle">
-                    <a class="btn btn-list-toggle{% if view == 'title' %} active{% endif %}" href="?view=title&browse=all">By Title</a>
-                    <a class="btn btn-list-toggle{% if view == 'topics' %} active{% endif %}" href="?view=topics">By Topic</a>
-                    <a class="btn btn-list-toggle{% if view == 'digitized' %} active{% endif %}" href="?view=digitized">With Digital Content</a>
-                </div>
-            </div>
+<div class="col-md-12" style="padding-top:1em!important">
+    <!-- just padding -->
+</div>
 
-            <div class="col-xs-12 col-sm-6 col-sm-offset-3 distinct-search">
-                <form action="." class="searchbox" method="get">
-                    <input type="search" required="" onkeyup="buttonUp();" class="searchbox-input" name="searchq" placeholder="Search finding aids"{% if searchq %} value="{{ searchq }}"{% endif %}/>
-                    <span class="searchbox-icon"><i title="search" class="fa fa-search"></i>
-                        <input type="submit" class="searchbox-submit" style="background-color: transparent; color: transparent;"/>
-                    </span>
-                </form>
-            </div>
-	    <div class="col-md-12" style="padding-top:1em!important">
-	        <!-- just padding -->
-	    </div>
-            
-	    <!-- case 1: user has just entered a search term -->
-            {% if searchq %}
-                {% if searchresults %}
-                    <div class="col-md-12" style="padding-top:1em!important">
-	                <!-- just padding -->
-	            </div>
-                    <table class="table table-striped scrc-list">
-                        <thead>
-                            <tr class="etable-header">
-                                <th colspan="1">
-                                    {{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for r in searchresults %}
-                                <tr>
-                                    <td colspan="1">
-					<h3><a target="_blank" href="{{ e_url }}{{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
-					<p>{{ r.abstract }}</p>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                {% else %}
-                    <table class="table table-striped scrc-list">
-                        <thead>
-                            <tr class="etable-header">
-                                <th colspan="1">
-                                    There were no results for your search.
-                                </th>
-                            </tr>
-                        </thead>
-                    </table>
-                {% endif %}
+<!-- case 1: user has just entered a search term -->
+{% if searchq %}
+{% if searchresults %}
+<div class="col-md-12" style="padding-top:1em!important">
+    <!-- just padding -->
+</div>
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header">
+            <th colspan="1">
+                {{ searchresultcount }} documents match your search for <em>{{ searchq }}</em>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for r in searchresults %}
+        <tr>
+            <td colspan="1">
+		<h3><a target="_blank" href="{{ e_url }}{{ r.eadid|urlencode }}&amp;q={{ searchq|urlencode }}">{{ r.title }}</a></h3>
+		<p>{{ r.abstract }}</p>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header">
+            <th colspan="1">
+                There were no results for your search.
+            </th>
+        </tr>
+    </thead>
+</table>
+{% endif %}
 
-                <!-- case 2: user is browsing all finding aids w/ pagination -->
-            {% elif page_obj and view == 'title' and browse == 'all' %}
-                <center>
-                    <ul class="pagination justify-content-center">
-                        {% if browse == 'all' %}
-                            <li class="active">
-                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                            </li>
-                        {% else %}
-                            <li>
-                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                            </li>
-                        {% endif %}
-                        {% for b in browselinks %}
-                            {% if browse == b %}
-                                <li class="active">
-                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                                </li>
-                            {% else %}
-                                <li>
-                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    </ul>
-                </center>
-                <table class="table table-striped scrc-list">
-                    <thead>
-                        <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
-                    </thead>
-                    <tbody>
-                        {% for b0, b1 in page_obj %}
-                            <tr>
-                                <td>
-                                    <strong>
-				        <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
-                                    </strong>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-                <center>
-                    <ul class="pagination justify-content-center">
-                        {% if page_obj.has_previous %}
-                            <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
-                        {% else %}
-                            <li class="disabled"><span>&laquo;</span></li>
-                        {% endif %}
+<!-- case 2: user is browsing all finding aids w/ pagination -->
+{% elif page_obj and view == 'title' and browse == 'all' %}
+<center>
+    <ul class="pagination justify-content-center">
+        {% if browse == 'all' %}
+        <li class="active">
+            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+        </li>
+        {% else %}
+        <li>
+            <a href="{{ root_url} google calend}?view=title&browse=all">ALL</a>
+        </li>
+        {% endif %}
+        {% for b in browselinks %}
+        {% if browse == b %}
+        <li class="active">
+            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+        </li>
+        {% else %}
+        <li>
+            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+    </ul>
+</center>
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
+    </thead>
+    <tbody>
+        {% for b0, b1 in page_obj %}
+        <tr>
+            <td>
+                <strong>
+		    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
+                </strong>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<center>
+    <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+        <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
+        {% else %}
+        <li class="disabled"><span>&laquo;</span></li>
+        {% endif %}
 
-                        {% for i in page_obj.paginator.page_range %}
-                            {% if page_obj.number == i %}
-                                <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                            {% else %}
-                                <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
-                            {% endif %}
-                        {% endfor %}
+        {% for i in page_obj.paginator.page_range %}
+        {% if page_obj.number == i %}
+        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+        {% else %}
+        <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
+        {% endif %}
+        {% endfor %}
 
-                        {% if page_obj.has_next %}
-                            <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
-                        {% else %}
-                            <li class="disabled"><span>&raquo;</span></li>
-                        {% endif %}
-                    </ul>
-                    <div class="text-primary col-md-12">
-                        page {{ page_obj.number }} of {{ num_pages }}
-                        <div class="col-md-12">
-                            <!-- more padding -->
-                            <p/>
-                        </div>
-                    </div>
-                </center>
+        {% if page_obj.has_next %}
+        <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+        {% else %}
+        <li class="disabled"><span>&raquo;</span></li>
+        {% endif %}
+    </ul>
+    <div class="text-primary col-md-12">
+        page {{ page_obj.number }} of {{ num_pages }}
+        <div class="col-md-12">
+            <!-- more padding -->
+            <p/>
+        </div>
+    </div>
+</center>
 
-                <!-- case 3: user is looking at browses by title -->
-            {% elif view == 'title' %}
-                <center>
-                    <ul class="pagination justify-content-center">
-                        {% if browse == 'all' %}
-                            <li class="active">
-                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                            </li>
-                        {% else %}
-                            <li>
-                                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                            </li>
-                        {% endif %}
-                        {% for b in browselinks %}
-                            {% if browse == b %}
-                                <li class="active">
-                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                                </li>
-                            {% else %}
-                                <li>
-                                    <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    </ul>
-                </center>
-                <div class="col-md-12" style="padding-top:1em!important">
-	            <!-- just padding -->
-	        </div>
-                <!-- wait till user has clicked on a link before displaying browses -->
-                {% if browse != 'all' %}
-                    <table class="table table-striped scrc-list">
-                        <thead>
-                            <tr class="etable-header">
-                                <th colspan="1">
-                                    All Finding Aids beginning with "{{ browse }}"
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for b0, b1 in browses %}
-                                <tr>
-                                    <td>
-                                        <strong>
-					    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
-                                        </strong>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                {% endif %}
+<!-- case 3: user is looking at browses by title -->
+{% elif view == 'title' %}
+<center>
+    <ul class="pagination justify-content-center">
+        {% if browse == 'all' %}
+        <li class="active">
+            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+        </li>
+        {% else %}
+        <li>
+            <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+        </li>
+        {% endif %}
+        {% for b in browselinks %}
+        {% if browse == b %}
+        <li class="active">
+            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+        </li>
+        {% else %}
+        <li>
+            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+    </ul>
+</center>
+<div class="col-md-12" style="padding-top:1em!important">
+    <!-- just padding -->
+</div>
+<!-- wait till user has clicked on a link before displaying browses -->
+{% if browse != 'all' %}
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header">
+            <th colspan="1">
+                All Finding Aids beginning with "{{ browse }}"
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for b0, b1 in browses %}
+        <tr>
+            <td>
+                <strong>
+		    <a target="_blank" href="{{ e_url }}{{ b0|urlencode }}">{{ b1 }}</a>
+                </strong>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
 
-                <!-- case 4: user is looking at browses by topic -->
-            {% elif view == 'topics' %}
-                {% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
-                    <table class="table table-striped scrc-list">
-                        <thead>
-                            <tr class="etable-header">
-                                <th colspan="1">
-                                    {{ topic }}
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for t0, t1, t2 in thistopiclist %}
-                                <tr>
-                                    <td>
-					<h3><a target="_blank" href="{{ e_url }}{{ t0|urlencode }}">{{ t1 }}</a></h3>
-					<p>{{ t2 }}</p>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                {% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
-                    <table class="table table-striped scrc-list">
-                        <thead>
-                            <tr class="etable-header">
-                                <th colspan="1">
-                                    Browse Finding Aids by Topic
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for t in topiclist %}
-                                <tr>
-                                    <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                {% endif %}
+<!-- case 4: user is looking at browses by topic -->
+{% elif view == 'topics' %}
+{% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header">
+            <th colspan="1">
+                {{ topic }}
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for t0, t1, t2 in thistopiclist %}
+        <tr>
+            <td>
+		<h3><a target="_blank" href="{{ e_url }}{{ t0|urlencode }}">{{ t1 }}</a></h3>
+		<p>{{ t2 }}</p>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% elif topiclist %}  <!-- the user has NOT clicked on a specific topic browse -->
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header">
+            <th colspan="1">
+                Browse Finding Aids by Topic
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for t in topiclist %}
+        <tr>
+            <td><strong><a href=".?topic={{ t.0|urlencode }}&amp;view=topics">{{ t.0 }} ({{ t.1 }})</a></strong></td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
 
-            <!-- case 5: user is looking at digital content -->
-            {% elif view == 'digitized' and digitizedlist %}
-                <table class="table table-striped scrc-list">
-                    <thead>
-                        <tr class="etable-header">
-                            <th colspan="1">
-                                Browse Finding Aids with Digitized Content
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for d0, d1, d2 in digitizedlist %}
-                            <tr>
-                                <td>
-				    <strong><a target="_blank" href="{{ e_url }}{{ d0|urlencode }}">{{ d1 }}</a></strong><br/>
-                                    {{ d2 }}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+<!-- case 5: user is looking at digital content -->
+{% elif view == 'digitized' and digitizedlist %}
+<table class="table table-striped scrc-list">
+    <thead>
+        <tr class="etable-header">
+            <th colspan="1">
+                Browse Finding Aids with Digitized Content
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for d0, d1, d2 in digitizedlist %}
+        <tr>
+            <td>
+		<strong><a target="_blank" href="{{ e_url }}{{ d0|urlencode }}">{{ d1 }}</a></strong><br/>
+                {{ d2 }}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
 
-                <!-- case 6: there's a problem grabbing the Mark Logic data -->
-            {% else %}
-                <div class="col-md-12">
-                    {% include "findingaids/marklogic_error.html" %}
-                </div>
+<!-- case 6: there's a problem grabbing the Mark Logic data -->
+{% else %}
+<div class="col-md-12">
+    {% include "findingaids/marklogic_error.html" %}
+</div>
 
-                <!-- end of cases 1-6 if/elif/else -->
-            {% endif %}
-
-        </article>
+<!-- end of cases 1-6 if/elif/else -->
+{% endif %}
 {% endblock %}

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -60,19 +60,12 @@
             </table>
         {% endif %}
 
-        <!-- case 2: user is browsing all finding aids w/ pagination -->
+    <!-- case 2: user is browsing all finding aids w/ pagination -->
     {% elif page_obj and view == 'title' and browse == 'all' %}
-        <center>
-            <ul class="pagination justify-content-center">
-                {% if browse == 'all' %}
-                    <li class="active">
-                        <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                    </li>
-                {% else %}
-                    <li>
-                        <a href="{{ root_url} google calend}?view=title&browse=all">ALL</a>
-                    </li>
-                {% endif %}
+            <ul class="text-center pagination justify-content-center">
+                <li class="active">
+                    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+                </li>
                 {% for b in browselinks %}
                     {% if browse == b %}
                         <li class="active">
@@ -85,7 +78,6 @@
                     {% endif %}
                 {% endfor %}
             </ul>
-        </center>
         <table class="table table-striped scrc-list">
             <thead>
                 <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
@@ -102,8 +94,7 @@
                 {% endfor %}
             </tbody>
         </table>
-        <center>
-            <ul class="pagination justify-content-center">
+            <ul class="text-center pagination justify-content-center">
                 {% if page_obj.has_previous %}
                     <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
                 {% else %}
@@ -131,12 +122,10 @@
                     <p/>
                 </div>
             </div>
-        </center>
 
-        <!-- case 3: user is looking at browses by title -->
+    <!-- case 3: user is looking at browses by title -->
     {% elif view == 'title' %}
-        <center>
-            <ul class="pagination justify-content-center">
+            <ul class="text-center pagination justify-content-center">
                 {% if browse == 'all' %}
                     <li class="active">
                         <a href="{{ root_url }}?view=title&browse=all">ALL</a>
@@ -158,7 +147,6 @@
                     {% endif %}
                 {% endfor %}
             </ul>
-        </center>
         <div class="col-md-12" style="padding-top:1em!important">
             <!-- just padding -->
         </div>

--- a/findingaids/templates/findingaids/finding_aids_page.html
+++ b/findingaids/templates/findingaids/finding_aids_page.html
@@ -60,31 +60,31 @@
             </table>
         {% endif %}
 
-    <!-- case 2: user is browsing by title -->
+        <!-- case 2: user is browsing by title -->
     {% elif page_obj and view == 'title' %}
-            <ul class="text-center pagination justify-content-center">
-                <li class="active">
-                    <a href="{{ root_url }}?view=title&browse=all">ALL</a>
-                </li>
-                {% for b in browselinks %}
-                    {% if browse == b %}
-                        <li class="active">
-                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                        </li>
-                    {% else %}
-                        <li>
-                            <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
+        <ul class="text-center pagination justify-content-center">
+            <li class="active">
+                <a href="{{ root_url }}?view=title&browse=all">ALL</a>
+            </li>
+            {% for b in browselinks %}
+                {% if browse == b %}
+                    <li class="active">
+                        <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                    </li>
+                {% else %}
+                    <li>
+                        <a href="{{ root_url }}?view=title&amp;browse={{ b|urlencode }}">{{ b }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
         <table class="table table-striped scrc-list">
             <thead>
-		{% if browse == 'all' %}
-                <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
-		{% else %}
-		<tr class="etable-header"> <th colspan="1"> All Finding Aids beginning with "{{ browse }}" </th> </tr>
-		{% endif %}
+                {% if browse == 'all' %}
+                    <tr class="etable-header"> <th colspan="1"> All Finding Aids </th> </tr>
+                {% else %}
+                    <tr class="etable-header"> <th colspan="1"> All Finding Aids beginning with "{{ browse }}" </th> </tr>
+                {% endif %}
             </thead>
             <tbody>
                 {% for b0, b1 in page_obj %}
@@ -98,39 +98,39 @@
                 {% endfor %}
             </tbody>
         </table>
-	<!-- show pagination only when 'all' is selected -->
-	{% if browse == 'all' %}
-        <ul class="text-center pagination justify-content-center">
-            {% if page_obj.has_previous %}
-            <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
-            {% else %}
-            <li class="disabled"><span>&laquo;</span></li>
-            {% endif %}
+        <!-- show pagination only when 'all' is selected -->
+        {% if browse == 'all' %}
+            <ul class="text-center pagination justify-content-center">
+                {% if page_obj.has_previous %}
+                    <li><a href="{{ root_link }}?view=title&browse=all&page={{ previous_page_number }}">&laquo;</a></li>
+                {% else %}
+                    <li class="disabled"><span>&laquo;</span></li>
+                {% endif %}
 
-            {% for i in page_obj.paginator.page_range %}
-            {% if page_obj.number == i %}
-            <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-            {% else %}
-            <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
-            {% endif %}
-            {% endfor %}
+                {% for i in page_obj.paginator.page_range %}
+                    {% if page_obj.number == i %}
+                        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                    {% else %}
+                        <li><a href="{{ root_link }}?view=title&browse=all&page={{ i }}">{{ i }}</a></li>
+                    {% endif %}
+                {% endfor %}
 
-            {% if page_obj.has_next %}
-            <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
-            {% else %}
-            <li class="disabled"><span>&raquo;</span></li>
-            {% endif %}
-        </ul>
-        <div class="text-primary col-md-12">
-            page {{ page_obj.number }} of {{ num_pages }}
-            <div class="col-md-12">
-                <!-- more padding -->
-                <p/>
+                {% if page_obj.has_next %}
+                    <li><a href="{{ root_link }}?view=title&browse=all&page={{ page_obj.next_page_number }}">&raquo;</a></li>
+                {% else %}
+                    <li class="disabled"><span>&raquo;</span></li>
+                {% endif %}
+            </ul>
+            <div class="text-primary col-md-12">
+                page {{ page_obj.number }} of {{ num_pages }}
+                <div class="col-md-12">
+                    <!-- more padding -->
+                    <p/>
+                </div>
             </div>
-        </div>
-	{% endif %}
+        {% endif %}
 
-    <!-- case 3: user is looking at browses by topic -->
+        <!-- case 3: user is looking at browses by topic -->
     {% elif view == 'topics' %}
         {% if thistopiclist %} 	<!-- the user has clicked on a specific topic browse -->
             <table class="table table-striped scrc-list">
@@ -171,7 +171,7 @@
             </table>
         {% endif %}
 
-    <!-- case 4: user is looking at digital content -->
+        <!-- case 4: user is looking at digital content -->
     {% elif view == 'digitized' and digitizedlist %}
         <table class="table table-striped scrc-list">
             <thead>
@@ -193,12 +193,12 @@
             </tbody>
         </table>
 
-    <!-- case 5: there's a problem grabbing the Mark Logic data -->
+        <!-- case 5: there's a problem grabbing the Mark Logic data -->
     {% else %}
         <div class="col-md-12">
             {% include "findingaids/marklogic_error.html" %}
         </div>
 
-    <!-- end of cases 1-5 if/elif/else -->
+        <!-- end of cases 1-5 if/elif/else -->
     {% endif %}
 {% endblock %}

--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -564,7 +564,9 @@ MARKLOGIC_LDR_URL = "%s:%i%s" % (MARKLOGIC_LDR_BASE,
 
 MARKLOGIC_FINDINGAIDS_PORT = 8011
 
-# "http://marklogic.lib.uchicago.edu:8011/admin/gimme.xqy?collection=institution%2FUniversity%20of%20Chicago")
+E_FINDING_AIDS_URL = "http://www.lib.uchicago.edu/e/scrc/findingaids/view.php"
+E_FINDING_AIDS_QUERY_STRING = "?eadid=" 
+E_FINDING_AIDS = E_FINDING_AIDS_URL + E_FINDING_AIDS_QUERY_STRING
 
 EBOOKS_SEARCH = 'https://catalog.lib.uchicago.edu/vufind/Search/Results?filter%5B%5D=format%3A%22Book%22&filter%5B%5D=format%3A%22E-Resource%22&type=AllFields&lookfor='
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ djhtml==1.5.2
 flake8==6.0.0
 isort==5.11.4
 tblib
-python-lsp-server
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ djhtml==1.5.2
 flake8==6.0.0
 isort==5.11.4
 tblib
+python-lsp-server


### PR DESCRIPTION
Fixes #817.

This PR avoids the in-browser memory leak by:

- adding an "all" button to the alphabetic browse links, which takes the user to a paginated listing of all finding aids pages
- retaining non-paginated listing of all title alphabetic browses
- retaining non-paginated listings of topic and digital-content-related browses
- retaining the old behavior in the face of searches

In addition, it simplifies the conditional logic in the `findingaids/templates/findingaids/finding_aids_page.html` template into something more linear, hopefully making the template easier to maintain in the long run.