### PR TITLE
Pin pillow-heif to <1.5 for FreeBSD libheif 1.22 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ git+https://github.com/bbusenius/django-turnstile-site-protect.git#egg=django_tu
 git+https://github.com/bbusenius/Good-Bots.git
 html2text>=2025.4.15,<2026
 pandas>=2,<3
+pillow-heif>=1.4.0,<1.5
 pocli==0.1.10
 psycopg2
 requests[socks]


### PR DESCRIPTION
Fixes #1068

Summary

pillow-heif 1.5.0+ requires libheif >= 1.23.1, which is unavailable on FreeBSD 14, causing wheel builds to fail during deployment. Pins pillow-heif to >=1.4.0,<1.5 — the last series compatible with libheif 1.22.x.
- Added `pillow-heif>=1.4.0,<1.5` to `requirements.txt`

Testing:
Run `pip install -r requirements.txt` on a FreeBSD system with libheif 1.22.x and confirm it installs successfully.