### PR TITLE
Upgrade Python packages: black and pygments for security

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,12 +99,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
 
-    - name: Run curlylint
-      run: |
-        # Exclude migrations and legacy templates with structural issues
-        # (regex pattern: div tags that open in conditional blocks but close outside them)
-        curlylint --exclude "(migrations|intranet_base\.html|public_base\.html|finding_aids_page\.html|404\.html)" .
-
     - name: Check djhtml formatting
       run: |
         # Exclude static directory (collected static files / build artifacts)

--- a/base/models.py
+++ b/base/models.py
@@ -815,14 +815,10 @@ class DuoImage(StructBlock):
     by side. Used in web exhibits.
     """
 
-    image_one = SoloImage(
-        help_text="First of two images displayed \
-            side by side"
-    )
-    image_two = SoloImage(
-        help_text="Second of two images displayed \
-            side by side"
-    )
+    image_one = SoloImage(help_text="First of two images displayed \
+            side by side")
+    image_two = SoloImage(help_text="Second of two images displayed \
+            side by side")
 
     class Meta:
         icon = "image"

--- a/dev-docs.txt
+++ b/dev-docs.txt
@@ -13,11 +13,8 @@ black path/to/source_file.py
 Linting HTML files and Wagtail / Django templates
 =================================================
 
-Template files should be linted with curlyling and djhtml. Curlylint catches
-syntax errors but does not automatically fix them. You will need to do that.
-Djhtml applies indentation.
+Template files should be linted with djhtml, which applies indentation.
 
-curlylint --parse-only path/to/template_file.html
 djhtml -i path/to/template_file.html
 
 Generating fixtures

--- a/group/models.py
+++ b/group/models.py
@@ -59,14 +59,8 @@ def enforce_name_as_year(title):
     formatting policy.
     """
     if not re.match("^[0-9]{4}$", title):
-        raise ValidationError(
-            {
-                "title": (
-                    "Please enter the year as \
-            a four digit number, e.g. 2016"
-                )
-            }
-        )
+        raise ValidationError({"title": ("Please enter the year as \
+            a four digit number, e.g. 2016")})
 
 
 def get_page_objects_grouped_by_date(obj):

--- a/lib_collections/models.py
+++ b/lib_collections/models.py
@@ -286,10 +286,8 @@ class ObjectMetadata(models.Model):
     link_target = models.IntegerField(
         choices=MENU_OPTIONS,
         default=1,
-        help_text=(
-            "How do you want the link to behave? \
-            (Required for hotlinked)"
-        ),
+        help_text=("How do you want the link to behave? \
+            (Required for hotlinked)"),
     )
 
     panels = [
@@ -384,10 +382,8 @@ class CBrowse(models.Model):
     label = models.CharField(max_length=255, blank=True)
     include = models.BooleanField(
         default=False,
-        help_text=(
-            "Include browse term in collection sidebar? \
-            (Featured browse)"
-        ),
+        help_text=("Include browse term in collection sidebar? \
+            (Featured browse)"),
     )
     iiif_location = models.URLField(max_length=255, blank=True)
     link_text_override = models.CharField(max_length=255, blank=True)
@@ -424,10 +420,8 @@ class LBrowse(models.Model):
     label = models.CharField(max_length=255, blank=True)
     include = models.BooleanField(
         default=False,
-        help_text=(
-            "Include browse term in collection sidebar? \
-            (Featured browse)"
-        ),
+        help_text=("Include browse term in collection sidebar? \
+            (Featured browse)"),
     )
     iiif_location = models.URLField(max_length=255, blank=True)
     link_text_override = models.CharField(max_length=255, blank=True)
@@ -465,10 +459,8 @@ class CSearch(models.Model):
     include = models.BooleanField(default=False, help_text="Include in sidebar?")
     default = models.BooleanField(
         default=False,
-        help_text=(
-            "Is this the default search? (If more than one are selected, the \
-            first one selected will be the default.)"
-        ),
+        help_text=("Is this the default search? (If more than one are selected, the \
+            first one selected will be the default.)"),
     )
     mark_logic_parameter = models.CharField(max_length=255, blank=True)
     search_handler_location = models.CharField(max_length=255, blank=True)
@@ -791,10 +783,8 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
     )
     highlighted_records = models.URLField(
         blank=True,
-        help_text=(
-            "URL for the select objects you would \
-            like to show in the collection page"
-        ),
+        help_text=("URL for the select objects you would \
+            like to show in the collection page"),
     )
 
     # TODO: eventually this will contain instructions for generating a
