### PR TITLE
StaffPage displays "Inactive Groups" before "Committees & Groups" in hierarchical group listing

### DIFF
--- a/staff/models.py
+++ b/staff/models.py
@@ -613,10 +613,13 @@ class StaffPage(BasePageWithoutStaffPageForeignKeys):
                     }
                 )
 
+        # Sort groups within each section alphabetically
+        for group_data in grouped_memberships.values():
+            group_data["groups"].sort(key=lambda x: x["title"])
+
         # Convert dict to list for template and sort by index page title
         hierarchical_group_memberships = sorted(
-            grouped_memberships.values(),
-            key=lambda x: x["index_page"]["title"]
+            grouped_memberships.values(), key=lambda x: x["index_page"]["title"]
         )
 
         context = super(StaffPage, self).get_context(request)


### PR DESCRIPTION
Fixes #954

Summary

After PR #952, GroupIndexPages were displayed in unpredictable order on StaffPages. This adds alphabetical sorting by index page title, ensuring "Committees & Groups" appears before "Inactive Groups". Additionally, the individual groups within each section are not alphabetized, making it difficult to scan long lists (especially "Inactive Groups" which can have 20+ items).
- Sort hierarchical_group_memberships by index page title using sorted() with key function
- Sort groups within group categories.

Testing:
1. Go to `nest` and ensure that "Committees & Groups" comes before "Inactive Groups" and that groups are alphabetically sorted in each category: https://looplet.lib.uchicago.edu/staff/elizabeth-edwards/