### PR TITLE
Add Good-Bots package for automated bot IP management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ base/static/bundles/*.LICENSE.txt
 
 django-errors.log
 library_website/settings/database.db
+*bot_ips_config.py
 
 .vagrant/
 /.vagrant/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ export TURNSTILE_ENABLED=True
 
 Note that this will only affect the current session. When you log out and log back in, `TURNSTILE_ENABLED` will be set back to "False".
 
+### Bot IP Management
+The site uses the [Good-Bots package](https://github.com/bbusenius/Good-Bots) to automatically manage IP exclusions for legitimate search engine bots and crawlers. This ensures they aren't blocked by Turnstile protection.
+
+The package generates a `bot_ips_config.py` file with ~1,700 bot IP ranges that gets updated daily via cron. This file is automatically imported in Django settings and excluded from version control.
+
 ### Vagrant Troubleshooting
 If you have issues loading your local instance, try:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ openpyxl>=3.1.0,<3.2.0
 git+https://github.com/owncloud/pyocclient.git@aa6b4374a779bf0f9e060117b2e8d1e810342bc8#egg=pyocclient
 git+https://github.com/uchicago-library/pyiiif.git#egg=pyiiif
 git+https://github.com/bbusenius/django-turnstile-site-protect.git#egg=django_turnstile_site_protect
+git+https://github.com/bbusenius/Good-Bots.git
 pandas>=2,<3
 pocli==0.1.10
 psycopg2


### PR DESCRIPTION
Title: Add Good-Bots package for automated bot IP management

Fixes #847

**Summary**

Integrates the Good-Bots package to automatically manage bot IP exclusions for Turnstile protection.
- Added good-bots package to requirements.txt
- Added bot_ips_config.py to .gitignore 
- Updated README with Bot IP Management section

**Testing**:
- Review the changes and verify the package will be installed during deployment. The cron setup and Django settings integration still need to be completed separately.
- If you want to test the command to generate the Good-Bots config, run this: `. /data/local/venv/bin/activate && good-bots -p /data/local/sites/library_website/library_website/settings/`. This is an approximation of what we'll put in cron. After running, you should see a `bot_ips_config.py` at the location set by `-p`.

**Documentation**:
https://loop.lib.uchicago.edu/departments/digital-strategy-services/web-discovery-services/documentation/whitelisting-good-bots-on-the-library-website/