### PR TITLE
Focal point on banner images

### DIFF
--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -2,8 +2,8 @@
 {% load cache compress static wagtailuserbar %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
-{% image banner original as banner %}
-{% image banner_feature original as banner_feature %}
+{% image banner fill-1920x400 as banner %}
+{% image banner_feature fill-400x400 as banner_feature %}
 {% load public_tags %}
 {% load staff_tags %}
 <!DOCTYPE html>
@@ -219,7 +219,7 @@
 
                                 <div class="carousel-inner">
                                     {% for item in carousel_items %}
-                                        {% image item.image original as nifty %}
+                                        {% image item.image fill-1920x500 as nifty %}
                                         {% if nifty %}
                                             <article class="item {% if forloop.first %}active{% endif %}">
                                                 {% if item.link %}

--- a/conferences/templates/conferences/conference_page.html
+++ b/conferences/templates/conferences/conference_page.html
@@ -2,7 +2,7 @@
 {% load compress static %}
 {% load compile_static %}
 {% load wagtailimages_tags %}
-{% image banner_image original as banner %}
+{% image banner_image fill-1920x400 as banner %}
 {% load cache compress static wagtailuserbar %}
 {% load wagtailcore_tags %}
 

--- a/conferences/templates/conferences/conference_sub_page.html
+++ b/conferences/templates/conferences/conference_sub_page.html
@@ -1,7 +1,7 @@
 {% extends "conferences/conference_page.html" %}
 {% load wagtailimages_tags %}
 {% image conference_logo width-400 as conference_logo %}
-{% image banner_image original as banner %}
+{% image banner_image fill-1920x400 as banner %}
 {% load cache compress static wagtailuserbar %}
 {% load wagtailcore_tags %}
 


### PR DESCRIPTION
Fixes #600

Summary

Banner images were using the 'original' resize rule which ignores focal points set in Wagtail admin, causing poor cropping on mobile views.
- Changed all banner images to use 'fill' resize rule with appropriate dimensions
- Banner images now respect focal points for better mobile display

Testing:
- Deploy to nest server
- Set focal point on a banner image in Wagtail admin
- View exhibit page on mobile to confirm focal point is respected