### PR TITLE
docker-cleanup.sh prunes Docker resources globally instead of scoping to the project

### DIFF
--- a/docker-cleanup.sh
+++ b/docker-cleanup.sh
@@ -27,11 +27,10 @@ docker volume rm $DOCKER_PROG -f library_website_postgres_data library_website_e
 echo "Removing project network..."
 docker network rm $DOCKER_PROG library_website_library_network 2>/dev/null || true
 
-# Only prune dangling/unused resources (safer than full system prune)
+# Prune stopped containers and unused networks scoped to this project
 echo "Cleaning up dangling resources..."
-docker container prune -f
-docker image prune -f
-docker network prune -f
+docker container prune -f --filter "label=com.docker.compose.project=library_website"
+docker network prune -f --filter "label=com.docker.compose.project=library_website"
 
 echo ""
 echo "✅ Docker cleanup complete!"


### PR DESCRIPTION
Fixes #1045

## Summary

`docker-cleanup.sh` is meant to tear down only this project's Docker environment, but its final "cleanup" step ran global `docker container/image/network prune`, which also removed resources belonging to unrelated Docker projects on the developer's machine. This scopes those prunes to the project.

- Scope `docker container prune` and `docker network prune` to the Compose project label `com.docker.compose.project=library_website`
- Drop the global `docker image prune -f` (the project's own image is already removed explicitly by the `docker image rm library_website-web` step above)
- Update the misleading "safer than full system prune" comment

## Testing

1. Have another Docker project with a stopped container / dangling image / unused network on your machine.
2. Run `./docker-cleanup.sh` from this repo.
3. Confirm the library_website environment is fully torn down while the other project's stopped containers, images, and networks remain intact (e.g. `docker ps -a`, `docker network ls`).