### PR TITLE
826 update click tracking to ga4

### DIFF
--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -132,22 +132,21 @@
                 params.event_subcategory = params.event_subcategory || 'list';
                 params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
             } else {
-                const parentLi = link.closest('li');
-                if (parentLi) {
+                const ancestor = link.closest('li');
+                // for any list
+                if (ancestor) { 
                     params.event_subcategory = params.event_subcategory || 'list';
-                    params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
-                } else {
-                    const parentNews = link.closest('.news-wrap');
-                    if (parentNews) {
-                        params.event_subcategory = params.event_subcategory || 'news-list';
-                        params.click_position = Array.from(parentNews.children).indexOf(link.closest('.newsblock')) + 1;
-                    } else {
-                        const parentNews = link.closest('.news-stories');
-                        if (parentNews) {
-                            params.event_subcategory = params.event_subcategory || 'news-list';
-                            params.click_position = Array.from(parentNews.children).indexOf(link.closest('article')) + 1;
-                        }
-                    }
+                    params.click_position = Array.from(ancestor.parentElement.children).indexOf(ancestor) + 1;
+                } 
+                // for the news list on the home page and on the news page
+                else if ((ancestor = link.closest('.news-wrap, .news-stories'))) {
+                    params.event_subcategory = params.event_subcategory || 'news-list';
+                    params.click_position = Array.from(ancestor.children).indexOf(link.closest('.newsblock, article')) + 1;
+                } 
+                // for collex but works for any table actually
+                else if ((ancestor = link.closest('tr'))) {
+                    params.event_subcategory = params.event_subcategory || 'table';
+                    params.click_position = Array.from(ancestor.parentElement.children).indexOf(ancestor) + 1;
                 }
             }
         }

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -28,8 +28,8 @@
     // Function to determine event parameters based on link context.
     function getEventParameters(link) {
         const params = {
-            event_category: null,
-            event_subcategory: null,
+            event_category: link.getAttribute('data-ga-category'),
+            event_subcategory: link.getAttribute('data-ga-subcategory'),
             event_label: link.getAttribute('data-ga-label') ||
                 link.getAttribute('aria-label') ||
                 (link.textContent.replace(/\s+/g, ' ').trim()) ||
@@ -39,48 +39,62 @@
             click_position: null,
         };
 
-        // Determine category, subcategory, and click_position based on link context.
+        // Determine category, subcategory, based on link context.
         if (link.closest('#global-navbar')) { // main navbar
-            params.event_category = 'navigation';
+            params.event_category = params.event_category || 'navigation';
             const listParent = link.closest('ul, ol');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+            params.event_subcategory = params.event_subcategory ||
                 (listParent ? listParent.getAttribute('aria-labelledby') : null) ||
                 params.label || 'navigation';
 
         } else if (link.closest('#navbar-right')) { // shortcuts
-            params.event_category = 'navbar-shortcuts';
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'shortcuts';
+            params.event_category = params.event_category || 'navbar-shortcuts';
+            params.event_subcategory = params.event_subcategory || 'navbar-shortcuts';
 
         } else if (link.closest('footer')) { // footer
-            params.event_category = 'footer';
+            params.event_category = params.event_category || 'footer';
             const listParent = link.closest('ul, ol');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+            params.event_subcategory = params.event_subcategory ||
                 (listParent ? listParent.getAttribute('aria-labelledby') : null) || 'footer';
 
-        } else if (link.closest('.widget, [id^="widget"]')) { // any widget
-            params.event_category = 'widget';
-            const widgetParent = link.closest('.widget, [id^="widget"]');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
-                (widgetParent?.id.startsWith('widget') ? widgetParent.id : null) || null;
+        } else if (link.closest('.widget, [id*="widget"]')) { // any widget
+            params.event_category = params.event_category || 'widget';
+            const widgetParent = link.closest('.widget, [id*="widget"]');
+            params.event_subcategory = params.event_subcategory ||
+                (widgetParent?.id.includes('widget') ? widgetParent.id : null) || null;
 
-        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id^="sidebar"]')) { // any sidebar
+        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id*="sidebar"]')) { // any sidebar
             params.event_category = 'sidebar';
-            const sidebarParent = link.closest('[class^="sidebar"], [id^="sidebar"]');
+            const sidebarParent = link.closest('[class^="sidebar"], [id*="sidebar"]');
             params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
-                (sidebarParent?.id.startsWith('sidebar') ? sidebarParent.id : '') ||
-                (sidebarParent?.className.split(' ').find(c => c.startsWith('sidebar')) || 'sidebar-link') || null;
+                (sidebarParent?.id.includes('sidebar') ? sidebarParent.id : '') ||
+                (sidebarParent?.className.split(' ').find(c => c.includes('sidebar')) || null);
 
         } else { // main content
-            params.event_category = 'main';
-            params.event_subcategory = link.closest('[id]').getAttribute('id');
-            if (link.getAttribute('data-ga-position')) {
+            params.event_category = params.event_category || 'main';
+            params.event_subcategory = params.event_category || link.closest('[id]').getAttribute('id');
+        }
+
+        // Get link position if in a list
+        if (link.getAttribute('data-ga-position')) {
+            params.event_subcategory = params.event_subcategory || 'list';
+            params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
+        } else {
+            const parentLi = link.closest('li');
+            if (parentLi) {
                 params.event_subcategory = params.event_subcategory || 'list';
-                params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
+                params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
             } else {
-                const parentLi = link.closest('li');
-                if (parentLi) {
-                    params.event_subcategory = 'list';
-                    params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
+                const parentNews = link.closest('.news-wrap');
+                if (parentNews) {
+                    params.event_subcategory = params.event_subcategory || 'news-list';
+                    params.click_position = Array.from(parentNews.children).indexOf(link.closest('.newsblock')) + 1;
+                } else {
+                    const parentNews = link.closest('.news-stories');
+                    if (parentNews) {
+                        params.event_subcategory = params.event_subcategory || 'news-list';
+                        params.click_position = Array.from(parentNews.children).indexOf(link.closest('article')) + 1;
+                    }
                 }
             }
         }
@@ -121,19 +135,20 @@
     function handleLinkClick(event) {
         event.preventDefault(); // Prevents default behavior like following links
         event.stopPropagation(); // Stops event from bubbling up
-        const target = event.target.closest('a');
+        const target = event.target.closest('a, button, input');
         const eventName = getEventName(target);
         if (eventName) {
-            const eventParams = getEventParameters(target);
+            const ep = getEventParameters(target);
             // gtag('event', eventName, eventParams);
-            console.log("Event Name: " + eventName);
-            console.log("Event params: " + eventParams);
+            console.log("Event Name: " + eventName + "\n" + ep.event_category + "\n" + ep.event_subcategory + "\n" + ep.event_label + "\n" + ep.click_position);
         } else {
             console.log("No click event. Event name: " + eventName)
+            console.log("No click event. Event name: " + eventName + ". event.target.tagName: " + event.target.tagName)
         }
     }
 
     // Attach a single event listener to the document body using event delegation.
-    document.body.addEventListener('click', debounce(handleLinkClick, 200));
+    // document.body.addEventListener('click', debounce(handleLinkClick, 200));
+    document.body.addEventListener('click', handleLinkClick);
 })();
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -67,6 +67,7 @@
 
     // Function to determine event parameters based on link context.
     function getEventParameters(link) {
+        
         const params = {
             event_category: link.getAttribute('data-ga-category'),
             event_subcategory: link.getAttribute('data-ga-subcategory'),
@@ -122,9 +123,7 @@
                 params.event_category = params.event_category || CATEGORIES.MAIN;
                 params.event_subcategory = params.event_subcategory || link.closest('[id]').getAttribute('id');
             }
-        } else {
-            console.log("already has category and subcategory from `data-ga-` property");
-        }
+        } 
 
         // Get link position if in a list
         if (!link.closest(SELECTORS.FOOTER)) {
@@ -132,21 +131,21 @@
                 params.event_subcategory = params.event_subcategory || 'list';
                 params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
             } else {
-                const ancestor = link.closest('li');
+                let ancestor = link.closest('li');
                 // for any list
-                if (ancestor) { 
+                if (ancestor) {
                     params.event_subcategory = params.event_subcategory || 'list';
                     params.click_position = Array.from(ancestor.parentElement.children).indexOf(ancestor) + 1;
-                } 
+                }
                 // for the news list on the home page and on the news page
                 else if ((ancestor = link.closest('.news-wrap, .news-stories'))) {
                     params.event_subcategory = params.event_subcategory || 'news-list';
                     params.click_position = Array.from(ancestor.children).indexOf(link.closest('.newsblock, article')) + 1;
-                } 
+                }
                 // for collex but works for any table actually