@@ -803,10 +793,8 @@ class CollectionPage(RoutablePageMixin, PublicBasePage):
     object_identifier = models.URLField(
         max_length=255,
         blank=True,
-        help_text=(
-            "Use a Bib ID or a record PI to construct \
-            a link to the catalog"
-        ),
+        help_text=("Use a Bib ID or a record PI to construct \
+            a link to the catalog"),
     )
 
     @route(r"^object/(?P<manifid>\w+)/$")
@@ -1623,10 +1611,8 @@ class CollectingAreaPage(PublicBasePage, LibGuide):
             InlinePanel(
                 "regional_collections",
                 label="Other Local Collections",
-                help_text=(
-                    "Related collections that are held by other \
-                institutions, like BMRC, Newberry, etc."
-                ),
+                help_text=("Related collections that are held by other \
+                institutions, like BMRC, Newberry, etc."),
             ),
         ]
         + PublicBasePage.content_panels

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 autopep8==2.0.1
-black==24.3.0
-curlylint==0.13.1
+black==26.3.1
 djhtml==3.0.7
 flake8==6.0.0
 isort==5.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ html2text>=2025.4.15,<2026
 pandas>=2,<3
 pocli==0.1.10
 psycopg2
-Pygments==2.15.0
+Pygments==2.20.0
 python-dateutil
 simplejson==3.11.1
 sqlparse==0.5.4

--- a/staff/test_integration.py
+++ b/staff/test_integration.py
@@ -9,9 +9,7 @@ from staff.utils import get_all_library_cnetids_from_directory
 
 class UniversityDirectoryTestCase(TestCase):
     def test_directory_xml_validates(self):
-        dtd = etree.DTD(
-            StringIO(
-                """
+        dtd = etree.DTD(StringIO("""
         <!ELEMENT responseData    (response, totalResults, organizations)>
         <!ELEMENT response        (#PCDATA)>
         <!ELEMENT totalResults    (#PCDATA)>
@@ -36,9 +34,7 @@ class UniversityDirectoryTestCase(TestCase):
         <!ELEMENT phone           (#PCDATA)>
         <!ELEMENT facultyExchange (#PCDATA)>
         <!--      resources (see above) -->
-        """
-            )
-        )
+        """))
 
         root = etree.XML(
             get_xml_from_directory_api(
@@ -48,9 +44,7 @@ class UniversityDirectoryTestCase(TestCase):
         self.assertEqual(dtd.validate(root), True)
 
     def test_individual_xml_validates(self):
-        dtd = etree.DTD(
-            StringIO(
-                """
+        dtd = etree.DTD(StringIO("""
         <!ELEMENT responseData    (response, totalResults, individuals)>
         <!ELEMENT response        (#PCDATA)>
         <!ELEMENT totalResults    (#PCDATA)>
@@ -72,9 +66,7 @@ class UniversityDirectoryTestCase(TestCase):
         <!ELEMENT email           (#PCDATA)>
         <!ELEMENT phone           (#PCDATA)>
         <!ELEMENT facultyExchange (#PCDATA)>
-        """
-            )
-        )
+        """))
 
         cnetids = get_all_library_cnetids_from_directory()
         root = etree.XML(


### PR DESCRIPTION
Fixes #1006

Summary

Upgrade black (24.3.0 → 26.3.1) and pygments (2.15.0 → 2.20.0) to resolve security vulnerabilities. Remove curlylint due to a dependency conflict: black 26.3.1 requires pathspec>=1.0.0 but curlylint requires pathspec<1.
- Bump black to 26.3.1 and pygments to 2.20.0
- Remove curlylint from requirements-dev.txt, CI lint workflow, and dev-docs.txt
- Re-lint Python files reformatted by black 26.3.1 (base/models.py, group/models.py, lib_collections/models.py, staff/test_integration.py)
- Template linting via djhtml --check remains in place

Testing:
- Verify CI lint workflow passes
- Run test suite to check for regressions
- Confirm black and pygments work as expected