### PR TITLE
add checks for whether docker commands are being run in an Emacs shell

### DIFF
--- a/docker-cleanup.sh
+++ b/docker-cleanup.sh
@@ -3,23 +3,29 @@
 # Docker cleanup script for Library Website
 # Handles proper cleanup of all services including profiled ones
 
+# simplify progress bar if this is being run in an Emacs shell
+if [ -n "$INSIDE_EMACS" ]; then
+    DOCKER_PROG=--progress=plain;
+else DOCKER_PROG=;
+fi
+
 echo "🧹 Cleaning up Library Website Docker environment..."
 
 # Stop all services including profiled ones (like Elasticsearch)
 echo "Stopping all services..."
-docker compose --profile elasticsearch down -v --remove-orphans
+docker compose $DOCKER_PROG --profile elasticsearch down -v --remove-orphans
 
 # Remove project-specific images
 echo "Removing project images..."
-docker image rm -f library_website-web 2>/dev/null || true
+docker image rm $DOCKER_PROG -f library_website-web 2>/dev/null || true
 
 # Remove project-specific volumes
 echo "Removing project volumes..."
-docker volume rm -f library_website_postgres_data library_website_elasticsearch_data library_website_static_files 2>/dev/null || true
+docker volume rm $DOCKER_PROG -f library_website_postgres_data library_website_elasticsearch_data library_website_static_files 2>/dev/null || true
 
 # Remove project-specific network
 echo "Removing project network..."
-docker network rm library_website_library_network 2>/dev/null || true
+docker network rm $DOCKER_PROG library_website_library_network 2>/dev/null || true
 
 # Only prune dangling/unused resources (safer than full system prune)
 echo "Cleaning up dangling resources..."


### PR DESCRIPTION
Fixes #909.

To test: try a fresh `./docker-cleanup.sh` and `./docker-setup.sh` on a branch of your choice.
