### PR TITLE
Fix event display issue with inconsistent GUIDs between feeds

### DIFF
--- a/events/utils.py
+++ b/events/utils.py
@@ -227,13 +227,32 @@ def filter_university_entries_to_ttrss_entries(university_entries, ttrss_entries
         xml feed and the Tiny Tiny Rss feed.
     """
     ttrss_guids = []
+    ttrss_slugs = []
+
     for ttrss_entry in ttrss_entries:
-        ttrss_guids.append(ttrss_entry['guid'])
+        guid = ttrss_entry['guid']
+        ttrss_guids.append(guid)
+        # Extract the slug (part after the last slash)
+        slug = guid.split('/')[-1]
+        # If the slug contains a hyphen followed by text, extract just that part
+        if '-' in slug:
+            slug = slug.split('-', 1)[1]  # Split on first hyphen only
+        ttrss_slugs.append(slug)
 
     entries_out = []
     for entry in university_entries:
-        if entry['guid'] in ttrss_guids:
+        guid = entry['link']
+
+        # Check for exact GUID match first
+        if guid in ttrss_guids:
             entries_out.append(entry)
+            continue
+
+        # If no exact match, try matching by slug
+        slug = guid.split('/')[-1]
+        if slug in ttrss_slugs:
+            entries_out.append(entry)
+
     return entries_out
 
 


### PR DESCRIPTION
Title: Fix event display issue with inconsistent GUIDs between feeds

Fixes #845

Summary

Modified the event filtering logic to handle inconsistent GUID formats between University and TTRSS feeds.
- Added slug-based matching to handle events with different URL formats
- Fixed comparison between University feed's 'link' field and TTRSS feed's 'guid' field
- Implemented fallback matching for events with numeric IDs in URLs

Testing:
1. Verify that events with multiple tags (e.g., 'library' and 'science') now appear on all relevant kiosk pages
2. Check that the 'Reg Reads Book Club Summer Meeting' event appears on both the library homepage and crerar page