-                else if ((ancestor = link.closest('tr'))) {
+                else if ((ancestor = link.closest('tbody'))) {
                     params.event_subcategory = params.event_subcategory || 'table';
-                    params.click_position = Array.from(ancestor.parentElement.children).indexOf(ancestor) + 1;
+                    params.click_position = Array.from(ancestor.children).indexOf(link.closest('tr')) + 1;
                 }
             }
         }
@@ -191,7 +190,7 @@
         if (eventName) {
             const ep = getEventParameters(target);
             // gtag('event', eventName, eventParams);
-            console.log("Event Name.::.: " + eventName + "\n" + ep.event_category + "\n" + ep.event_subcategory + "\n" + ep.event_label + "\n" + ep.click_position);
+            console.log("Event Name: " + eventName + "\n" + ep.event_category + "\n" + ep.event_subcategory + "\n" + ep.event_label + "\n" + ep.click_position);
         } else {
             // console.log("No click event. Event name: " + eventName + ". event.target.tagName: " + event.target.tagName)
         }

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -119,9 +119,8 @@
                     (sidebarParent?.className.split(' ').find(c => c.includes('sidebar')) || null);
 
             } else if (window.location.href.indexOf("lib.uchicago.edu/vufind/Search/Results") > -1) { // Catalog Vufind Search results
-                params.event_category = params.event_category || CATEGORIES.SIDEBAR;
-                const sidebarParent = link.closest(SELECTORS.SIDEBAR);
-                params.event_subcategory = params.event_subcategory || "vufind-search-results";
+                params.event_category = params.event_category || "vufind-search-results";
+                params.event_subcategory = params.event_subcategory || link.closest('[id]').getAttribute('id');
                 params.event_label = link.classList.contains('title') ? 'title' :
                     link.classList.contains('result-author') ? 'author' :
                         link.classList.contains('external') ? 'holding' :

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -120,7 +120,10 @@
 
             } else if (window.location.href.indexOf("lib.uchicago.edu/vufind/Search/Results") > -1) { // Catalog Vufind Search results
                 params.event_category = params.event_category || "vufind-search-results";
-                params.event_subcategory = params.event_subcategory || link.closest('[id]').getAttribute('id');
+                params.event_subcategory = params.event_subcategory ||
+                    link.closest('.action-toolbar') ? 'action-toolbar' :
+                    link.closest('.pagination') ? 'pagination' :
+                        link.closest('[id]').getAttribute('id');
                 params.event_label = link.classList.contains('title') ? 'title' :
                     link.classList.contains('result-author') ? 'author' :
                         link.classList.contains('external') ? 'holding' :

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -30,7 +30,10 @@
         const params = {
             event_category: '',
             event_subcategory: '',
-            event_label: link.textContent.trim() || link.getAttribute('aria-label') || 'Unknown',
+            event_label: (link.textContent.replace(/\s+/g, ' ').trim()) ||
+                link.getAttribute('aria-label') ||
+                (link.querySelector('img') ? link.querySelector('img').getAttribute('alt') : '') ||
+                'Unknown',
             click_position: link.getAttribute('data-click-position') ? parseInt(link.getAttribute('data-click-position'), 10) : null,
         };
 
@@ -60,22 +63,22 @@
         if (!target) return false;
 
         // Check if event target or direct parent is defined as a tab
-        if (target.matches('[role="tab"], [data-role="tab"]') || 
+        if (target.matches('[role="tab"], [data-role="tab"]') ||
             target.closest('[role="tab"], [data-role="tab"]')) {
             return 'tab';
         }
         // Check if target or direct parent is defined as a toggler
-        else if (target.matches('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]') || 
-                 target.closest('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]')) {
+        else if (target.matches('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]') ||
+            target.closest('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]')) {
             return 'dropdown';
         }
         // Check if target is an input of type checkbox
         else if (target.matches('input[type="checkbox"]') ||
-                 target.matches('input[type="radio"]') ) {
+            target.matches('input[type="radio"]')) {
             return 'checkbox';
         }
         // Check if element is an <a>
-        else if (target.matches('a')) {
+        else if (target.matches('a') || target.matches('button')) {
             return 'click';
         }
         // return false and do not trigger a GA4 event
@@ -100,265 +103,4 @@
     // Ensure the script does not interfere with screen readers.
     document.body.setAttribute('aria-live', 'polite');
 })();
-
-
-(function ($) {
-    $.fn.track = function (options) {
-        // Set defaults
-        var defaults = {
-            outbound: true,
-            debug: false
-        };
-        var settings = $.extend(defaults, options);
-
-        $.expr[':'].external = function (obj) {
-            return !obj.href.match(/^mailto:/) && !obj.href.match(/^tel:/) && !obj.href.match(/^#/) && (obj.hostname.replace(/^www\./i, '') != document.location.hostname.replace(/^www\./i, ''));
-        };
-
-        pushEvent = function (params) {
-            var gauEventInfo = {
-                'hitType': 'event',
-                'eventCategory': params['category'],
-                'eventAction': params['action']
-            };
-            if (params['label']) {
-                gauEventInfo['eventLabel'] = params['label'];
-            }
-            if (params['value']) {
-                gauEventInfo['eventValue'] = params['value'];
-            }
-            if (params['nonInteraction']) {
-                gauEventInfo['nonInteraction'] = Number(params['nonInteraction']);
-            }
-
-            try {
-                ga('send', gauEventInfo);
-                if (settings.debug) {
-                    console.log(gauEventInfo);
-                }
-            } catch (e) {
-                if (settings.debug) {
-                    console.log("Google Analytics must be installed and initiated for Track Everything to work");
-                }
-            }
-        }
-
-        // $('body').track() means that this loop will be executed once. 
-        return this.each(function () {
-            $('*[data-ga-category][data-ga-action][data-ga-label]').each(function () {
-                // Skip anything that has been tracked already.
-                if ($(this).is('[data-ga-tracked]')) {
-                    return;
-                }
-                // <a> elements. 
-                if ($(this).is('a')) {
-                    $(this).attr("data-ga-tracked", "on");
-                    $(this).on("click.track-everything keypress.track-everything", function (e) {
-                        pushEvent({
-                            'category': $(this).attr('data-ga-category'),
-                            'action': $(this).attr('data-ga-action'),
-                            'label': $(this).attr('data-ga-label')
-                        });
-                    });
-                    if (settings.debug) {
-                        console.log('Added tracking for:');
-                        console.log($(this));
-                    }
-                }
-                // <form> elements.
-                if ($(this).is("form")) {
-                    $(this).on("submit.track-everything", function (e) {
-                        pushEvent({
-                            'category': $(this).attr('data-ga-category'),
-                            'action': $(this).attr('data-ga-action'),
-                            'label': $(this).attr('data-ga-label')
-                        });
-                    });
-                    if (settings.debug) {
-                        console.log('Added tracking for:');
-                        console.log($(this));
-                    }
-                }
-                // <input type="checkbox">, <input type="radio"> elements.
-                if ($(this).is("input[type='checkbox'], input[type='radio']")) {
-                    $(this).on("change.track-everything", function (e) {
-                        pushEvent({
-                            'category': $(this).attr('data-ga-category'),
-                            'action': $(this).attr('data-ga-action'),
-                            'label': $(this).attr('data-ga-label')
-                        });
-                    });
-                }
-            });
-
-            // Outbound links.
-            if (settings.outbound) {
-                $(this).find("a:external").each(function () {
-                    // Skip anything that has been tracked already.
-                    if ($(this).is('[data-ga-tracked]')) {
-                        return;
-                    }
-                    $(this).attr("data-ga-tracked", "on");
-                    $(this).on("click.track-everything keypress.track-everything", function (e) {
-                        pushEvent({
-                            'category': $(this).attr('data-ga-category'),
-                            'action': $(this).attr('data-ga-action'),
-                            'label': $(this).attr('data-ga-label')
-                        });
-                    });
-                    if (settings.debug) {
-                        console.log('Added tracking for:');
-                        console.log($(this));
-                    }
-                });
-            }
-
-            /* For debugging, check to see if anything with a data-ga-category, data-ga-action,
-             * or data-ga-label wasn't tracked. 
-             */
-            if (settings.debug) {
-                $('body').find('[data-ga-category]:not([data-ga-tracked])').each(function () {
-                    console.log('Element has a data-ga-category attribute, but was not tracked.');
-                    console.log($(this));
-                });
-                $('body').find('[data-ga-action]:not([data-ga-tracked])').each(function () {
-                    console.log('Element has a data-ga-action attribute, but was not tracked.');
-                    console.log($(this));
-                });
-                $('body').find('[data-ga-label]:not([data-ga-tracked])').each(function () {
-                    console.log('Element has a data-ga-label attribute, but was not tracked.');
-                    console.log($(this));
-                });
-            }
-        });
-    };
-
-    $(document).ready(function () {
-        // Explore Research Guides
-        // View all link. 
-        $('#widget-explore-research-guides-view-all').on('click.track-everything keypress.track-everything', function (e) {
-            pushEvent({
-                'category': 'Guides and Course Support',
-                'action': 'click',
-                'label': 'View all'
-            });
-        });
-        $('#widget-explore-research-guides-view-all').attr("data-ga-tracked", "on");
-
-        // All other links .
-        $('#widget-explore-research-guides a').not('#widget-explore-research-guides-view-all').each(function () {
-            $(this).on('click.track-everything keypress.track-everything', function (e) {
-                pushEvent({
-                    'category': 'Guides and Course Support',
-                    'action': 'click',
-                    'label': $(this).text()
-                });
-            });
-            $(this).attr("data-ga-tracked", "on");
-        });
-
-        // Featured Library Expert
-        // View all link. 
-        $('#widget-featured-library-expert-view-all').on('click.track-everything keypress.track-everything', function (e) {
-            pushEvent({
-                'category': 'Featured Library Expert',
-                'action': 'click',
-                'label': 'View all'
-            });
-        });
-        $('#widget-featured-library-expert-view-all').attr("data-ga-tracked", "on");
-
-        // All other links .
-        $('#widget-featured-library-expert a').not('#widget-featured-library-expert-view-all').each(function () {
-            $(this).on('click.track-everything keypress.track-everything', function (e) {
-                pushEvent({
-                    'category': 'Featured Library Expert',
-                    'action': 'click',
-                    'label': $(this).text()
-                });
-            });
-            $(this).attr("data-ga-tracked", "on");
-        });
-
-        // Quick Links
-        $('#widget-quicklinks a').each(function () {
-            $(this).on('click.track-everything keypress.track-everything', function (e) {
-                pushEvent({
-                    'category': 'Quicklinks',
-                    'action': 'click',
-                    'label': $(this).text()
-                });
-            });
-            $(this).attr("data-ga-tracked", "on");
-        });
-
-        // Spaces
-        $('#widget-spaces a').each(function () {
-            $(this).on('click.track-everything keypress.track-everything', function (e) {
-                var title = $(this).parents('p').text().split('    ').pop();
-                pushEvent({
-                    'category': 'Spaces',
-                    'action': 'click',
-                    'label': title
-                });
-            });
-            $(this).attr("data-ga-tracked", "on");
-        });
-
-        // Workshops and Events
-        $('#widget-workshops-and-events a').each(function () {
-            $(this).on('click.track-everything keypress.track-everything', function (e) {
-                pushEvent({
-                    'category': 'Workshops and Events',
-                    'action': 'click',
-                    'label': $(this).text()
-                });
-            });
-            $(this).attr("data-ga-tracked", "on");
-        });
-
-        // Social Media
-        $('#widget-social-media a').each(function () {
-            $(this).on('click.track-everything keypress.track-everything', function (e) {
-                pushEvent({
-                    'category': 'Social Media',
-                    'action': 'click',
-                    'label': $(this).text()
-                });
-            });
-            $(this).attr("data-ga-tracked", "on");
-        });
-    });
-
-    // News
-    var interval = setInterval(function () {
-        if ($('.newsblock').length == 0) {
-            return;
-        } else {
-            clearInterval(interval);
-            // View all link. 
-            $('#widget-news-view-all').on('click.track-everything keypress.track-everything', function (e) {
-                pushEvent({
-                    'category': 'News',
-                    'action': 'click',
-                    'label': 'View all'
-                });
-            });
-            $('#widget-news-view-all').attr("data-ga-tracked", "on");
-
-            // All other links .
-            $('#widget-news a').not('#widget-news-view-all').each(function () {
-                $(this).on('click.track-everything keypress.track-everything', function (e) {
-                    var title = $(this).parents('.newsblock').find('a').eq(1).text();
-                    pushEvent({
-                        'category': 'News',
-                        'action': 'click',
-                        'label': title
-                    });
-                });
-                $(this).attr("data-ga-tracked", "on");
-            });
-        }
-    }, 100);
-}(jQuery));
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -203,22 +203,18 @@
         const eventName = getEventName(target);
         if (!eventName) { return; }
 
-        // event.preventDefault(); // Prevents default behavior like following links
-        // event.stopPropagation(); // Stops event from bubbling up
-
         const ep = getEventParameters(target);
-        // DEBUG
+        // DEBUG, leaving it here for the first couple of weeks.
         console.log("Event Name: " + eventName + "\n" + ep.event_category + "\n" + ep.event_subcategory + "\n" + ep.event_label + "\n" + ep.click_position);
-        // gtag('event', eventName, eventParams);
+        gtag('event', eventName, eventParams);
 
         // for links that navigate away
         const href = target.getAttribute('href');
         if (href) {
-            console.log("Link HREF: " + href);
-            // e.preventDefault(); // delay navigation just slightly
-            // setTimeout(() => {
-            //     window.location.href = href;
-            // }, 200); // give GA time to fire
+            e.preventDefault(); // delay navigation just slightly
+            setTimeout(() => {
+                window.location.href = href;
+            }, 200); // give GA time to fire
         }
     }
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -9,9 +9,12 @@
 * - Edge case handling for robustness.
 * - Accessibility considerations to avoid conflicts with screen readers.
 * - Browser compatibility for wide support.
+news-wrap
 */
 
 (function () {
+    console.log("track-everything 010 init");
+
     // Debounce function to limit the rate at which a function can fire.
     function debounce(func, wait) {
         let timeout;
@@ -28,8 +31,8 @@
     // Function to determine event parameters based on link context.
     function getEventParameters(link) {
         const params = {
-            event_category: null,
-            event_subcategory: null,
+            event_category: link.getAttribute('data-ga-category'),
+            event_subcategory: link.getAttribute('data-ga-subcategory'),
             event_label: link.getAttribute('data-ga-label') ||
                 link.getAttribute('aria-label') ||
                 (link.textContent.replace(/\s+/g, ' ').trim()) ||
@@ -39,48 +42,62 @@
             click_position: null,
         };
 
-        // Determine category, subcategory, and click_position based on link context.
+        // Determine category, subcategory, based on link context.
         if (link.closest('#global-navbar')) { // main navbar
-            params.event_category = 'navigation';
+            params.event_category = params.event_category || 'navigation';
             const listParent = link.closest('ul, ol');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+            params.event_subcategory = params.event_subcategory ||
                 (listParent ? listParent.getAttribute('aria-labelledby') : null) ||
                 params.label || 'navigation';
 
         } else if (link.closest('#navbar-right')) { // shortcuts
-            params.event_category = 'navbar-shortcuts';
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'shortcuts';
+            params.event_category = params.event_category || 'navbar-shortcuts';
+            params.event_subcategory = params.event_subcategory || 'shortcuts';
 
         } else if (link.closest('footer')) { // footer
-            params.event_category = 'footer';
+            params.event_category = params.event_category || 'footer';
             const listParent = link.closest('ul, ol');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+            params.event_subcategory = params.event_subcategory ||
                 (listParent ? listParent.getAttribute('aria-labelledby') : null) || 'footer';
 
-        } else if (link.closest('.widget, [id^="widget"]')) { // any widget
-            params.event_category = 'widget';
-            const widgetParent = link.closest('.widget, [id^="widget"]');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
-                (widgetParent?.id.startsWith('widget') ? widgetParent.id : null) || null;
+        } else if (link.closest('.widget, [id*="widget"]')) { // any widget
+            params.event_category = params.event_category || 'widget';
+            const widgetParent = link.closest('.widget, [id*="widget"]');
+            params.event_subcategory = params.event_subcategory ||
+                (widgetParent?.id.includes('widget') ? widgetParent.id : null) || null;
 
-        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id^="sidebar"]')) { // any sidebar
-            params.event_category = 'sidebar';
+        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id*="sidebar"]')) { // any sidebar
+            params.event_category = params.event_category || 'sidebar';
             const sidebarParent = link.closest('[class^="sidebar"], [id^="sidebar"]');
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
-                (sidebarParent?.id.startsWith('sidebar') ? sidebarParent.id : '') ||
-                (sidebarParent?.className.split(' ').find(c => c.startsWith('sidebar')) || 'sidebar-link') || null;
+            params.event_subcategory = params.event_subcategory ||
+                (sidebarParent?.id.includes('sidebar') ? sidebarParent.id : '') ||
+                (sidebarParent?.className.split(' ').find(c => c.includes('sidebar')) || '') || null;
 
         } else { // main content
-            params.event_category = 'main';
-            params.event_subcategory = link.closest('[id]').getAttribute('id');
-            if (link.getAttribute('data-ga-position')) {
+            params.event_category = params.event_category || 'main';
+            params.event_subcategory = params.event_subcategory || link.closest('[id]').getAttribute('id');
+        }
+
+        // Get link position if in a list
+        if (link.getAttribute('data-ga-position')) {
+            params.event_subcategory = params.event_subcategory || 'list';
+            params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
+        } else {
+            const parentLi = link.closest('li');
+            if (parentLi) {
                 params.event_subcategory = params.event_subcategory || 'list';
-                params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
+                params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
             } else {
-                const parentLi = link.closest('li');
-                if (parentLi) {
-                    params.event_subcategory = 'list';
-                    params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
+                const parentNews = link.closest('.news-wrap');
+                if (parentNews) {
+                    params.event_subcategory = params.event_subcategory || 'news-list';
+                    params.click_position = Array.from(parentNews.children).indexOf(link.closest('.newsblock')) + 1;
+                } else {
+                    const parentNews = link.closest('.news-stories');
+                    if (parentNews) {
+                        params.event_subcategory = params.event_subcategory || 'news-list';
+                        params.click_position = Array.from(parentNews.children).indexOf(link.closest('article')) + 1;
+                    }
                 }
             }
         }
@@ -121,19 +138,19 @@
     function handleLinkClick(event) {
         event.preventDefault(); // Prevents default behavior like following links
         event.stopPropagation(); // Stops event from bubbling up
-        const target = event.target.closest('a');
+        const target = event.target.closest('a, button, input');
         const eventName = getEventName(target);
         if (eventName) {
-            const eventParams = getEventParameters(target);
+            const ep = getEventParameters(target);
             // gtag('event', eventName, eventParams);
-            console.log("Event Name: " + eventName);
-            console.log("Event params: " + eventParams);
+            console.log("Event Name: " + eventName + "\n" + ep.event_category + "\n" + ep.event_subcategory + "\n" + ep.event_label + "\n" + ep.click_position);
         } else {
-            console.log("No click event. Event name: " + eventName)
+            console.log("No click event. Event name: " + eventName + ". event.target.tagName: " + event.target.tagName)
         }
     }
 
     // Attach a single event listener to the document body using event delegation.
-    document.body.addEventListener('click', debounce(handleLinkClick, 200));
+    // document.body.addEventListener('click', debounce(handleLinkClick, 200));
+    document.body.addEventListener('click', handleLinkClick);
 })();
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -63,7 +63,7 @@
             params.event_subcategory = params.event_subcategory ||
                 (widgetParent?.id.includes('widget') ? widgetParent.id : null) || null;
 
-        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id*="sidebar"]')) { // any sidebar
+        } else if (link.closest('[class^="sidebar"], [id*="sidebar"]')) { // any sidebar
             params.event_category = 'sidebar';
             const sidebarParent = link.closest('[class^="sidebar"], [id*="sidebar"]');
             params.event_subcategory = link.getAttribute('data-ga-subcategory') ||

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -1,47 +1,151 @@
+/**
+* Script to track link clicks and send events to GA4 using event delegation.
+*
+* This script handles:
+* - Event delegation for efficient event handling.
+* - Debouncing to prevent excessive event firing.
+* - Documentation for clarity and maintainability.
+* - Consistent naming conventions.
+* - Edge case handling for robustness.
+* - Accessibility considerations to avoid conflicts with screen readers.
+* - Browser compatibility for wide support.
+*/
+
+(function () {
+    // Debounce function to limit the rate at which a function can fire.
+    function debounce(func, wait) {
+        let timeout;
+        return function (...args) {
+            const later = () => {
+                clearTimeout(timeout);
+                func(...args);
+            };
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+        };
+    }
+
+    // Function to determine event parameters based on link context.
+    function getEventParameters(link) {
+        const params = {
+            event_category: '',
+            event_subcategory: '',
+            event_label: link.textContent.trim() || link.getAttribute('aria-label') || 'Unknown',
+            click_position: link.getAttribute('data-click-position') ? parseInt(link.getAttribute('data-click-position'), 10) : null,
+        };
+
+        // Determine category and subcategory based on link context.
+        if (link.closest('nav')) {
+            params.event_category = 'navigation';
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'nav-link';
+        } else if (link.closest('.sidebar')) {
+            params.event_category = 'sidebar';
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'sidebar-link';
+        } else if (link.closest('.widget')) {
+            params.event_category = 'widget';
+            params.event_subcategory = `widget-${link.getAttribute('data-widget-name') || 'unknown'}`;
+        } else if (link.closest('main')) {
+            params.event_category = 'content';
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'content-link';
+        } else {
+            params.event_category = 'other';
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'unknown-link';
+        }
+
+        return params;
+    }
+
+    // Function to establish the event name
+    function getEventName(target) {
+        if (!target) return false;
+
+        // Check if event target or direct parent is defined as a tab
+        if (target.matches('[role="tab"], [data-role="tab"]') || 
+            target.closest('[role="tab"], [data-role="tab"]')) {
+            return 'tab';
+        }
+        // Check if target or direct parent is defined as a toggler
+        else if (target.matches('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]') || 
+                 target.closest('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]')) {
+            return 'dropdown';
+        }
+        // Check if target is an input of type checkbox
+        else if (target.matches('input[type="checkbox"]') ||
+                 target.matches('input[type="radio"]') ) {
+            return 'checkbox';
+        }
+        // Check if element is an <a>
+        else if (target.matches('a')) {
+            return 'click';
+        }
+        // return false and do not trigger a GA4 event
+        else {
+            return false;
+        }
+    }
+
+    // Function to handle link clicks and send events to GA4.
+    function handleLinkClick(event) {
+        const target = event.target.closest('a');
+        const eventName = getEventName(target);
+        if (target) {
+            const eventParams = getEventParameters(target);
+            gtag('event', eventName, eventParams);
+        }
+    }
+
+    // Attach a single event listener to the document body using event delegation.
+    document.body.addEventListener('click', debounce(handleLinkClick, 200));
+
+    // Ensure the script does not interfere with screen readers.
+    document.body.setAttribute('aria-live', 'polite');
+})();
+
+
 (function ($) {
-	$.fn.track = function(options) {
-		// Set defaults
-		var defaults = {
-			outbound: true,
-			debug: false
-		};
-		var settings = $.extend(defaults, options);
+    $.fn.track = function (options) {
+        // Set defaults
+        var defaults = {
+            outbound: true,
+            debug: false
+        };
+        var settings = $.extend(defaults, options);
 
-		$.expr[':'].external = function(obj){
-			return !obj.href.match(/^mailto:/) && !obj.href.match(/^tel:/) && !obj.href.match(/^#/) && (obj.hostname.replace(/^www\./i, '') != document.location.hostname.replace(/^www\./i, ''));
-		};
+        $.expr[':'].external = function (obj) {
+            return !obj.href.match(/^mailto:/) && !obj.href.match(/^tel:/) && !obj.href.match(/^#/) && (obj.hostname.replace(/^www\./i, '') != document.location.hostname.replace(/^www\./i, ''));
+        };
 
-		pushEvent = function (params) {
-			var gauEventInfo = {
-				'hitType'      : 'event',
-				'eventCategory': params['category'],
-				'eventAction'  : params['action']
-			};
-			if (params['label']) {
-				gauEventInfo['eventLabel'] = params['label'];
-			}
-			if (params['value']) {
-				gauEventInfo['eventValue'] = params['value'];
-			}
-			if (params['nonInteraction']) {
-				gauEventInfo['nonInteraction'] = Number(params['nonInteraction']);
-			}
+        pushEvent = function (params) {
+            var gauEventInfo = {
+                'hitType': 'event',
+                'eventCategory': params['category'],
+                'eventAction': params['action']
+            };
+            if (params['label']) {
+                gauEventInfo['eventLabel'] = params['label'];
+            }
+            if (params['value']) {
+                gauEventInfo['eventValue'] = params['value'];
+            }
+            if (params['nonInteraction']) {
+                gauEventInfo['nonInteraction'] = Number(params['nonInteraction']);
+            }
 
-			try {
-			    ga('send', gauEventInfo);
+            try {
+                ga('send', gauEventInfo);
                 if (settings.debug) {
                     console.log(gauEventInfo);
-                } 
-			} catch (e) {
-				if (settings.debug) {
-					console.log("Google Analytics must be installed and initiated for Track Everything to work");
-				}
-			}
-		}
+                }
+            } catch (e) {
+                if (settings.debug) {
+                    console.log("Google Analytics must be installed and initiated for Track Everything to work");
+                }
+            }
+        }
 
         // $('body').track() means that this loop will be executed once. 
-		return this.each(function() {
-            $('*[data-ga-category][data-ga-action][data-ga-label]').each(function() {
+        return this.each(function () {
+            $('*[data-ga-category][data-ga-action][data-ga-label]').each(function () {
                 // Skip anything that has been tracked already.
                 if ($(this).is('[data-ga-tracked]')) {
                     return;
@@ -49,13 +153,13 @@
                 // <a> elements. 
                 if ($(this).is('a')) {
                     $(this).attr("data-ga-tracked", "on");
-				    $(this).on("click.track-everything keypress.track-everything", function (e) {
-					    pushEvent({
+                    $(this).on("click.track-everything keypress.track-everything", function (e) {
+                        pushEvent({
                             'category': $(this).attr('data-ga-category'),
-                            'action'  : $(this).attr('data-ga-action'),
-                            'label'   : $(this).attr('data-ga-label')
+                            'action': $(this).attr('data-ga-action'),
+                            'label': $(this).attr('data-ga-label')
                         });
-				    });
+                    });
                     if (settings.debug) {
                         console.log('Added tracking for:');
                         console.log($(this));
@@ -64,11 +168,11 @@
                 // <form> elements.
                 if ($(this).is("form")) {
                     $(this).on("submit.track-everything", function (e) {
-					    pushEvent({
+                        pushEvent({
                             'category': $(this).attr('data-ga-category'),
-                            'action'  : $(this).attr('data-ga-action'),
-                            'label'   : $(this).attr('data-ga-label')
-				        });
+                            'action': $(this).attr('data-ga-action'),
+                            'label': $(this).attr('data-ga-label')
+                        });
                     });
                     if (settings.debug) {
                         console.log('Added tracking for:');
@@ -80,28 +184,28 @@
                     $(this).on("change.track-everything", function (e) {
                         pushEvent({
                             'category': $(this).attr('data-ga-category'),
-                            'action'  : $(this).attr('data-ga-action'),
-                            'label'   : $(this).attr('data-ga-label')
+                            'action': $(this).attr('data-ga-action'),
+                            'label': $(this).attr('data-ga-label')
                         });
                     });
                 }
             });
 
             // Outbound links.
-			if (settings.outbound) {
-                $(this).find("a:external").each(function() {
+            if (settings.outbound) {
+                $(this).find("a:external").each(function () {
                     // Skip anything that has been tracked already.
                     if ($(this).is('[data-ga-tracked]')) {
                         return;
                     }
                     $(this).attr("data-ga-tracked", "on");
-				    $(this).on("click.track-everything keypress.track-everything", function (e) {
-					    pushEvent({
+                    $(this).on("click.track-everything keypress.track-everything", function (e) {
+                        pushEvent({
                             'category': $(this).attr('data-ga-category'),
-                            'action'  : $(this).attr('data-ga-action'),
-                            'label'   : $(this).attr('data-ga-label')
+                            'action': $(this).attr('data-ga-action'),
+                            'label': $(this).attr('data-ga-label')
                         });
-				    });
+                    });
                     if (settings.debug) {
                         console.log('Added tracking for:');
                         console.log($(this));
@@ -126,28 +230,28 @@
                     console.log($(this));
                 });
             }
-		});
-	};
+        });
+    };
 
     $(document).ready(function () {
         // Explore Research Guides
         // View all link. 
         $('#widget-explore-research-guides-view-all').on('click.track-everything keypress.track-everything', function (e) {
-	        pushEvent({
+            pushEvent({
                 'category': 'Guides and Course Support',
-                'action'  : 'click',
-                'label'   : 'View all'
+                'action': 'click',
+                'label': 'View all'
             });
         });
         $('#widget-explore-research-guides-view-all').attr("data-ga-tracked", "on");
 
         // All other links .
-        $('#widget-explore-research-guides a').not('#widget-explore-research-guides-view-all').each(function() {
+        $('#widget-explore-research-guides a').not('#widget-explore-research-guides-view-all').each(function () {
             $(this).on('click.track-everything keypress.track-everything', function (e) {
-	            pushEvent({
+                pushEvent({
                     'category': 'Guides and Course Support',
-                    'action'  : 'click',
-                    'label'   : $(this).text()
+                    'action': 'click',
+                    'label': $(this).text()
                 });
             });
             $(this).attr("data-ga-tracked", "on");
@@ -156,70 +260,70 @@
         // Featured Library Expert
         // View all link. 
         $('#widget-featured-library-expert-view-all').on('click.track-everything keypress.track-everything', function (e) {
-	        pushEvent({
+            pushEvent({
                 'category': 'Featured Library Expert',
-                'action'  : 'click',
-                'label'   : 'View all'
+                'action': 'click',
+                'label': 'View all'
             });
         });
         $('#widget-featured-library-expert-view-all').attr("data-ga-tracked", "on");
 
         // All other links .
-        $('#widget-featured-library-expert a').not('#widget-featured-library-expert-view-all').each(function() {
+        $('#widget-featured-library-expert a').not('#widget-featured-library-expert-view-all').each(function () {
             $(this).on('click.track-everything keypress.track-everything', function (e) {
-	            pushEvent({
+                pushEvent({
                     'category': 'Featured Library Expert',
-                    'action'  : 'click',
-                    'label'   : $(this).text()
+                    'action': 'click',
+                    'label': $(this).text()
                 });
             });
             $(this).attr("data-ga-tracked", "on");
         });
 
         // Quick Links
-        $('#widget-quicklinks a').each(function() {
+        $('#widget-quicklinks a').each(function () {
             $(this).on('click.track-everything keypress.track-everything', function (e) {
-		        pushEvent({
+                pushEvent({
                     'category': 'Quicklinks',
-                    'action'  : 'click',
-                    'label'   : $(this).text()
+                    'action': 'click',
+                    'label': $(this).text()
                 });
             });
             $(this).attr("data-ga-tracked", "on");
         });
 
         // Spaces
-        $('#widget-spaces a').each(function() {
+        $('#widget-spaces a').each(function () {
             $(this).on('click.track-everything keypress.track-everything', function (e) {
                 var title = $(this).parents('p').text().split('    ').pop();
-		        pushEvent({
+                pushEvent({
                     'category': 'Spaces',
-                    'action'  : 'click',
-                    'label'   : title
+                    'action': 'click',
+                    'label': title
                 });
             });
             $(this).attr("data-ga-tracked", "on");
         });
 
         // Workshops and Events
-        $('#widget-workshops-and-events a').each(function() {
+        $('#widget-workshops-and-events a').each(function () {
             $(this).on('click.track-everything keypress.track-everything', function (e) {
-	            pushEvent({
+                pushEvent({
                     'category': 'Workshops and Events',
-                    'action'  : 'click',
-                    'label'   : $(this).text()
+                    'action': 'click',
+                    'label': $(this).text()
                 });
             });
             $(this).attr("data-ga-tracked", "on");
         });
 
         // Social Media
-        $('#widget-social-media a').each(function() {
+        $('#widget-social-media a').each(function () {
             $(this).on('click.track-everything keypress.track-everything', function (e) {
-	            pushEvent({
+                pushEvent({
                     'category': 'Social Media',
-                    'action'  : 'click',
-                    'label'   : $(this).text()
+                    'action': 'click',
+                    'label': $(this).text()
                 });
             });
             $(this).attr("data-ga-tracked", "on");
@@ -227,34 +331,34 @@
     });
 
     // News
-    var interval = setInterval(function() {
+    var interval = setInterval(function () {
         if ($('.newsblock').length == 0) {
             return;
         } else {
             clearInterval(interval);
             // View all link. 
             $('#widget-news-view-all').on('click.track-everything keypress.track-everything', function (e) {
-	            pushEvent({
+                pushEvent({
                     'category': 'News',
-                    'action'  : 'click',
-                    'label'   : 'View all'
+                    'action': 'click',
+                    'label': 'View all'
                 });
             });
             $('#widget-news-view-all').attr("data-ga-tracked", "on");
 
             // All other links .
-            $('#widget-news a').not('#widget-news-view-all').each(function() {
+            $('#widget-news a').not('#widget-news-view-all').each(function () {
                 $(this).on('click.track-everything keypress.track-everything', function (e) {
                     var title = $(this).parents('.newsblock').find('a').eq(1).text();
-	                pushEvent({
+                    pushEvent({
                         'category': 'News',
-                        'action'  : 'click',
-                        'label'   : title
+                        'action': 'click',
+                        'label': title
                     });
                 });
                 $(this).attr("data-ga-tracked", "on");
             });
         }
     }, 100);
-}( jQuery ));
+}(jQuery));
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -1,6 +1,6 @@
 /**
 * Script to track link clicks and send events to GA4 using event delegation.
-*
+* 
 * This script handles:
 * - Event delegation for efficient event handling.
 * - Debouncing to prevent excessive event firing.
@@ -28,31 +28,61 @@
     // Function to determine event parameters based on link context.
     function getEventParameters(link) {
         const params = {
-            event_category: '',
-            event_subcategory: '',
-            event_label: (link.textContent.replace(/\s+/g, ' ').trim()) ||
+            event_category: null,
+            event_subcategory: null,
+            event_label: link.getAttribute('data-ga-label') ||
                 link.getAttribute('aria-label') ||
+                (link.textContent.replace(/\s+/g, ' ').trim()) ||
+                link.getAttribute('title') ||
                 (link.querySelector('img') ? link.querySelector('img').getAttribute('alt') : '') ||
                 'Unknown',
-            click_position: link.getAttribute('data-click-position') ? parseInt(link.getAttribute('data-click-position'), 10) : null,
+            click_position: null,
         };
 
-        // Determine category and subcategory based on link context.
-        if (link.closest('nav')) {
+        // Determine category, subcategory, and click_position based on link context.
+        if (link.closest('#global-navbar')) { // main navbar
             params.event_category = 'navigation';
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'nav-link';
-        } else if (link.closest('.sidebar')) {
-            params.event_category = 'sidebar';
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'sidebar-link';
-        } else if (link.closest('.widget')) {
+            const listParent = link.closest('ul, ol');
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+                (listParent ? listParent.getAttribute('aria-labelledby') : null) ||
+                params.label || 'navigation';
+
+        } else if (link.closest('#navbar-right')) { // shortcuts
+            params.event_category = 'navbar-shortcuts';
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'shortcuts';
+
+        } else if (link.closest('footer')) { // footer
+            params.event_category = 'footer';
+            const listParent = link.closest('ul, ol');
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+                (listParent ? listParent.getAttribute('aria-labelledby') : null) || 'footer';
+
+        } else if (link.closest('.widget, [id^="widget"]')) { // any widget
             params.event_category = 'widget';
-            params.event_subcategory = `widget-${link.getAttribute('data-widget-name') || 'unknown'}`;
-        } else if (link.closest('main')) {
-            params.event_category = 'content';
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'content-link';
-        } else {
-            params.event_category = 'other';
-            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'unknown-link';
+            const widgetParent = link.closest('.widget, [id^="widget"]');
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+                (widgetParent?.id.startsWith('widget') ? widgetParent.id : null) || null;
+
+        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id^="sidebar"]')) { // any sidebar
+            params.event_category = 'sidebar';
+            const sidebarParent = link.closest('[class^="sidebar"], [id^="sidebar"]');
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+                (sidebarParent?.id.startsWith('sidebar') ? sidebarParent.id : '') ||
+                (sidebarParent?.className.split(' ').find(c => c.startsWith('sidebar')) || 'sidebar-link') || null;
+
+        } else { // main content
+            params.event_category = 'main';
+            params.event_subcategory = link.closest('[id]').getAttribute('id');
+            if (link.getAttribute('data-ga-position')) {
+                params.event_subcategory = params.event_subcategory || 'list';
+                params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
+            } else {
+                const parentLi = link.closest('li');
+                if (parentLi) {
+                    params.event_subcategory = 'list';
+                    params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
+                }
+            }
         }
 
         return params;
@@ -89,18 +119,21 @@
 
     // Function to handle link clicks and send events to GA4.
     function handleLinkClick(event) {
+        event.preventDefault(); // Prevents default behavior like following links
+        event.stopPropagation(); // Stops event from bubbling up
         const target = event.target.closest('a');
         const eventName = getEventName(target);
-        if (target) {
+        if (eventName) {
             const eventParams = getEventParameters(target);
-            gtag('event', eventName, eventParams);
+            // gtag('event', eventName, eventParams);
+            console.log("Event Name: " + eventName);
+            console.log("Event params: " + eventParams);
+        } else {
+            console.log("No click event. Event name: " + eventName)
         }
     }
 
     // Attach a single event listener to the document body using event delegation.
     document.body.addEventListener('click', debounce(handleLinkClick, 200));
-
-    // Ensure the script does not interfere with screen readers.
-    document.body.setAttribute('aria-live', 'polite');
 })();
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -9,12 +9,9 @@
 * - Edge case handling for robustness.
 * - Accessibility considerations to avoid conflicts with screen readers.
 * - Browser compatibility for wide support.
-news-wrap
 */
 
 (function () {
-    console.log("track-everything 010 init");
-
     // Debounce function to limit the rate at which a function can fire.
     function debounce(func, wait) {
         let timeout;
@@ -31,8 +28,8 @@ news-wrap
     // Function to determine event parameters based on link context.
     function getEventParameters(link) {
         const params = {
-            event_category: link.getAttribute('data-ga-category'),
-            event_subcategory: link.getAttribute('data-ga-subcategory'),
+            event_category: null,
+            event_subcategory: null,
             event_label: link.getAttribute('data-ga-label') ||
                 link.getAttribute('aria-label') ||
                 (link.textContent.replace(/\s+/g, ' ').trim()) ||
@@ -42,62 +39,48 @@ news-wrap
             click_position: null,
         };
 
-        // Determine category, subcategory, based on link context.
+        // Determine category, subcategory, and click_position based on link context.
         if (link.closest('#global-navbar')) { // main navbar
-            params.event_category = params.event_category || 'navigation';
+            params.event_category = 'navigation';
             const listParent = link.closest('ul, ol');
-            params.event_subcategory = params.event_subcategory ||
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
                 (listParent ? listParent.getAttribute('aria-labelledby') : null) ||
                 params.label || 'navigation';
 
         } else if (link.closest('#navbar-right')) { // shortcuts
-            params.event_category = params.event_category || 'navbar-shortcuts';
-            params.event_subcategory = params.event_subcategory || 'shortcuts';
+            params.event_category = 'navbar-shortcuts';
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') || 'shortcuts';
 
         } else if (link.closest('footer')) { // footer
-            params.event_category = params.event_category || 'footer';
+            params.event_category = 'footer';
             const listParent = link.closest('ul, ol');
-            params.event_subcategory = params.event_subcategory ||
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
                 (listParent ? listParent.getAttribute('aria-labelledby') : null) || 'footer';
 
-        } else if (link.closest('.widget, [id*="widget"]')) { // any widget
-            params.event_category = params.event_category || 'widget';
-            const widgetParent = link.closest('.widget, [id*="widget"]');
-            params.event_subcategory = params.event_subcategory ||
-                (widgetParent?.id.includes('widget') ? widgetParent.id : null) || null;
+        } else if (link.closest('.widget, [id^="widget"]')) { // any widget
+            params.event_category = 'widget';
+            const widgetParent = link.closest('.widget, [id^="widget"]');
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+                (widgetParent?.id.startsWith('widget') ? widgetParent.id : null) || null;
 
-        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id*="sidebar"]')) { // any sidebar
-            params.event_category = params.event_category || 'sidebar';
+        } else if (link.closest('[class^="sidebar"], [role="complementary"], [id^="sidebar"]')) { // any sidebar
+            params.event_category = 'sidebar';
             const sidebarParent = link.closest('[class^="sidebar"], [id^="sidebar"]');
-            params.event_subcategory = params.event_subcategory ||
-                (sidebarParent?.id.includes('sidebar') ? sidebarParent.id : '') ||
-                (sidebarParent?.className.split(' ').find(c => c.includes('sidebar')) || '') || null;
+            params.event_subcategory = link.getAttribute('data-ga-subcategory') ||
+                (sidebarParent?.id.startsWith('sidebar') ? sidebarParent.id : '') ||
+                (sidebarParent?.className.split(' ').find(c => c.startsWith('sidebar')) || 'sidebar-link') || null;
 
         } else { // main content
-            params.event_category = params.event_category || 'main';
-            params.event_subcategory = params.event_subcategory || link.closest('[id]').getAttribute('id');
-        }
-
-        // Get link position if in a list
-        if (link.getAttribute('data-ga-position')) {
-            params.event_subcategory = params.event_subcategory || 'list';
-            params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
-        } else {
-            const parentLi = link.closest('li');
-            if (parentLi) {
+            params.event_category = 'main';
+            params.event_subcategory = link.closest('[id]').getAttribute('id');
+            if (link.getAttribute('data-ga-position')) {
                 params.event_subcategory = params.event_subcategory || 'list';
-                params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
+                params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
             } else {
-                const parentNews = link.closest('.news-wrap');
-                if (parentNews) {
-                    params.event_subcategory = params.event_subcategory || 'news-list';
-                    params.click_position = Array.from(parentNews.children).indexOf(link.closest('.newsblock')) + 1;
-                } else {
-                    const parentNews = link.closest('.news-stories');
-                    if (parentNews) {
-                        params.event_subcategory = params.event_subcategory || 'news-list';
-                        params.click_position = Array.from(parentNews.children).indexOf(link.closest('article')) + 1;
-                    }
+                const parentLi = link.closest('li');
+                if (parentLi) {
+                    params.event_subcategory = 'list';
+                    params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
                 }
             }
         }
@@ -138,19 +121,19 @@ news-wrap
     function handleLinkClick(event) {
         event.preventDefault(); // Prevents default behavior like following links
         event.stopPropagation(); // Stops event from bubbling up
-        const target = event.target.closest('a, button, input');
+        const target = event.target.closest('a');
         const eventName = getEventName(target);
         if (eventName) {
-            const ep = getEventParameters(target);
+            const eventParams = getEventParameters(target);
             // gtag('event', eventName, eventParams);
-            console.log("Event Name: " + eventName + "\n" + ep.event_category + "\n" + ep.event_subcategory + "\n" + ep.event_label + "\n" + ep.click_position);
+            console.log("Event Name: " + eventName);
+            console.log("Event params: " + eventParams);
         } else {
-            console.log("No click event. Event name: " + eventName + ". event.target.tagName: " + event.target.tagName)
+            console.log("No click event. Event name: " + eventName)
         }
     }
 
     // Attach a single event listener to the document body using event delegation.
-    // document.body.addEventListener('click', debounce(handleLinkClick, 200));
-    document.body.addEventListener('click', handleLinkClick);
+    document.body.addEventListener('click', debounce(handleLinkClick, 200));
 })();
 

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -35,7 +35,12 @@
         GLOBAL_NAV: '#global-navbar',
         NAVBAR_RIGHT: '#navbar-right',
         WIDGET: '.widget, [id*="widget"]',
-        SIDEBAR: '[class^="sidebar"], [id*="sidebar"], .rightside, [role="complementary"]'
+        SIDEBAR: '[class^="sidebar"], [id*="sidebar"], .rightside, [role="complementary"]',
+        FOOTER: 'footer',
+        TAB: '[role="tab"], [data-role="tab"], .spaces-toggle',
+        DROPDOWN: '[data-bs-toggle="dropdown"], [data-toggle="dropdown"]',
+        CHECKBOX_RADIO: 'input[type="checkbox"], input[type="radio"]',
+        BUTTON_A: 'button, a'
     };
 
     const CATEGORIES = {
@@ -111,24 +116,26 @@
         }
 
         // Get link position if in a list
-        if (link.getAttribute('data-ga-position')) {
-            params.event_subcategory = params.event_subcategory || 'list';
-            params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
-        } else {
-            const parentLi = link.closest('li');
-            if (parentLi) {
+        if (!link.closest(SELECTORS.FOOTER)) {
+            if (link.getAttribute('data-ga-position')) {
                 params.event_subcategory = params.event_subcategory || 'list';
-                params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
+                params.click_position = parseInt(link.getAttribute('data-ga-position'), 10);
             } else {
-                const parentNews = link.closest('.news-wrap');
-                if (parentNews) {
-                    params.event_subcategory = params.event_subcategory || 'news-list';
-                    params.click_position = Array.from(parentNews.children).indexOf(link.closest('.newsblock')) + 1;
+                const parentLi = link.closest('li');
+                if (parentLi) {
+                    params.event_subcategory = params.event_subcategory || 'list';
+                    params.click_position = Array.from(parentLi.parentElement.children).indexOf(parentLi) + 1;
                 } else {
-                    const parentNews = link.closest('.news-stories');
+                    const parentNews = link.closest('.news-wrap');
                     if (parentNews) {
                         params.event_subcategory = params.event_subcategory || 'news-list';
-                        params.click_position = Array.from(parentNews.children).indexOf(link.closest('article')) + 1;
+                        params.click_position = Array.from(parentNews.children).indexOf(link.closest('.newsblock')) + 1;
+                    } else {
+                        const parentNews = link.closest('.news-stories');
+                        if (parentNews) {
+                            params.event_subcategory = params.event_subcategory || 'news-list';
+                            params.click_position = Array.from(parentNews.children).indexOf(link.closest('article')) + 1;
+                        }
                     }
                 }
             }
@@ -142,22 +149,21 @@
         if (!target) return false;
 
         // Check if event target or direct parent is defined as a tab
-        if (target.matches('[role="tab"], [data-role="tab"]') ||
-            target.closest('[role="tab"], [data-role="tab"]')) {
+        if (target.matches(SELECTORS.TAB) ||
+            target.closest(SELECTORS.TAB)) {
             return 'tab';
         }
         // Check if target or direct parent is defined as a toggler
-        else if (target.matches('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]') ||
-            target.closest('[data-bs-toggle="dropdown"], [data-toggle="dropdown"]')) {
+        else if (target.matches(SELECTORS.DROPDOWN) ||
+            target.closest(SELECTORS.DROPDOWN)) {
             return 'dropdown';
         }
         // Check if target is an input of type checkbox
-        else if (target.matches('input[type="checkbox"]') ||
-            target.matches('input[type="radio"]')) {
+        else if (target.matches(SELECTORS.CHECKBOX_RADIO)) {
             return 'checkbox';
         }
         // Check if element is an <a>
-        else if (target.matches('a') || target.matches('button')) {
+        else if (target.matches(SELECTORS.BUTTON_A)) {
             return 'click';
         }
         // return false and do not trigger a GA4 event

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -35,7 +35,7 @@
         GLOBAL_NAV: '#global-navbar',
         NAVBAR_RIGHT: '#navbar-right',
         WIDGET: '.widget, [id*="widget"]',
-        SIDEBAR: '[class^="sidebar"], [id*="sidebar"]'
+        SIDEBAR: '[class^="sidebar"], [id*="sidebar"], .rightside, [role="complementary"]'
     };
 
     const CATEGORIES = {

--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -122,8 +122,9 @@
                 params.event_category = params.event_category || "vufind-search-results";
                 params.event_subcategory = params.event_subcategory ||
                     link.closest('.action-toolbar') ? 'action-toolbar' :
-                    link.closest('.pagination') ? 'pagination' :
-                        link.closest('[id]').getAttribute('id');
+                    link.closest('.searchtools') ? 'searchtools' :
+                        link.closest('.pagination') ? 'pagination' :
+                            link.closest('[id]').getAttribute('id');
                 params.event_label = link.classList.contains('title') ? 'title' :
                     link.classList.contains('result-author') ? 'author' :
                         link.classList.contains('external') ? 'holding' :

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -600,9 +600,7 @@
         <script src="{% static "base/js/offcanvas.js" %}"></script>
         <script src="{% static "base/js/library_website.js" %}"></script>
         <script src="{% static "base/js/render_hours.js" %}"></script>
-        <script>console.log("before track-everything load");</script>
         <script src='/static/base/js/jquery.track-everything.js'></script>
-        <script>console.log("after track-everything load");</script>
         <script src='/static/base/js/ga.public.js'></script>
         <script src='https://www.lib.uchicago.edu/clickheat/js/clickheat.js'></script>
         <script src='/static/base/js/clickheat-config.js'></script>

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -600,7 +600,9 @@
         <script src="{% static "base/js/offcanvas.js" %}"></script>
         <script src="{% static "base/js/library_website.js" %}"></script>
         <script src="{% static "base/js/render_hours.js" %}"></script>
+        <script>console.log("before track-everything load");</script>
         <script src='/static/base/js/jquery.track-everything.js'></script>
+        <script>console.log("after track-everything load");</script>
         <script src='/static/base/js/ga.public.js'></script>
         <script src='https://www.lib.uchicago.edu/clickheat/js/clickheat.js'></script>
         <script src='/static/base/js/clickheat-config.js'></script>

--- a/public/templates/public/blocks/search_widget.html
+++ b/public/templates/public/blocks/search_widget.html
@@ -2,9 +2,9 @@
 <div class="tabs col-xs-12 nopadding main-search" role="tablist" aria-labelledby="tablist-1"> <!-- Search Tabs Wrapper -->
     <nav class="transformer-tabs">
         <ul>
-            <li><a id="t-1" class="active" href="#tab-1" data-ga-category="search-widget" data-ga-action="click" data-ga-label="tab-1" role="tab" aria-selected="true" aria-controls="tab-1" tabindex="0">Catalogs</a></li>
-            <li><a id="t-2" href="#tab-2" data-ga-category="search-widget" data-ga-action="click" data-ga-label="tab-2" role="tab" aria-selected="false" aria-controls="tab-2" tabindex="-1"><span class="hidden-xs">Articles, Journals &amp; </span>Databases</a></li>
-            <li><a id="t-3" href="#tab-3" data-ga-category="search-widget" data-ga-action="click" data-ga-label="tab-3" role="tab" aria-selected="false" aria-controls="tab-3" tabindex="-1">Website<span class="hidden-xs"> Search</span></a></li>
+            <li><a id="t-1" class="active" href="#tab-1" data-ga-category="search-widget" data-ga-category="tab" data-ga-action="click" data-ga-label="Catalogs" role="tab" aria-selected="true" aria-controls="tab-1" tabindex="0">Catalogs</a></li>
+            <li><a id="t-2" href="#tab-2" data-ga-category="search-widget" data-ga-category="tab" data-ga-action="click" data-ga-label="Articles" role="tab" aria-selected="false" aria-controls="tab-2" tabindex="-1"><span class="hidden-xs">Articles, Journals &amp; </span>Databases</a></li>
+            <li><a id="t-3" href="#tab-3" data-ga-category="search-widget" data-ga-category="tab" data-ga-action="click" data-ga-label="Website Search" role="tab" aria-selected="false" aria-controls="tab-3" tabindex="-1">Website<span class="hidden-xs"> Search</span></a></li>
         </ul>
     </nav>
 


### PR DESCRIPTION
Fixes #826 

**Changes in this request**
- Completely rewrites the track everything script.
- It can now submit events to GA4.
- It can now track all clicks on VuFind. (vufind needs to include this script https://github.com/uchicago-library/vufind/tree/add-script-for-click-tracking)
- Code is much cleaner.
- Includes a debouncing function that was not working, but I left it there anyway.
- It still accepts specific html encoded event parameters, but it has a bunch of logic to track other cases.
- Improves homepage search widget tab tracking.