### PR TITLE
Enable auto-generated sitemap feature on exhibit pages

### DIFF
--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -2044,6 +2044,16 @@ class ExhibitPage(PublicBasePage):
         ),
     ]
 
+    widget_content_panels = [
+        MultiFieldPanel(
+            [
+                FieldPanel('enable_index'),
+                FieldPanel('display_hierarchical_listing'),
+            ],
+            heading='Auto-generated Sitemap',
+        ),
+    ]
+
     content_panels = (
         Page.content_panels
         + [
@@ -2163,6 +2173,7 @@ class ExhibitPage(PublicBasePage):
             ObjectList(content_panels, heading='Content'),
             ObjectList(PublicBasePage.promote_panels, heading='Promote'),
             ObjectList(Page.settings_panels, heading='Settings', classname="settings"),
+            ObjectList(widget_content_panels, heading='Widgets'),
             ObjectList(web_exhibit_panels, heading='Web Exhibit'),
         ]
     )


### PR DESCRIPTION
Fixes #705

**Summary**

Added auto-generated sitemap functionality to ExhibitPage by enabling the existing `enable_index` and `display_hierarchical_listing` fields from PublicBasePage.
- Created a new "Widgets" tab in ExhibitPage admin with the auto-generated sitemap controls
- Added MultiFieldPanel for `enable_index` and `display_hierarchical_listing` fields
- Maintains consistency with other page types like StandardPage that already have this feature

**Testing**:
1. Access the Wagtail admin and navigate to an ExhibitPage
2. Verify the new "Widgets" tab appears alongside Content, Promote, Settings, and Web Exhibit tabs
3. Enable the "Enable index" and/or "Display hierarchical listing" options (choose an exhibit with child pages)
4. Save and view the page to confirm the auto-generated sitemap displays child pages correctly