### PR TITLE
ADA: News Template Issues

### DIFF
--- a/base/static/base/css/uclib.scss
+++ b/base/static/base/css/uclib.scss
@@ -1131,9 +1131,8 @@ table.etable>tbody>tr {
     background-color: $hovercalmlight;
   }
   &:focus {
-    box-shadow: $box-shadow-focus;
-    color: black;
-    background-color: $hovercalmlight;
+    outline: 2px solid #767676;
+    outline-offset: 2px;
   }
 }
 

--- a/base/templates/base/public_base.html
+++ b/base/templates/base/public_base.html
@@ -181,9 +181,11 @@
                     {% endif %}
                     <!-- // Left Sidebar -->
 
+                    {% if page_type|slugify != 'libnewspage' and page_type|slugify != 'libnewsindexpage' %}
                     <div class="{{breadcrumb_div_css}}" role="navigation" aria-label="breadcrumb">
                         {% include "base/includes/public_site_breadcrumbs.html" %}
                     </div>
+                    {% endif %}
                     {% block above_main_content %}{% endblock %}
                     <div class="{{content_div_css}}" id="content" role="main">
                         {% if has_left_sidebar %}

--- a/lib_news/templates/lib_news/lib_news_index_page.html
+++ b/lib_news/templates/lib_news/lib_news_index_page.html
@@ -51,7 +51,7 @@
                     {% if feature.thumbnail %}
                         <span class="img-object">
                             <a href="{{feature.url}}">
-                                {% image feature.thumbnail width-1000 class="article-img" %}
+                                {% image feature.thumbnail width-1000 class="article-img" alt=feature.title %}
                             </a>
                         </span>
                     {% endif %}


### PR DESCRIPTION
**Parent Issue**:
Fixes #332

**Sub-issues**:
Fixes #902
Fixes #903
Fixes #904

**Summary**

Addresses three ADA compliance issues on the News template.
- Hidden breadcrumbs from screen readers on news pages
- Added visible focus indicator to search button
- Added alt text to news thumbnail images

**Testing**:
Deploy to dev server and verify:
1. Screen readers don't announce breadcrumbs on news pages
2. Search button shows gray outline when focused via keyboard
3. News thumbnail images have alt text (from alt_text field or title fallback)