### PR TITLE
Add Cloudflare Turnstile protection against distributed AI harvesting bots

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_bleach',
+    'django_turnstile_site_protect',
     'taggit',
     'compressor',
     'modelcluster',
@@ -115,6 +116,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'django_turnstile_site_protect.middleware.TurnstileMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'wagtailcache.cache.FetchFromCacheMiddleware',
 ]
@@ -623,3 +625,21 @@ FOLIO_TYPE_LINKING_ISSN_ID = '5860f255-a27f-4916-a830-262aa900a6b9'
 # up in the "out of sync staff members" email report.
 DO_NOT_SYNC = []
 MAIL_ALIASES_PATH = '/data/web/aliases/data.json'
+
+# Cloudflare Turnstile settings (using test keys that always pass)
+TURNSTILE_SITE_KEY = '3x00000000000000000000FF'
+TURNSTILE_SECRET_KEY = '1x0000000000000000000000000000000AA'
+TURNSTILE_MODE = 'non-interactive'  # Options: 'managed', 'non-interactive', 'invisible'
+TURNSTILE_APPEARANCE = 'always'
+
+# 2 weeks (in seconds)
+SESSION_COOKIE_AGE = 1209600
+
+# Exclude admin, static files, etc. from Turnstile protection
+TURNSTILE_EXCLUDED_PATHS = [
+    r'^/admin/.*$',
+    r'^/django-admin/.*$',
+    r'^/static/.*$',
+    r'^/media/.*$',
+    r'^/shib/.*$',
+]

--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -103,8 +103,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'wagtailcache.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django_turnstile_site_protect.middleware.TurnstileMiddleware',
+    'wagtailcache.cache.UpdateCacheMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -116,7 +117,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-    'django_turnstile_site_protect.middleware.TurnstileMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'wagtailcache.cache.FetchFromCacheMiddleware',
 ]
@@ -637,6 +637,11 @@ SESSION_COOKIE_AGE = 1209600
 
 # Exclude admin, static files, etc. from Turnstile protection
 TURNSTILE_EXCLUDED_PATHS = [
+    r'^/json-events/.*$',
+    r'^/chat-status/.*$',
+    r'^/json-hours/.*$',
+    r'^/item-servlet/.*$',
+    r'^/cgi-bin/.*$',
     r'^/admin/.*$',
     r'^/django-admin/.*$',
     r'^/static/.*$',

--- a/library_website/urls.py
+++ b/library_website/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
         mail_aliases_view,
         name="mail_aliases",
     ),
+    re_path(r'^turnstile/', include('django_turnstile_site_protect.urls')),
     re_path(r"^citation_display$", citation_display, name="citation_display"),
     re_path(r"^collex/collections/$", RedirectView.as_view(url="/collex/")),
     re_path(r"^collex/exhibits/$", RedirectView.as_view(url="/collex/?view=exhibits")),

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ networkx
 openpyxl>=3.1.0,<3.2.0
 git+https://github.com/owncloud/pyocclient.git@aa6b4374a779bf0f9e060117b2e8d1e810342bc8#egg=pyocclient
 git+https://github.com/uchicago-library/pyiiif.git#egg=pyiiif
+git+https://github.com/bbusenius/django-turnstile-site-protect.git#egg=django_turnstile_site_protect
 pandas>=2,<3
 pocli==0.1.10
 psycopg2


### PR DESCRIPTION
Title: Add Cloudflare Turnstile protection against distributed AI harvesting bots

Fixes #827

Summary

Integrates Cloudflare Turnstile protection to defend against distributed AI harvesting bots that attack with unique IPs on every request.
- Added django-turnstile-site-protect package to requirements.txt
- Configured Turnstile middleware and settings in Django
- Set up appropriate exclusions for admin pages, static files, and authenticated sections
- Implemented non-interactive mode for minimal user impact
- Configured session timeout settings

Testing:
This can be deployed and tested on https://liblet.lib.uchicago.edu/ () to verify functionality before merging to production.