### PR TITLE
Add page type to Library search results

### DIFF
--- a/results/templates/results/results.html
+++ b/results/templates/results/results.html
@@ -47,7 +47,7 @@
                     <li>
                         {% if result.searchable_content %}
                             <h4><a href="{{ result.url }}">{{ result.title }}</a></h4>
-                            <p>{{ result.datestamp }}</p>
+                            <p><strong>{% autoescape off %}{% pagetype result %}{% endautoescape %}</strong> {{ result.datestamp }}</p>
                             {{ result.description }}
                         {% else %}
                             <h4><a href="{% pageurl result %}">{{ result }}</a></h4>

--- a/searchable_content/models.py
+++ b/searchable_content/models.py
@@ -47,4 +47,7 @@ class LibGuidesSearchableContent(SearchableContent):
 
 
 class LibGuidesAssetsSearchableContent(SearchableContent):
-    pass
+    search_fields = [
+        index.SearchField('title', boost=4),
+        index.SearchField('description'),
+    ]


### PR DESCRIPTION
Fixes #261

## Summary

This PR adds page type labels to search results and fixes a bug preventing databases from appearing in search results.

**Page Type Labels:**
- Displays the top-level website section for Wagtail pages (e.g., "News", "Collections", "Services")
- Displays "Research Guide" for LibGuides research guides
- Displays "Database" for LibGuides databases/assets
- Labels appear in bold before the date, making result types easily scannable

**Database Search Fix:**
- Fixed `LibGuidesAssetsSearchableContent` (databases) not appearing in search results
- The model was inheriting `search_fields` from parent class but the inheritance wasn't working for search indexing
- Added explicit `search_fields` definition to the model
- Databases will now appear in search results after running `./manage.py update_index`

## Background

**Original Issue:**
The `pagetype` template tag was non-functional on production because it checked for Loop/intranet-specific page types (Groups, Departments, Forms, etc.) but was only used in the public site search results template. Since the public site has no Loop pages, it always returned an empty string.

**Solution:**
Based on team feedback, the implementation was changed to show parent-level categories (top-level website sections) instead of technical page types, with a special override for news pages. The approach was then extended to include LibGuides content.

**Database Search Bug:**
While implementing LibGuides labels, discovered that databases weren't appearing in search results at all (in both dev and production with Elasticsearch). Root cause: `LibGuidesAssetsSearchableContent` was inheriting `search_fields` from `SearchableContent` but the inheritance wasn't being recognized by the search indexing system.

## Changes

1. **search/templatetags/core_search_tags.py** - Extended `pagetype` tag to detect and label LibGuides content
2. **results/templates/results/results.html** - Applied `pagetype` labels to LibGuides results
3. **searchable_content/models.py** - Added explicit `search_fields` to `LibGuidesAssetsSearchableContent`

<img width="1329" height="1002" alt="image" src="https://github.com/user-attachments/assets/bf8f93cd-415b-4f2a-a5be-745330a1f291" />

## Testing

1. Navigate to `/results/?query=<search term>` on the public site
2. Search for terms that return various result types:
   - Wagtail pages (should show section labels like "News", "Collections", etc.)
   - Research guides (should show "Research Guide")
   - Databases (should show "Database" - **previously these didn't appear at all**)
3. Verify page type labels appear in bold before the date for each result
4. Try searching for database names like "JSTOR", "ProQuest", "PubMed" to verify databases now appear

## Deployment Notes

After deploying to production, run:
```bash
./manage.py update_index
```

This rebuilds the search index so databases will be properly indexed and appear in search results.

**No migrations required** - changes only affect search field configuration, not database schema.