### PR TITLE
Python security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,11 @@ RUN mkdir -p /root/.vim/pack/git-plugins/start && \
 # Conditionally install Java and Elasticsearch
 RUN if [ "$ELASTICSEARCH" != "false" ]; then \
     apt-get install -y openjdk-11-jre-headless ca-certificates-java wget && \
-    wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.13-amd64.deb && \
-    dpkg -i elasticsearch-7.17.13-amd64.deb && \
+    wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.19.0-amd64.deb && \
+    dpkg -i elasticsearch-8.19.0-amd64.deb && \
     sed -i 's/^\(-Xm[sx]\)2g$/\1512m/g' /etc/elasticsearch/jvm.options && \
-    rm elasticsearch-7.17.13-amd64.deb && \
-    echo "xpack.security.enabled: false" >> /etc/elasticsearch/elasticsearch.yml; \
+    rm elasticsearch-8.19.0-amd64.deb && \
+    sed -i 's/^xpack.security.enabled:.*$/xpack.security.enabled: false/' /etc/elasticsearch/elasticsearch.yml; \
     fi
 
 # Conditionally install Node.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - library_network
 
   elasticsearch:
-    image: elasticsearch:7.17.13
+    image: elasticsearch:8.19.0
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/library_website/settings/base.py
+++ b/library_website/settings/base.py
@@ -232,7 +232,7 @@ WAGTAIL_SITE_NAME = "library_website"
 
 WAGTAILSEARCH_BACKENDS = {
     "default": {
-        "BACKEND": "wagtail.search.backends.elasticsearch7",
+        "BACKEND": "wagtail.search.backends.elasticsearch8",
         "URLS": ["http://localhost:9200"],
         "INDEX": "wagtail",
         "TIMEOUT": 5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bleach==3.3.0
 DateTime>=4,<5
 defusedxml
 git+https://github.com/bbusenius/Diablo-Python.git#egg=diablo_python
-Django==5.2.8
+Django==5.2.9
 django-appconf==1.0.4
 django-bleach==0.6.1
 django-compressor>=4.0,<5.0
@@ -14,7 +14,7 @@ django-redis
 git+https://github.com/rev138/django-shibboleth-remoteuser.git#egg=django_shibboleth_remoteuser
 django-static-precompiler
 django-webpack-loader==1.8.0
-elasticsearch>=7.0.0,<8.0.0
+elasticsearch>=8.0.0,<9.0.0
 libsass
 lxml
 networkx
@@ -31,7 +31,7 @@ python-dateutil
 simplejson==3.11.1
 sqlparse==0.5.0
 Unidecode==1.1.1
-urllib3==1.26.19
+urllib3==2.6.0
 wagtail==7.0.3
 wagtailmedia==0.15.2
 wagtail-cache==3.0.0


### PR DESCRIPTION
Fixes #943

Summary

Upgrades Elasticsearch to version 8 and updates related dependencies to address security vulnerabilities and compatibility requirements.
- Upgraded Elasticsearch from 7.17.13 to 8.19.0 (latest 8.x version)
- Upgraded urllib3 from 1.26.19 to 2.6.0 (required for Elasticsearch 8 compatibility)
- Updated Django from 5.2.8 to 5.2.9
- Changed Wagtail search backend from elasticsearch7 to elasticsearch8
- Fixed Elasticsearch 8 configuration: xpack.security.enabled is now modified instead of appended (ES 8 includes this setting by default)
- Fixed Vagrantfile Python shell command quoting issue using heredoc pattern

Testing:
1. Docker: Run `./docker-cleanup.sh && ./docker-setup.sh` and verify Elasticsearch starts successfully
2. Vagrant: Run `vagrant destroy && vagrant up` and verify Elasticsearch starts without errors
3. Verify search functionality works in both environments
4. Check that `curl http://localhost:9200` returns ES 8.19.0 version info