### PR TITLE
Add Alert Styling For Reusable Content Blocks On Loop

### DIFF
--- a/base/static/base/css/loop.css
+++ b/base/static/base/css/loop.css
@@ -698,3 +698,53 @@ ul.index-list {
   .template-searchresults .page-turn a {
     font-size: 1.1em;
     color: #337ab7; }
+
+/*
+ * Reusable Content Snippets
+ * --------------------------------------------------
+ */
+.widget-reusable-content-block > .rich-text > p:empty {
+  display: none; }
+
+.widget-reusable-content-block.alert-box {
+  color: #800000;
+  background-color: #f7ebeb;
+  padding: 1em; }
+  .widget-reusable-content-block.alert-box h2,
+  .widget-reusable-content-block.alert-box h3 {
+    color: #4d0000 !important;
+    border-color: #660000 !important; }
+
+.widget-reusable-content-block.info-box {
+  color: #003849;
+  background-color: #eef6fc;
+  padding: 1em; }
+  .widget-reusable-content-block.info-box h2,
+  .widget-reusable-content-block.info-box h3 {
+    color: #003849 !important;
+    border-color: #003849 !important; }
+
+.block-reusable_content,
+.block-reusable_content_block {
+  margin-bottom: 0.5em; }
+  .block-reusable_content h2,
+  .block-reusable_content_block h2 {
+    margin-top: 0; }
+  .block-reusable_content a,
+  .block-reusable_content_block a {
+    color: #007396;
+    text-decoration: underline; }
+    .block-reusable_content a:hover,
+    .block-reusable_content_block a:hover {
+      color: #59315F;
+      font-weight: 600; }
+  .block-reusable_content .alert-box,
+  .block-reusable_content_block .alert-box {
+    color: #800000;
+    background-color: #f7ebeb;
+    padding: 1em; }
+  .block-reusable_content .info-box,
+  .block-reusable_content_block .info-box {
+    color: #003849;
+    background-color: #eef6fc;
+    padding: 1em; }

--- a/base/static/base/css/loop/loop.scss
+++ b/base/static/base/css/loop/loop.scss
@@ -856,6 +856,61 @@ table, tbody {
   }
 }
 
+/*
+ * Reusable Content Snippets
+ * --------------------------------------------------
+ */
+
+.widget-reusable-content-block { // sidebar widget styling
+  & > .rich-text > p:empty {
+    display: none;
+  }
+  &.alert-box {
+    color: #800000;
+    background-color: #f7ebeb;
+    padding: 1em;
+    h2, h3 {
+      color: #4d0000 !important;
+      border-color: #660000 !important;
+    }
+  }
+  &.info-box {
+    color: #003849;
+    background-color: #eef6fc;
+    padding: 1em;
+    h2, h3 {
+      color: #003849 !important;
+      border-color: #003849 !important;
+    }
+  }
+}
+
+.block-reusable_content, .block-reusable_content_block { // in-page content styling
+  margin-bottom: 0.5em;
+  h2 {
+    margin-top: 0;
+  }
+  a {
+    color: #007396;
+    text-decoration: underline;
+    &:hover {
+      color: #59315F;
+      font-weight: 600;
+    }
+  }
+  .alert-box {
+    color: #800000;
+    background-color: #f7ebeb;
+    padding: 1em;
+  }
+  .info-box {
+    color: #003849;
+    background-color: #eef6fc;
+    padding: 1em;
+  }
+}
+
+
 
 
 


### PR DESCRIPTION
Fixes #791

Added missing CSS styles for reusable content snippets in Loop (intranet) pages. The styles for "Alert" and "Informative" reusable content snippets were only present in uclib.scss (used by public pages) but not in loop.css (used by Loop/intranet pages).

Changes:
- Added `.block-reusable_content` and `.block-reusable_content_block styles` to `loop.css` with `.alert-box` and `.info-box variants`
- Added `.widget-reusable-content-block` styles for sidebar widgets
- Also added the same styles to `loop.scss` for future SCSS migration

The styles now match the public site:
- Alert (alert-box): Light red background (#f7ebeb) with maroon text
- Informative (info-box): Light blue background (#eef6fc) with dark blue text

## Testing:

To test, add reusable content blocks to `IntranetPlain` pages. You should now see alert box styling that matches the kind of alert selected. This matches the behavior on the public site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)