### PR TITLE
StaffPage crashes with AttributeError after removal of is_active field from GroupPage

### DIFF
--- a/staff/templates/staff/staff_page.html
+++ b/staff/templates/staff/staff_page.html
@@ -78,16 +78,19 @@
       </ul>
     {% endif %}
 
-    {% if group_memberships %}
+    {% if hierarchical_group_memberships %}
       <h2>Committees &amp; Groups</h2>
-      <ul>
-        {% for group_membership in group_memberships %}
-          <li><a href="{{ group_membership.group.url }}">
-            {{ group_membership.group.title }}
-            {% if group_membership.role %}{{ group_membership.role }}{% endif %}
-          </a></li>
-        {% endfor %}
-      </ul>
+      {% for index_group in hierarchical_group_memberships %}
+        <h3><a href="{{ index_group.index_page.url }}">{{ index_group.index_page.title }}</a></h3>
+        <ul>
+          {% for group in index_group.groups %}
+            <li>
+              <a href="{{ group.url }}">{{ group.title }}</a>
+              {% if group.role %} - {{ group.role }}{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
     {% endif %}
 
   </div> <!-- END Right Sidebar Content -->


### PR DESCRIPTION
Fixes #951

Summary

After PR #942 removed the is_active field from GroupPage, StaffPage.get_context() crashes with AttributeError when trying to filter group memberships. This fix removes the is_active check and implements hierarchical group membership display.

- Remove is_active check from StaffPage.get_context() that was causing AttributeError
- Organize group memberships hierarchically by GroupIndexPage ancestors using get_ancestors().type(GroupIndexPage)
- Update template to display groups in hierarchical structure with index page headers
- Move GroupIndexPage import to module level for cleaner code

Testing:
1. Navigate to any staff page on the intranet (e.g., http://loopdev:8000/staff/[staff-member]/)
2. Verify the page loads without errors
3. Check that "Committees & Groups" section displays groups organized under their parent GroupIndexPage names
4. Verify that all group memberships are shown (both current and past)