### PR TITLE
Test failures on fresh clones due to missing media/documents directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,6 +68,7 @@ docker-compose*.yml
 # Project specific
 static/
 media/
+cache/
 *.sqlite3
 *.db
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN echo 'source /venv/bin/activate' >> /root/.bashrc && \
     echo 'export PATH="/app/node_modules/.bin:$PATH"' >> /root/.bashrc && \
     echo 'export TURNSTILE_ENABLED="False"' >> /root/.bashrc
 
-# Make static directories
-RUN mkdir -p /app/static /app/library_website/static
+# Make static directories (in Docker volume)
+RUN mkdir -p /app/static
 
 # Clean up
 RUN apt-get autoremove -y && \

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -19,6 +19,10 @@ fi
 
 echo "🐳 Setting up Library Website Docker environment..."
 
+# Create necessary directories (under bind mount)
+echo "Creating required directories..."
+mkdir -p media/documents library_website/static
+
 # Build and start services
 echo "Building Docker images..."
 docker compose build


### PR DESCRIPTION
Fixes #866

## Summary

This PR addresses directory structure issues that cause test failures on fresh clones when using Docker. The main issue was that the `media/documents` directory doesn't exist on fresh clones, causing 6 tests in `LinkQueueSpreadsheetBlockTestCase` to fail with `OSError: Cannot save file into a non-existent directory: 'media/documents'`.

Key changes:
- Added `cache/` to `.dockerignore` to prevent permission errors during Docker builds
- Updated `docker-setup.sh` to create `media/documents` and `library_website/static` directories on the host
- Cleaned up `Dockerfile` to only create directories that live in Docker volumes (not under bind mounts)

## Testing

After these changes:
- Run `./docker-setup.sh` on a fresh clone
- Run `docker compose exec web ./manage.py test base.tests.LinkQueueSpreadsheetBlockTestCase`
- The 6 previously failing tests should now pass

**Note:** This fixes the OSError for missing `media/documents` directory. However, other test failures may still occur (such as the intermittent sitemap test issue) which will be addressed separately.