### PR TITLE
Upgrade Wagtail and Django

### DIFF
--- a/lib_collections/tests.py
+++ b/lib_collections/tests.py
@@ -1107,6 +1107,7 @@ class TestExhibitFiltering(TestCase):
             unit=self.unit,
         )
         self.space.add_child(instance=self.physical_exhibit)
+        self.physical_exhibit.save()
 
     def tearDown(self):
         # Clean up created pages
@@ -1194,6 +1195,10 @@ class TestExhibitFiltering(TestCase):
             unit=self.unit,
         )
         self.space.add_child(instance=another_web_exhibit)
+
+        # Update search index to ensure objects are searchable
+        search_backend = get_search_backend()
+        search_backend.add_bulk(ExhibitPage, ExhibitPage.objects.all())
 
         try:
             # This simulates what happens in the collections view

--- a/lib_news/tests.py
+++ b/lib_news/tests.py
@@ -98,6 +98,11 @@ class test_lib_news_pages_and_categories(TestCase):
             slug='borg-attack',
         )
         self.news_homepage.add_child(instance=self.news_article)
+        PublicNewsCategories.objects.create(text='Picard').save()
+        PublicNewsCategories.objects.create(text='Borg').save()
+        PublicNewsCategories.objects.create(text='Alpha Quadrant').save()
+        self.news_article.save()
+        self.news_homepage.save()
 
         self.factory = RequestFactory()
         self.client = Client()
@@ -106,22 +111,15 @@ class test_lib_news_pages_and_categories(TestCase):
         self.site.delete()
 
     def test_get_alpha_cats_with_categories(self):
-        PublicNewsCategories.objects.create(text='Picard').save()
-        PublicNewsCategories.objects.create(text='Borg').save()
-        PublicNewsCategories.objects.create(text='Alpha Quadrant').save()
         cats = self.news_homepage.get_alpha_cats()
         self.assertEqual(cats[0], 'Alpha Quadrant')
         self.assertEqual(cats[1], 'Borg')
         self.assertEqual(cats[2], 'Picard')
 
     def test_get_alpha_cats_without_categories(self):
+        PublicNewsCategories.objects.all().delete()
         cats = self.news_homepage.get_alpha_cats()
         self.assertEqual(cats, [])
-
-    def test_visit_to_news_article_page(self):
-        url = LibNewsPage.objects.live().first().url
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
 
     def test_generic_news_article_page_routing(self):
         url = self.news_article.url
@@ -129,6 +127,7 @@ class test_lib_news_pages_and_categories(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_news_article_page_routing_to_category_listing(self):
+        PublicNewsCategories.objects.create(text='Borg').save()
         url = '/starfleet-news/category/borg/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bleach==3.3.0
 DateTime>=4,<5
 defusedxml
 git+https://github.com/bbusenius/Diablo-Python.git#egg=diablo_python
-Django==5.0.10
+Django==5.2.6
 django-appconf==1.0.4
 django-bleach==0.6.1
 django-compressor>=4.0,<5.0
@@ -32,8 +32,8 @@ simplejson==3.11.1
 sqlparse==0.5.0
 Unidecode==1.1.1
 urllib3==1.26.19
-wagtail==6.1.3
+wagtail==7.0.3
 wagtailmedia==0.15.2
-wagtail-cache==2.4.0
+wagtail-cache==3.0.0
 wheel==0.38.1
 zope.interface==4.1.2


### PR DESCRIPTION
Fixes #859 

**Changes in this request**:
- Upgrades to `Django 5.2.6` 
- Upgrades to `Wagtail 7.0.3`

## Django release notes
- https://docs.djangoproject.com/en/5.2/releases/5.1/
- https://docs.djangoproject.com/en/5.2/releases/5.2/

## Wagtail release notes
- https://docs.wagtail.org/en/stable/releases/6.2.html
- https://docs.wagtail.org/en/stable/releases/6.3.html
- https://docs.wagtail.org/en/stable/releases/6.4.html
- https://docs.wagtail.org/en/stable/releases/7.0.html

This can be [previewed on liblet](https://liblet.lib.uchicago.edu/).