### PR TITLE
RSS feed inaccessible to feed readers due to Turnstile CAPTCHA

### DIFF
--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -649,4 +649,5 @@ TURNSTILE_EXCLUDED_PATHS = [
     r'^/shib/.*$',
     r'^/_util/.*$',
     r'^/api/.*$',
+    r'^/rss/.*$',
 ]


### PR DESCRIPTION
Fixes #877

## Summary

RSS feed readers (Feedly, Blogtrottr, etc.) cannot access the library news RSS feed because Turnstile CAPTCHA requires verification that automated readers cannot complete. This change excludes RSS feed paths from Turnstile protection, allowing feed readers to access the feeds.

- Added `r'^/rss/.*$'` to `TURNSTILE_EXCLUDED_PATHS` in `library_website/settings/base.py`

## Testing

- Verify the RSS feed at https://liblet.lib.uchicago.edu/rss/news/ is accessible without CAPTCHA (this branch is currently checked out on `nest`)