### PR TITLE
Fix Wagtail password protection by excluding /_util/ paths from Turnstile

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -647,4 +647,5 @@ TURNSTILE_EXCLUDED_PATHS = [
     r'^/static/.*$',
     r'^/media/.*$',
     r'^/shib/.*$',
+    r'^/_util/.*$',
 ]


### PR DESCRIPTION
Fixes #829

Summary

Password-protected pages in Wagtail were not working after the Cloudflare Turnstile implementation. When users entered the password, nothing happened.
- Added  to TURNSTILE_EXCLUDED_PATHS to exclude Wagtail's utility endpoints from Turnstile verification
- This allows the /_util/authenticate_with_password/ endpoint to function properly

Testing:
1. Clear the wagtail-cache before testing (either in the admin or with )
2. Visit a password-protected page such as https://www.lib.uchicago.edu/collex/exhibits/binding-energy/
3. Enter the password and verify that the page loads correctly