### PR TITLE
IntranetIndexPage child page listing ignores Wagtail menu sort order

### DIFF
--- a/base/models.py
+++ b/base/models.py
@@ -2423,13 +2423,6 @@ class IntranetIndexPage(BasePage):
                 )
             )
 
-        def alphabetize_pages(currentlevel):
-            for node in currentlevel:
-                node["children"] = alphabetize_pages(node["children"])
-            return sorted(currentlevel, key=lambda c: c["title"])
-
-        pages = alphabetize_pages(pages)
-
         def get_html(currentlevel):
             if not currentlevel:
                 return ""


### PR DESCRIPTION
Fixes #1013

Summary

The auto-generated child page list on `IntranetIndexPage` was being re-sorted alphabetically by title, which silently discarded any reordering editors made with Wagtail's "Sort menu order" action.

- Remove the `alphabetize_pages` helper and its call in `IntranetIndexPage.get_context()` so the listing falls through to Wagtail's default `get_children()` order (menu/path order)
- Affects both the flat listing and the `display_hierarchical_listing` mode

Testing:
1. Pick an `IntranetIndexPage` with several child pages (e.g. the FOLIO Loop page at `/documentation/folio/`).
2. In the Wagtail admin, use "Sort menu order" to put the children in a non-alphabetical order and save.
3. Visit the page on the front end and confirm the listing reflects the chosen order rather than alphabetical order.