### PR TITLE
Upgrade Node.js from version 18 to version 20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install Node dependencies
@@ -68,7 +68,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install Node dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN if [ "$ELASTICSEARCH" != "false" ]; then \
 # Conditionally install Node.js
 RUN if [ "$NODEJS" != "false" ]; then \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y nodejs && \
     npm install -g eslint@8.57.0 prettier eslint-plugin-prettier eslint-config-prettier eslint-config-airbnb install-peerdeps; \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if [ "$2" != "false" ]; then
         echo "============== Installing NVM and NodeJS =============="
         curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-        NODE_MAJOR=18
+        NODE_MAJOR=20
         echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
         apt-get update
         apt-get install nodejs -y


### PR DESCRIPTION
Fixes #1004

Summary

Upgrade Node.js from version 18 to version 20 across Docker, Vagrant, and GitHub Actions workflows to maintain compatibility with security patches.

- Update .github/workflows/lint.yml to use Node 20 (2 occurrences)
- Update Dockerfile nodesource repo from node_18.x to node_20.x
- Update Vagrantfile NODE_MAJOR from 18 to 20

Testing:
- Docker build works with Node 20
- Vagrant VM works with Node 20
- GitHub Actions lint workflow passes