### PR TITLE
Subject Dropdown Should Be Dynamic

### DIFF
--- a/lib_collections/views.py
+++ b/lib_collections/views.py
@@ -274,16 +274,10 @@ def collections(request):
         subjecttree = subjecttree.replace('<body>', '')
         subjecttree = subjecttree.replace('</body>', '')
 
-    # for the subject pulldown, find subjects that are first generation
-    # children- their parents should have no parent.  still need these:
-    # Area Studies Social Sciences Biological Sciences Physical Sciences
-
-    subjects_pulldown = [
-        'Area Studies', 'Arts', 'Biological Sciences', 'Business',
-        'Humanities', 'Law', 'Literature', 'Medicine',
-        'Physical Sciences', 'Social Sciences', 'Social Services',
-        'Special Collections'
-    ]
+    # Get subjects dynamically from the database using the display_in_dropdown field
+    subjects_pulldown = Subject.objects.filter(
+        display_in_dropdown=True
+    ).order_by('name').values_list('name', flat=True)
 
     default_image = None
     try:


### PR DESCRIPTION
Fixes #354

Summary

Replaced hardcoded subject list in lib_collections/views.py with a dynamic QuerySet that filters Subject objects using the existing display_in_dropdown field. This allows subjects to be managed through the Wagtail admin panel without requiring code changes or deployments.

- Removed hardcoded list of 12 subjects from views.py
- Implemented dynamic query using Subject.objects.filter(display_in_dropdown=True)
- Maintained alphabetical ordering with .order_by('name')

Testing:
1. Verify that the Collections & Exhibits page loads correctly
2. Check that the subject dropdown displays the expected subjects
3. In the Wagtail admin, test toggling the display_in_dropdown field on Subject snippets
4. Confirm that changes to display_in_dropdown are reflected in the dropdown without code changes