### PR TITLE
Firefox CSRF verification failure on homepage search forms

### DIFF
--- a/library_website/settings/production.py
+++ b/library_website/settings/production.py
@@ -9,3 +9,5 @@ except ImportError:
     pass
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
Fixes #852

Summary

Adds CSRF_COOKIE_SECURE setting to production environment to fix Firefox CSRF verification failures on homepage search forms. Firefox requires the Secure flag on CSRF cookies for HTTPS sites.

- Add CSRF_COOKIE_SECURE = True to production.py

Testing:
This branch is checked out on nest and can be tested there.