### PR TITLE
Fix appointment buttons on CDS staff pages

### DIFF
--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -606,10 +606,8 @@
         <script src='/static/base/js/clickheat-config.js'></script>
 
         {% block extra_scripts %}
-            {% if request.path == '/' %}
-                {# for the libcal "schedule an appointment" button #}
-                <script src="{% static "base/js/libcal_buttons_init.js" %}"></script>
-            {% endif %}
+            {# for the libcal "schedule an appointment" button #}
+            <script src="{% static "base/js/libcal_buttons_init.js" %}"></script>
         {% endblock %}
 
         {% if is_hours_page %}


### PR DESCRIPTION
## Summary

Fixes #840

This PR fixes an issue where appointment buttons on CDS staff pages (e.g., /research/scholar/about-us/) were not working. The problem was caused by the  script only being loaded on the homepage due to a conditional check.

## Changes Made
- Removed conditional check that was preventing the appointment button initialization script from loading on non-homepage pages
- Ensured the script loads on all pages where appointment buttons might appear

## Testing
1. Navigate to a CDS staff page (e.g., /research/scholar/about-us/)
2. Verify that clicking an appointment button opens the scheduling modal
3. Verify that appointment buttons still work on the directory page