### PR TITLE
open links in new tab

### DIFF
--- a/base/static/base/js/jquery.track-everything.js
+++ b/base/static/base/js/jquery.track-everything.js
@@ -266,7 +266,9 @@
 
         // for links that navigate away
         const href = target.getAttribute('href');
-        if (href && !isMiddleClick && !(eventName === 'tab' && href && href.startsWith('#'))) {
+        // const isNewTab = target.target === '_blank' || event.ctrlKey || event.metaKey || event.shiftKey || isMiddleClick; // UNTESTED
+        const isNewTab = target.target === '_blank' || isMiddleClick;
+        if (href && !isNewTab && !(eventName === 'tab' && href && href.startsWith('#'))) {
             event.preventDefault(); // delay navigation just slightly
             setTimeout(() => {
                 window.location.href = href;


### PR DESCRIPTION
Fixes #842 

Allows links that were supposed to open in a new tab to continue.