### PR TITLE
Add informational alert to Loop search results for uploaded documents

### DIFF
--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -678,6 +678,9 @@ ul.index-list {
   font-weight: 600;
   font-size: 1.1em; }
 
+.template-searchresults .alert {
+  margin-top: 1em;}
+
 .template-searchresults .page-path {
   display: block;
   font-size: 1em;

--- a/search/templates/search/loop_search.html
+++ b/search/templates/search/loop_search.html
@@ -12,6 +12,10 @@
         <h1>Search Results</h1>
         <small>There are <span class="result-number">{{ search_results_count }}</span> Results</small>
 
+        <div class="alert alert-info" role="alert">
+            Looking for reports or other documents? Try searching by filename in the <a href="/admin/documents/" class="alert-link">Wagtail document library</a>.
+        </div>
+
         {% if search_picks %}
             {% for pick in search_picks %}
                 <h2><a href="{{ pick.page.url }}">{{ pick.page }}</a></h2>


### PR DESCRIPTION
Fixes #873

## Summary

Users reported that Loop search doesn't find uploaded documents (PDFs, etc.) because they are not indexed in the main Loop search. This adds a blue informational alert box to Loop search results directing users to search by filename in the Wagtail admin document library.

- Added Bootstrap alert-info box to Loop search results template
- Added CSS for alert spacing in Loop stylesheet
- Alert only appears on Loop (intranet) site, not public site
- Includes direct link to /admin/documents/

## Testing

1. Start development server and access Loop at http://loopdev:8000
2. Perform a search on Loop
3. Verify blue informational alert appears below result count
4. Verify link to Wagtail document library works correctly